### PR TITLE
Animate Icon + Two-Pane Welcome Screen

### DIFF
--- a/app/desktop/src/main/kotlin/app/campfire/di/DesktopApplicationComponent.kt
+++ b/app/desktop/src/main/kotlin/app/campfire/di/DesktopApplicationComponent.kt
@@ -1,4 +1,4 @@
-// Copyright 2023, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright 2023, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package app.campfire.di

--- a/app/ios/src/iosMain/kotlin/app/campfire/ios/CampfireUiViewController.kt
+++ b/app/ios/src/iosMain/kotlin/app/campfire/ios/CampfireUiViewController.kt
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright 2020, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package app.campfire.ios

--- a/app/ios/src/iosMain/kotlin/app/campfire/ios/di/IosApplicationComponent.kt
+++ b/app/ios/src/iosMain/kotlin/app/campfire/ios/di/IosApplicationComponent.kt
@@ -1,4 +1,4 @@
-// Copyright 2023, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright 2023, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package app.campfire.ios.di

--- a/common/compose/build.gradle.kts
+++ b/common/compose/build.gradle.kts
@@ -32,6 +32,10 @@ kotlin {
       }
     }
 
+    val skikoMain by creating {
+      dependsOn(commonMain.get())
+    }
+
     val jvmCommon by creating {
       dependsOn(commonMain.get())
 
@@ -41,6 +45,7 @@ kotlin {
     }
 
     jvmMain {
+      dependsOn(skikoMain)
       dependsOn(jvmCommon)
       dependencies {
         implementation(compose.preview)
@@ -61,6 +66,7 @@ kotlin {
     }
 
     appleMain {
+      dependsOn(skikoMain)
       dependencies {
         api(libs.coil.networking.ktor3)
         api(libs.ktor.client.darwin)

--- a/common/compose/src/androidMain/kotlin/app/campfire/common/compose/shaders/PerlinNoise.android.kt
+++ b/common/compose/src/androidMain/kotlin/app/campfire/common/compose/shaders/PerlinNoise.android.kt
@@ -1,0 +1,53 @@
+package app.campfire.common.compose.shaders
+
+import android.graphics.RenderEffect
+import android.graphics.RuntimeShader
+import android.os.Build
+import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+
+@Composable
+actual fun Modifier.applyNoiseEffect(
+  frequencyX: Float,
+  frequencyY: Float,
+  speed: Float,
+  amplitude: Float,
+): Modifier {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
+
+  val time by produceState(0f) {
+    while (true) {
+      withInfiniteAnimationFrameMillis {
+        value = it / 1000f
+      }
+    }
+  }
+
+  val shader = RuntimeShader(PerlinNoise).apply {
+    setFloatUniform("frequencyX", frequencyX)
+    setFloatUniform("frequencyY", frequencyY)
+    setFloatUniform("speed", speed)
+    setFloatUniform("amplitude", amplitude)
+  }
+
+  return this
+    .onSizeChanged {
+      shader.setFloatUniform(
+        "resolution",
+        it.width.toFloat(),
+        it.height.toFloat(),
+      )
+    }
+    .graphicsLayer {
+      shader.setFloatUniform("time", time)
+      renderEffect = RenderEffect
+        .createRuntimeShaderEffect(shader, "contents")
+        .asComposeRenderEffect()
+    }
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/CampfireSplit.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/CampfireSplit.kt
@@ -1,5 +1,11 @@
 package app.campfire.common.compose.icons
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.SolidColor
@@ -9,15 +15,19 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.group
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import app.campfire.common.compose.shaders.applyNoiseEffect
 
-private var _Campfire: ImageVector? = null
+private var _CampfireLogs: ImageVector? = null
+private var _CampfireFireInner: ImageVector? = null
+private var _CampfireFireOuter: ImageVector? = null
 
-val CampfireIcons.Campfire: ImageVector
+val CampfireIcons.CampfireLogs: ImageVector
   get() {
-    if (_Campfire != null) {
-      return _Campfire!!
+    if (_CampfireLogs != null) {
+      return _CampfireLogs!!
     }
-    _Campfire = ImageVector.Builder(
+    _CampfireLogs = ImageVector.Builder(
       name = "Campfire",
       defaultWidth = 53.dp,
       defaultHeight = 53.dp,
@@ -102,6 +112,60 @@ val CampfireIcons.Campfire: ImageVector
         curveTo(12.8265f, 40.9493f, 14.9952f, 42.3333f, 15.9704f, 44.7198f)
         close()
       }
+    }.build()
+    return _CampfireLogs!!
+  }
+
+val CampfireIcons.CampfireFireInner: ImageVector
+  get() {
+    if (_CampfireFireInner != null) {
+      return _CampfireFireInner!!
+    }
+    _CampfireFireInner = ImageVector.Builder(
+      name = "Campfire",
+      defaultWidth = 53.dp,
+      defaultHeight = 53.dp,
+      viewportWidth = 53f,
+      viewportHeight = 53f,
+    ).apply {
+      group {
+        // Inner Fire
+        path(
+          fill = SolidColor(Color(0xFFF34624)),
+          fillAlpha = 1.0f,
+          stroke = null,
+          strokeAlpha = 1.0f,
+          strokeLineWidth = 1.0f,
+          strokeLineCap = StrokeCap.Butt,
+          strokeLineJoin = StrokeJoin.Miter,
+          strokeLineMiter = 1.0f,
+          pathFillType = PathFillType.NonZero,
+        ) {
+          moveTo(26.9498253f, 24.9999084f)
+          curveToRelative(-0.7755f, -0.4743f, -1.7608f, -0.0158f, -1.9127f, 0.8804f)
+          curveToRelative(-0.3024f, 1.7842f, -1.8528f, 3.0309f, -2.5905f, 5.0946f)
+          curveToRelative(-0.8599f, 2.4056f, 0.4236f, 4.7362f, 2.8423f, 5.3638f)
+          curveToRelative(2.5983f, 0.6742f, 4.9416f, -0.7221f, 5.428f, -3.2344f)
+          curveTo(31.3254f, 29.9616f, 29.7492f, 26.7119f, 26.9498f, 24.9999f)
+          close()
+        }
+      }
+    }.build()
+    return _CampfireFireInner!!
+  }
+
+val CampfireIcons.CampfireFireOuter: ImageVector
+  get() {
+    if (_CampfireFireOuter != null) {
+      return _CampfireFireOuter!!
+    }
+    _CampfireFireOuter = ImageVector.Builder(
+      name = "Campfire",
+      defaultWidth = 53.dp,
+      defaultHeight = 53.dp,
+      viewportWidth = 53f,
+      viewportHeight = 53f,
+    ).apply {
       group {
         // Outer Fire
         path(
@@ -127,28 +191,48 @@ val CampfireIcons.Campfire: ImageVector
           curveTo(13.2618f, 26.5846f, 13.7082f, 19.6188f, 18.9636f, 14.207f)
           close()
         }
-
-        // Inner Fire
-        path(
-          fill = SolidColor(Color(0xFFF34624)),
-          fillAlpha = 1.0f,
-          stroke = null,
-          strokeAlpha = 1.0f,
-          strokeLineWidth = 1.0f,
-          strokeLineCap = StrokeCap.Butt,
-          strokeLineJoin = StrokeJoin.Miter,
-          strokeLineMiter = 1.0f,
-          pathFillType = PathFillType.NonZero,
-        ) {
-          moveTo(26.9498253f, 24.9999084f)
-          curveToRelative(-0.7755f, -0.4743f, -1.7608f, -0.0158f, -1.9127f, 0.8804f)
-          curveToRelative(-0.3024f, 1.7842f, -1.8528f, 3.0309f, -2.5905f, 5.0946f)
-          curveToRelative(-0.8599f, 2.4056f, 0.4236f, 4.7362f, 2.8423f, 5.3638f)
-          curveToRelative(2.5983f, 0.6742f, 4.9416f, -0.7221f, 5.428f, -3.2344f)
-          curveTo(31.3254f, 29.9616f, 29.7492f, 26.7119f, 26.9498f, 24.9999f)
-          close()
-        }
       }
     }.build()
-    return _Campfire!!
+    return _CampfireFireOuter!!
   }
+
+@Composable
+fun NoisyCampfireIcon(
+  modifier: Modifier = Modifier,
+) {
+  Box(modifier) {
+    Image(
+      CampfireIcons.CampfireLogs,
+      contentDescription = null,
+      modifier = Modifier
+        .fillMaxSize()
+        .zIndex(0f),
+    )
+    Image(
+      CampfireIcons.CampfireFireOuter,
+      contentDescription = null,
+      modifier = Modifier
+        .fillMaxSize()
+        .zIndex(1f)
+        .applyNoiseEffect(
+          frequencyX = 15f,
+          frequencyY = 3f,
+          speed = 0.7f,
+          amplitude = 0.02f
+        ),
+    )
+    Image(
+      CampfireIcons.CampfireFireInner,
+      contentDescription = null,
+      modifier = Modifier
+        .fillMaxSize()
+        .zIndex(2f)
+        .applyNoiseEffect(
+          frequencyX = 8f,
+          frequencyY = 4f,
+          amplitude = 0.04f,
+          speed = .75f
+        ),
+    )
+  }
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/CampfireSplit.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/CampfireSplit.kt
@@ -3,7 +3,6 @@ package app.campfire.common.compose.icons
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -218,7 +217,7 @@ fun NoisyCampfireIcon(
           frequencyX = 15f,
           frequencyY = 3f,
           speed = 0.7f,
-          amplitude = 0.02f
+          amplitude = 0.02f,
         ),
     )
     Image(
@@ -231,7 +230,7 @@ fun NoisyCampfireIcon(
           frequencyX = 8f,
           frequencyY = 4f,
           amplitude = 0.04f,
-          speed = .75f
+          speed = .75f,
         ),
     )
   }

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/shaders/PerlinNoise.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/shaders/PerlinNoise.kt
@@ -1,3 +1,6 @@
+// Copyright 2025, Google LLC, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package app.campfire.common.compose.shaders
 
 import androidx.compose.runtime.Composable
@@ -5,7 +8,7 @@ import androidx.compose.ui.Modifier
 
 /* Copyright 2022 Google LLC.
    SPDX-License-Identifier: Apache-2.0 */
-//@Language("AGSL")
+// @Language("AGSL")
 val PerlinNoise = """
    uniform float2 resolution;
    uniform float time;

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/shaders/PerlinNoise.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/shaders/PerlinNoise.kt
@@ -1,0 +1,134 @@
+package app.campfire.common.compose.shaders
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/* Copyright 2022 Google LLC.
+   SPDX-License-Identifier: Apache-2.0 */
+//@Language("AGSL")
+val PerlinNoise = """
+   uniform float2 resolution;
+   uniform float time;
+   uniform float frequencyX; // 3
+   uniform float frequencyY; // 6
+   uniform float speed; // 0.65
+   uniform float amplitude; // 0.03
+   uniform shader contents;
+
+   //
+   // Description : Array and textureless GLSL 2D/3D/4D simplex
+   //               noise functions.
+   //      Author : Ian McEwan, Ashima Arts.
+   //  Maintainer : stegu
+   //     Lastmod : 20201014 (stegu)
+   //     License : Copyright (C) 2011 Ashima Arts. All rights reserved.
+   //               Distributed under the MIT License. See LICENSE file.
+   //               https://github.com/ashima/webgl-noise
+   //               https://github.com/stegu/webgl-noise
+   //
+
+   vec3 mod289(vec3 x) {
+    return x - floor(x * (1.0 / 289.0)) * 289.0;
+   }
+
+   vec4 mod289(vec4 x) {
+    return x - floor(x * (1.0 / 289.0)) * 289.0;
+   }
+
+   vec4 permute(vec4 x) {
+       return mod289(((x*34.0)+10.0)*x);
+   }
+
+   float snoise(vec3 v)
+   {
+    const vec2  C = vec2(1.0/6.0, 1.0/3.0) ;
+    const vec4  D = vec4(0.0, 0.5, 1.0, 2.0);
+
+     // First corner
+    vec3 i  = floor(v + dot(v, C.yyy) );
+    vec3 x0 =   v - i + dot(i, C.xxx) ;
+
+    // Other corners
+    vec3 g = step(x0.yzx, x0.xyz);
+    vec3 l = 1.0 - g;
+    vec3 i1 = min( g.xyz, l.zxy );
+    vec3 i2 = max( g.xyz, l.zxy );
+
+    //   x0 = x0 - 0.0 + 0.0 * C.xxx;
+    //   x1 = x0 - i1  + 1.0 * C.xxx;
+    //   x2 = x0 - i2  + 2.0 * C.xxx;
+    //   x3 = x0 - 1.0 + 3.0 * C.xxx;
+    vec3 x1 = x0 - i1 + C.xxx;
+    vec3 x2 = x0 - i2 + C.yyy; // 2.0*C.x = 1/3 = C.y
+    vec3 x3 = x0 - D.yyy;      // -1.0+3.0*C.x = -0.5 = -D.y
+
+    // Permutations
+    i = mod289(i);
+    vec4 p = permute( permute( permute(
+               i.z + vec4(0.0, i1.z, i2.z, 1.0 ))
+             + i.y + vec4(0.0, i1.y, i2.y, 1.0 ))
+             + i.x + vec4(0.0, i1.x, i2.x, 1.0 ));
+
+    // Gradients: 7x7 points over a square, mapped onto an octahedron.
+    // The ring size 17*17 = 289 is close to a multiple of 49 (49*6 = 294)
+    float n_ = 0.142857142857; // 1.0/7.0
+    vec3  ns = n_ * D.wyz - D.xzx;
+
+    vec4 j = p - 49.0 * floor(p * ns.z * ns.z);  //  mod(p,7*7)
+
+    vec4 x_ = floor(j * ns.z);
+    vec4 y_ = floor(j - 7.0 * x_ );    // mod(j,N)
+
+    vec4 x = x_ *ns.x + ns.yyyy;
+    vec4 y = y_ *ns.x + ns.yyyy;
+    vec4 h = 1.0 - abs(x) - abs(y);
+
+    vec4 b0 = vec4( x.xy, y.xy );
+    vec4 b1 = vec4( x.zw, y.zw );
+
+    vec4 s0 = floor(b0)*2.0 + 1.0;
+    vec4 s1 = floor(b1)*2.0 + 1.0;
+    vec4 sh = -step(h, vec4(0.0));
+
+    vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
+    vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww ;
+
+    vec3 p0 = vec3(a0.xy,h.x);
+    vec3 p1 = vec3(a0.zw,h.y);
+    vec3 p2 = vec3(a1.xy,h.z);
+    vec3 p3 = vec3(a1.zw,h.w);
+
+    //Normalise gradients
+    vec4 norm = inversesqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2, p2), dot(p3,p3)));
+    p0 *= norm.x;
+    p1 *= norm.y;
+    p2 *= norm.z;
+    p3 *= norm.w;
+
+    // Mix final noise value
+    vec4 m = max(0.5 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+    m = m * m;
+    return 105.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1),
+                                  dot(p2,x2), dot(p3,x3) ) );
+   }
+
+   half4 main(in vec2 fragCoord) {
+      vec2 uv = (fragCoord.xy / resolution.xy);
+      float noise = snoise(vec3(uv.x * frequencyX, uv.y * frequencyY, time * speed));
+
+      noise *= exp(-length(abs(uv * 1.5)));
+      vec2 offset1 = vec2(noise * amplitude);
+      vec2 offset2 = vec2(amplitude) / resolution.xy;
+      uv += offset1 - offset2;
+
+      return contents.eval(uv * resolution.xy);
+   }
+""".trimIndent()
+
+@Composable
+expect fun Modifier.applyNoiseEffect(
+  frequencyX: Float = 3f,
+  frequencyY: Float = 6f,
+  speed: Float = 0.65f,
+  amplitude: Float = 0.03f,
+): Modifier

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/theme/Shape.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/theme/Shape.kt
@@ -1,4 +1,4 @@
-// Copyright 2020, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright 2020, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package app.campfire.common.compose.theme

--- a/common/compose/src/jvmMain/kotlin/app/campfire/common/compose/icons/CampfireIconPreview.kt
+++ b/common/compose/src/jvmMain/kotlin/app/campfire/common/compose/icons/CampfireIconPreview.kt
@@ -15,26 +15,24 @@ import androidx.compose.ui.unit.dp
 fun CampfireIconPreview() {
   Row(
     verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(16.dp)
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
   ) {
-
     Image(
       CampfireIcons.Campfire,
-      contentDescription = null
+      contentDescription = null,
     )
 
     Image(
       CampfireIcons.Campfire,
       contentDescription = null,
-      modifier = Modifier.size(120.dp)
+      modifier = Modifier.size(120.dp),
     )
 
     Image(
       CampfireIcons.Campfire,
       contentDescription = null,
       modifier = Modifier
-        .size(240.dp)
+        .size(240.dp),
     )
-
   }
 }

--- a/common/compose/src/jvmMain/kotlin/app/campfire/common/compose/icons/CampfireIconPreview.kt
+++ b/common/compose/src/jvmMain/kotlin/app/campfire/common/compose/icons/CampfireIconPreview.kt
@@ -1,0 +1,40 @@
+package app.campfire.common.compose.icons
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Preview
+@Composable
+fun CampfireIconPreview() {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(16.dp)
+  ) {
+
+    Image(
+      CampfireIcons.Campfire,
+      contentDescription = null
+    )
+
+    Image(
+      CampfireIcons.Campfire,
+      contentDescription = null,
+      modifier = Modifier.size(120.dp)
+    )
+
+    Image(
+      CampfireIcons.Campfire,
+      contentDescription = null,
+      modifier = Modifier
+        .size(240.dp)
+    )
+
+  }
+}

--- a/common/compose/src/skikoMain/kotlin/app/campfire/common/compose/shaders/PerlinNoise.skiko.kt
+++ b/common/compose/src/skikoMain/kotlin/app/campfire/common/compose/shaders/PerlinNoise.skiko.kt
@@ -1,0 +1,83 @@
+package app.campfire.common.compose.shaders
+
+import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntSize
+import org.jetbrains.skia.ImageFilter
+import org.jetbrains.skia.RuntimeEffect
+import org.jetbrains.skia.RuntimeShaderBuilder
+
+@Composable
+actual fun Modifier.applyNoiseEffect(
+  frequencyX: Float,
+  frequencyY: Float,
+  speed: Float,
+  amplitude: Float,
+): Modifier {
+  var resolution by remember { mutableStateOf(IntSize.Zero) }
+
+  val time by produceState(0f) {
+    while (true) {
+      withInfiniteAnimationFrameMillis {
+        value = it / 1000f
+      }
+    }
+  }
+
+  return this
+    .onSizeChanged { resolution = it }
+    .graphicsLayer {
+      renderEffect = createRenderEffect(
+        resolution = resolution,
+        time = time,
+        frequencyX = frequencyX,
+        frequencyY = frequencyY,
+        speed = speed,
+        amplitude = amplitude,
+      )
+    }
+}
+
+fun createRenderEffect(
+  resolution: IntSize,
+  time: Float,
+  frequencyX: Float,
+  frequencyY: Float,
+  speed: Float,
+  amplitude: Float,
+): RenderEffect {
+  val builder = RuntimeShaderBuilder(perlinNoiseEffect).apply {
+    uniform(
+      "resolution",
+      resolution.width.toFloat(),
+      resolution.height.toFloat(),
+    )
+    uniform("time", time)
+    uniform("frequencyX", frequencyX)
+    uniform("frequencyY", frequencyY)
+    uniform("speed", speed)
+    uniform("amplitude", amplitude)
+  }
+
+  return ImageFilter
+    .makeRuntimeShader(
+      runtimeShaderBuilder = builder,
+      shaderName = "contents",
+      input = null,
+    )
+    .asComposeRenderEffect()
+}
+
+val perlinNoiseEffect: RuntimeEffect by lazy {
+  RuntimeEffect.makeForShader(PerlinNoise)
+}

--- a/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
+++ b/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
@@ -32,6 +32,10 @@ data object WelcomeScreen : BaseScreen(name = "Welcome()") {
 data class LoginScreen(
   val isAddingAccount: Boolean = false,
 ) : BaseScreen(name = "Login()") {
+  override val arguments = mapOf(
+    "isAddingAccount" to isAddingAccount,
+  )
+
   override val presentation: Presentation
     get() = Presentation(hideBottomNav = !isAddingAccount)
 }

--- a/core/src/commonMain/kotlin/app.campfire.core/animations/Lerp.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/animations/Lerp.kt
@@ -1,4 +1,4 @@
-// Copyright 2018, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright 2018, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package app.campfire.core.animations

--- a/core/src/commonMain/kotlin/app.campfire.core/app/ApplicationInfo.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/app/ApplicationInfo.kt
@@ -1,4 +1,4 @@
-// Copyright 2023, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright 2023, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package app.campfire.core.app

--- a/core/src/commonMain/kotlin/app.campfire.core/extensions/Lazy.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/extensions/Lazy.kt
@@ -1,4 +1,4 @@
-// Copyright 2022, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright 2022, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package app.campfire.core.extensions

--- a/core/src/commonMain/kotlin/app.campfire.core/extensions/LetIf.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/extensions/LetIf.kt
@@ -1,4 +1,4 @@
-// Copyright 2023, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright 2023, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package app.campfire.core.extensions

--- a/data/account/ui/src/commonMain/kotlin/app/campfire/account/ui/picker/AccountPickerBottomSheet.kt
+++ b/data/account/ui/src/commonMain/kotlin/app/campfire/account/ui/picker/AccountPickerBottomSheet.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.di.rememberComponent
 import app.campfire.common.compose.icons.filled.PersonAdd
-import app.campfire.common.compose.icons.filled.ShieldPerson
 import app.campfire.common.compose.icons.icon
 import app.campfire.common.compose.widgets.CampsiteIcon
 import app.campfire.core.coroutines.LoadState
@@ -275,16 +274,7 @@ private fun AccountListItem(
       Row(
         verticalAlignment = Alignment.CenterVertically,
       ) {
-        Text(server.user.name)
-        if (isCurrent) {
-          Spacer(Modifier.width(4.dp))
-          Icon(
-            Icons.Filled.ShieldPerson,
-            contentDescription = null,
-            modifier = Modifier.size(18.dp),
-            tint = MaterialTheme.colorScheme.primary,
-          )
-        }
+        Text("${server.user.name} @ ${server.name}")
       }
     },
     supportingContent = { Text(server.url) },

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUi.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUi.kt
@@ -67,9 +67,6 @@ private fun LoginContent(
   isAddingAccount: Boolean,
   modifier: Modifier = Modifier,
 ) {
-  val eventSink = state.eventSink
-  var hasFocus by remember { mutableStateOf(false) }
-
   Surface(
     modifier = modifier
       .systemBarsPadding()
@@ -97,63 +94,76 @@ private fun LoginContent(
         )
       }
 
-      Column(
+      LoginUiContent(
+        state = state,
         modifier = Modifier
           .align(Alignment.Center)
-          .fillMaxWidth()
-          .padding(horizontal = 16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-      ) {
-        ServerCard(
-          tent = state.tent,
-          onTentChange = { eventSink(LoginUiEvent.ChangeTent(it)) },
-          serverName = state.serverName,
-          onServerNameChange = { eventSink(LoginUiEvent.ServerName(it)) },
-          serverUrl = state.serverUrl,
-          onServerUrlChange = { eventSink(LoginUiEvent.ServerUrl(it)) },
-          username = state.userName,
-          onUsernameChange = { eventSink(LoginUiEvent.UserName(it)) },
-          password = state.password,
-          onPasswordChange = { eventSink(LoginUiEvent.Password(it)) },
-          onGo = { eventSink(LoginUiEvent.AddCampsite) },
-          connectionState = state.connectionState,
-          authError = state.authError,
-          isAuthenticating = state.isAuthenticating,
-          modifier = Modifier.onFocusChanged {
-            hasFocus = it.hasFocus
-          }.widthIn(max = 500.dp),
+          .fillMaxWidth(),
+      )
+    }
+  }
+}
+
+@Composable
+internal fun LoginUiContent(
+  state: LoginUiState,
+  modifier: Modifier = Modifier,
+) {
+  val eventSink = state.eventSink
+  var hasFocus by remember { mutableStateOf(false) }
+
+  Column(
+    modifier = modifier.padding(horizontal = 16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    ServerCard(
+      tent = state.tent,
+      onTentChange = { eventSink(LoginUiEvent.ChangeTent(it)) },
+      serverName = state.serverName,
+      onServerNameChange = { eventSink(LoginUiEvent.ServerName(it)) },
+      serverUrl = state.serverUrl,
+      onServerUrlChange = { eventSink(LoginUiEvent.ServerUrl(it)) },
+      username = state.userName,
+      onUsernameChange = { eventSink(LoginUiEvent.UserName(it)) },
+      password = state.password,
+      onPasswordChange = { eventSink(LoginUiEvent.Password(it)) },
+      onGo = { eventSink(LoginUiEvent.AddCampsite) },
+      connectionState = state.connectionState,
+      authError = state.authError,
+      isAuthenticating = state.isAuthenticating,
+      modifier = Modifier.onFocusChanged {
+        hasFocus = it.hasFocus
+      }.widthIn(max = 500.dp),
+    )
+
+    Spacer(Modifier.height(16.dp))
+
+    Button(
+      enabled = state.serverUrl.isNotBlank() &&
+        state.userName.isNotBlank() &&
+        state.password.isNotBlank() &&
+        !state.isAuthenticating,
+      onClick = {
+        eventSink(LoginUiEvent.AddCampsite)
+      },
+      modifier = Modifier
+        .widthIn(max = 500.dp)
+        .fillMaxWidth(),
+    ) {
+      if (!state.isAuthenticating) {
+        Icon(
+          Icons.Rounded.Add,
+          contentDescription = null,
         )
-
-        Spacer(Modifier.height(16.dp))
-
-        Button(
-          enabled = state.serverUrl.isNotBlank() &&
-            state.userName.isNotBlank() &&
-            state.password.isNotBlank() &&
-            !state.isAuthenticating,
-          onClick = {
-            eventSink(LoginUiEvent.AddCampsite)
-          },
-          modifier = Modifier
-            .widthIn(max = 500.dp)
-            .fillMaxWidth(),
-        ) {
-          if (!state.isAuthenticating) {
-            Icon(
-              Icons.Rounded.Add,
-              contentDescription = null,
-            )
-            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-            Text(stringResource(Res.string.action_add_campsite))
-          } else {
-            Text(stringResource(Res.string.label_authenticating_loading_message))
-          }
-        }
-
-        Spacer(
-          Modifier.imePadding(),
-        )
+        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+        Text(stringResource(Res.string.action_add_campsite))
+      } else {
+        Text(stringResource(Res.string.label_authenticating_loading_message))
       }
     }
+
+    Spacer(
+      Modifier.imePadding(),
+    )
   }
 }

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/composables/TitleBanner.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/composables/TitleBanner.kt
@@ -1,6 +1,5 @@
 package app.campfire.auth.ui.login.composables
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,8 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import app.campfire.common.compose.icons.Campfire
-import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.NoisyCampfireIcon
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import campfire.features.auth.ui.generated.resources.Res
 import campfire.features.auth.ui.generated.resources.welcome_title
@@ -29,9 +27,7 @@ internal fun TitleBanner(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.aligned(Alignment.CenterHorizontally),
   ) {
-    Image(
-      CampfireIcons.Campfire,
-      contentDescription = null,
+    NoisyCampfireIcon(
       modifier = Modifier.size(96.dp),
     )
     Spacer(Modifier.width(16.dp))

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomePresenter.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomePresenter.kt
@@ -1,6 +1,8 @@
 package app.campfire.auth.ui.welcome
 
 import androidx.compose.runtime.Composable
+import app.campfire.auth.api.AuthRepository
+import app.campfire.auth.ui.login.LoginPresenter
 import app.campfire.common.screens.LoginScreen
 import app.campfire.common.screens.WelcomeScreen
 import app.campfire.core.di.UserScope
@@ -13,12 +15,22 @@ import me.tatarka.inject.annotations.Inject
 @CircuitInject(WelcomeScreen::class, UserScope::class)
 @Inject
 class WelcomePresenter(
+  private val authRepository: AuthRepository,
   @Assisted private val navigator: Navigator,
 ) : Presenter<WelcomeUiState> {
 
+  private val loginPresenter = LoginPresenter(
+    navigator = navigator,
+    authRepository = authRepository,
+  )
+
   @Composable
   override fun present(): WelcomeUiState {
-    return WelcomeUiState { event ->
+    val loginUiState = loginPresenter.present()
+
+    return WelcomeUiState(
+      loginUiState = loginUiState,
+    ) { event ->
       when (event) {
         WelcomeUiEvent.AddCampsite -> navigator.goTo(LoginScreen())
       }

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomeUi.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomeUi.kt
@@ -2,6 +2,7 @@ package app.campfire.auth.ui.welcome
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,9 +17,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import app.campfire.auth.ui.welcome.composables.AddCampsiteCard
-import app.campfire.common.compose.icons.Campfire
+import app.campfire.common.compose.icons.CampfireFireInner
+import app.campfire.common.compose.icons.CampfireFireOuter
 import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.CampfireLogs
+import app.campfire.common.compose.icons.NoisyCampfireIcon
+import app.campfire.common.compose.shaders.applyNoiseEffect
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.screens.WelcomeScreen
 import app.campfire.core.di.UserScope
@@ -43,10 +49,8 @@ fun Welcome(
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.Bottom,
     ) {
-      Image(
-        CampfireIcons.Campfire,
-        contentDescription = null,
-        modifier = Modifier.size(236.dp),
+      NoisyCampfireIcon(
+        modifier = Modifier.size(236.dp)
       )
 
       Spacer(Modifier.height(16.dp))

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomeUi.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomeUi.kt
@@ -1,10 +1,11 @@
 package app.campfire.auth.ui.welcome
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -12,19 +13,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
+import app.campfire.auth.ui.login.LoginUiContent
+import app.campfire.auth.ui.login.LoginUiState
 import app.campfire.auth.ui.welcome.composables.AddCampsiteCard
-import app.campfire.common.compose.icons.CampfireFireInner
-import app.campfire.common.compose.icons.CampfireFireOuter
-import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.CampfireLogs
+import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.icons.NoisyCampfireIcon
-import app.campfire.common.compose.shaders.applyNoiseEffect
+import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.screens.WelcomeScreen
 import app.campfire.core.di.UserScope
@@ -39,8 +40,31 @@ fun Welcome(
   state: WelcomeUiState,
   modifier: Modifier,
 ) {
+  val windowSizeClass = LocalWindowSizeClass.current
   val eventSink = state.eventSink
 
+  CampfireTheme(
+    tent = state.loginUiState.tent,
+  ) {
+    if (windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Large) {
+      TwoPaneLayout(
+        loginUiState = state.loginUiState,
+        modifier = modifier,
+      )
+    } else {
+      SinglePaneLayout(
+        onEvent = eventSink,
+        modifier = modifier,
+      )
+    }
+  }
+}
+
+@Composable
+private fun SinglePaneLayout(
+  onEvent: (WelcomeUiEvent) -> Unit,
+  modifier: Modifier = Modifier,
+) {
   Column(modifier.fillMaxSize()) {
     Column(
       modifier = Modifier
@@ -50,7 +74,7 @@ fun Welcome(
       verticalArrangement = Arrangement.Bottom,
     ) {
       NoisyCampfireIcon(
-        modifier = Modifier.size(236.dp)
+        modifier = Modifier.size(236.dp),
       )
 
       Spacer(Modifier.height(16.dp))
@@ -69,7 +93,7 @@ fun Welcome(
       verticalArrangement = Arrangement.Center,
     ) {
       AddCampsiteCard(
-        onClick = { eventSink(WelcomeUiEvent.AddCampsite) },
+        onClick = { onEvent(WelcomeUiEvent.AddCampsite) },
         modifier = Modifier
           .widthIn(max = 500.dp)
           .fillMaxWidth()
@@ -77,6 +101,48 @@ fun Welcome(
             horizontal = 26.dp,
           ),
       )
+    }
+  }
+}
+
+@Composable
+private fun TwoPaneLayout(
+  loginUiState: LoginUiState,
+  modifier: Modifier = Modifier,
+) {
+  Surface {
+    Row(
+      modifier = modifier
+        .fillMaxSize(),
+    ) {
+      Column(
+        modifier = Modifier
+          .fillMaxHeight()
+          .weight(1f),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+      ) {
+        NoisyCampfireIcon(
+          modifier = Modifier.size(236.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+          text = stringResource(Res.string.welcome_title),
+          style = MaterialTheme.typography.displayLarge,
+          fontFamily = PaytoneOneFontFamily,
+        )
+      }
+
+      Box(
+        modifier = Modifier
+          .fillMaxHeight()
+          .weight(1f),
+      ) {
+        LoginUiContent(
+          state = loginUiState,
+          modifier = Modifier.align(Alignment.CenterStart),
+        )
+      }
     }
   }
 }

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomeUiState.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomeUiState.kt
@@ -1,9 +1,11 @@
 package app.campfire.auth.ui.welcome
 
+import app.campfire.auth.ui.login.LoginUiState
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 
 class WelcomeUiState(
+  val loginUiState: LoginUiState,
   val eventSink: (WelcomeUiEvent) -> Unit,
 ) : CircuitUiState
 

--- a/spotless/google-copyright.txt
+++ b/spotless/google-copyright.txt
@@ -1,3 +1,3 @@
-// Copyright $YEAR, Google LLC, Christopher Banes and the Tivi project contributors
+// Copyright $YEAR, Google LLC, Drew Heavner and the Campfire project contributors
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Added a perlin noise animation to the fire in the campfire icon on the welcome/login screens.

Added a two-pane layout to welcome screen on Large+ devices that incorporates the login ui

## Screenshots

![Screen Recording 2025-01-27 at 9 03 58 PM](https://github.com/user-attachments/assets/070520d5-6455-4c41-95c1-09ae405a2da4)

![Screen Recording 2025-01-27 at 11 25 32 PM](https://github.com/user-attachments/assets/36bf1d84-d2cb-4e5f-a018-608284b9590f)
