### PR TITLE
Ephemeral Sessions

### DIFF
--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/extensions/LocalDateTime.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/extensions/LocalDateTime.kt
@@ -1,6 +1,7 @@
 package app.campfire.common.compose.extensions
 
 import androidx.compose.runtime.Composable
+import app.campfire.core.extensions.epochMilliseconds
 import campfire.common.compose.generated.resources.Res
 import campfire.common.compose.generated.resources.time_ago_days
 import campfire.common.compose.generated.resources.time_ago_hours
@@ -14,14 +15,11 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
 import org.jetbrains.compose.resources.stringResource
 
 val LocalDateTime.timeAgo: String
   @Composable get() {
-    val thisMs = toInstant(TimeZone.UTC).toEpochMilliseconds()
-    return thisMs.timeAgo
+    return epochMilliseconds.timeAgo
   }
 
 val Long.timeAgo: String
@@ -31,7 +29,7 @@ val Long.timeAgo: String
     val elapsedDuration = elapsedMs.milliseconds
 
     return when {
-      elapsedDuration < 5.minutes -> stringResource(Res.string.time_ago_now)
+      elapsedDuration < 1.minutes -> stringResource(Res.string.time_ago_now)
       elapsedDuration < 1.hours -> stringResource(
         Res.string.time_ago_minutes,
         (elapsedDuration.inWholeMinutes % 60).toInt(),

--- a/core/src/commonMain/kotlin/app.campfire.core/extensions/LocalDateTime.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/extensions/LocalDateTime.kt
@@ -19,6 +19,6 @@ val LocalDateTime.readableFormat: String
   }
 
 val LocalDateTime.epochMilliseconds: Long
-  get() = toInstant(TimeZone.UTC).toEpochMilliseconds()
+  get() = toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
 
 private fun Int.withSignificantZero(): String = if (this < 10) "0$this" else "$this"

--- a/core/src/commonMain/kotlin/app.campfire.core/model/Session.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/model/Session.kt
@@ -19,6 +19,7 @@ data class Session(
 
   // Current Playback State
   val timeListening: Duration,
+  val startTime: Duration,
   val currentTime: Duration,
 
   // Date / Time

--- a/data/db/src/commonMain/kotlin/app.campfire.db/DatabaseFactory.kt
+++ b/data/db/src/commonMain/kotlin/app.campfire.db/DatabaseFactory.kt
@@ -90,6 +90,7 @@ class DatabaseFactory(
       idAdapter = UuidAdapter,
       playMethodAdapter = EnumColumnAdapter(),
       timeListeningAdapter = DurationAdapter,
+      startTimeAdapter = DurationAdapter,
       currentTimeAdapter = DurationAdapter,
       startedAtAdapter = LocalDateTimeAdapter,
       updatedAtAdapter = LocalDateTimeAdapter,

--- a/data/db/src/commonMain/sqldelight/app/campfire/data/session.sq
+++ b/data/db/src/commonMain/sqldelight/app/campfire/data/session.sq
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS session (
   mediaPlayer TEXT NOT NULL,
 
   timeListening INTEGER AS Duration NOT NULL DEFAULT 0,
+  startTime INTEGER AS Duration NOT NULL DEFAULT 0,
   currentTime INTEGER AS Duration NOT NULL DEFAULT 0,
 
   startedAt TEXT AS LocalDateTime NOT NULL,
@@ -38,8 +39,19 @@ WHERE libraryItemId = ?
   AND userId = ?;
 
 insert:
-INSERT OR IGNORE INTO session
+INSERT OR REPLACE INTO session
 VALUES ?;
+
+activate {
+  UPDATE session
+  SET isActive = 0
+  WHERE userId = :userId;
+
+  UPDATE session
+  SET isActive = 1
+  WHERE libraryItemId = :libraryItemId
+    AND userId = :userId;
+}
 
 delete:
 DELETE FROM session
@@ -66,14 +78,3 @@ SET isActive = 0
 WHERE libraryItemId = ?
   AND userId = ?;
 
-disableAll:
-UPDATE session
-SET isActive = 0
-WHERE isActive = 1
-  AND userId = ?;
-
-enable:
-UPDATE session
-SET isActive = 1
-WHERE libraryItemId = ?
-  AND userId = ?;

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/network/DefaultNetworkSessionMapper.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/network/DefaultNetworkSessionMapper.kt
@@ -9,6 +9,7 @@ import app.campfire.core.currentPlatform
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.asSeconds
 import app.campfire.core.extensions.capitalized
+import app.campfire.core.extensions.epochMilliseconds
 import app.campfire.core.model.Session
 import app.campfire.network.models.AuthorSeries
 import app.campfire.network.models.BookChapter
@@ -22,9 +23,7 @@ import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
-import kotlinx.datetime.toInstant
 import me.tatarka.inject.annotations.Inject
 
 @ContributesBinding(UserScope::class)
@@ -112,10 +111,10 @@ class DefaultNetworkSessionMapper(
       date = session.startedAt.date.format(LocalDate.Formats.ISO),
       dayOfWeek = session.startedAt.date.dayOfWeek.name.capitalized(),
       timeListening = session.timeListening.asSeconds(),
-      startTime = session.startedAt.toInstant(TimeZone.UTC).toEpochMilliseconds().milliseconds.asSeconds(),
+      startTime = session.startTime.asSeconds(),
       currentTime = session.currentTime.asSeconds(),
-      startedAt = session.startedAt.toInstant(TimeZone.UTC).toEpochMilliseconds(),
-      updatedAt = session.updatedAt.toInstant(TimeZone.UTC).toEpochMilliseconds(),
+      startedAt = session.startedAt.epochMilliseconds,
+      updatedAt = session.updatedAt.epochMilliseconds,
     )
   }
 }

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/composables/WeeklyListeningCard.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/composables/WeeklyListeningCard.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.zIndex
 import app.campfire.common.compose.extensions.largestDurationUnit
 import app.campfire.common.compose.extensions.thresholdReadoutFormat
 import app.campfire.core.extensions.toString
-import app.campfire.core.logging.bark
 import app.campfire.stats.ui.StatsUiModel.WeeklyListening
 import campfire.features.stats.ui.generated.resources.Res
 import campfire.features.stats.ui.generated.resources.weekly_listening_card_title
@@ -214,8 +213,6 @@ private fun WeeklyGraph(
 
         val columnWidth = size.width / 7
         val x = (columnWidth / 2f) + (columnWidth * (6 - i))
-
-        bark { "Graph[$i] - [$thisWeekDayOffset, $lastWeekDayOffset] - x($x)" }
 
         val pathHeight = size.height - TopGraphPadding.toPx()
         val thisWeekY = size.height - pathHeight * (thisWeekDayDuration / maxDuration)


### PR DESCRIPTION
My initial implementation was naive in how listening sessions should operate and were not working well with how the backend uses them to calculate user metrics.

This adjusts that by make the sessions more ephemeral and fixing some other off values.

Resolves #91 