### PR TITLE
Fixing how LibraryItems are persisted

### DIFF
--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/AudioBookShelfApi.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/AudioBookShelfApi.kt
@@ -8,11 +8,9 @@ import app.campfire.network.models.Author
 import app.campfire.network.models.Collection
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
-import app.campfire.network.models.LibraryItemMinified
 import app.campfire.network.models.LibraryStats
 import app.campfire.network.models.ListeningStats
 import app.campfire.network.models.MediaProgress
-import app.campfire.network.models.MinifiedBookMetadata
 import app.campfire.network.models.PlaybackSession
 import app.campfire.network.models.SearchResult
 import app.campfire.network.models.Series
@@ -63,7 +61,7 @@ interface AudioBookShelfApi {
   suspend fun getLibraryItems(
     libraryId: String,
     filter: String? = null,
-  ): Result<List<LibraryItemMinified<MinifiedBookMetadata>>>
+  ): Result<List<LibraryItemExpanded>>
 
   /**
    * Fetch a single library item

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/AudioBookShelfApi.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/AudioBookShelfApi.kt
@@ -8,9 +8,11 @@ import app.campfire.network.models.Author
 import app.campfire.network.models.Collection
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
+import app.campfire.network.models.LibraryItemMinified
 import app.campfire.network.models.LibraryStats
 import app.campfire.network.models.ListeningStats
 import app.campfire.network.models.MediaProgress
+import app.campfire.network.models.MinifiedBookMetadata
 import app.campfire.network.models.PlaybackSession
 import app.campfire.network.models.SearchResult
 import app.campfire.network.models.Series
@@ -62,6 +64,27 @@ interface AudioBookShelfApi {
     libraryId: String,
     filter: String? = null,
   ): Result<List<LibraryItemExpanded>>
+
+  /**
+   * DEPRECATED
+   * ----------
+   * This endpoint is deprecated, and only in use while we get a fix merged upstream for returning
+   * the expanded item models from the backend.
+   * [https://github.com/advplyr/audiobookshelf/pull/3945](https://github.com/advplyr/audiobookshelf/pull/3945)
+   *
+   * Fetch a library's items
+   *
+   * @param libraryId the id of the library to fetch the items for
+   * @return as result with the list of library items
+   */
+  @Deprecated(
+    message = "This endpoint is deprecated since it only returns the minified model",
+    replaceWith = ReplaceWith("getLibraryItems"),
+  )
+  suspend fun getLibraryItemsMinified(
+    libraryId: String,
+    filter: String? = null,
+  ): Result<List<LibraryItemMinified<MinifiedBookMetadata>>>
 
   /**
    * Fetch a single library item

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/envelopes/Envelope.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/envelopes/Envelope.kt
@@ -1,0 +1,17 @@
+package app.campfire.network.envelopes
+
+import app.campfire.network.RequestOrigin
+import app.campfire.network.models.NetworkModel
+
+/**
+ * Base model for all API response envelopes
+ */
+abstract class Envelope : NetworkModel() {
+
+  /**
+   * This must be overridden to populate the [RequestOrigin] throughout the containing [NetworkModel]
+   * in this envelope. This is necessary for parts of our setup that use this field to relate what [serverUrl]
+   * the request came from.
+   */
+  abstract fun applyPostage()
+}

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/models/Author.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/models/Author.kt
@@ -30,4 +30,4 @@ data class Author(
   // Attributes only included in /authors/:id endpoint
   val libraryItems: List<LibraryItemMinified<MinifiedBookMetadata>>? = null,
   val series: List<AuthorSeries>? = null,
-)
+) : NetworkModel()

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/models/Collection.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/models/Collection.kt
@@ -10,7 +10,7 @@ data class Collection(
   val description: String?,
   val cover: String? = null,
   val coverFullPath: String? = null,
-  val books: List<LibraryItemMinified<ExpandedBookMetadata>>,
+  val books: List<LibraryItemExpanded>,
   val lastUpdate: Long,
   val createdAt: Long,
-)
+) : NetworkModel()

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/models/Library.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/models/Library.kt
@@ -28,4 +28,4 @@ data class Library(
   val settings: LibrarySettings,
   val createdAt: Long,
   val lastUpdate: Long,
-)
+) : NetworkModel()

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/models/MediaProgress.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/models/MediaProgress.kt
@@ -20,4 +20,4 @@ data class MediaProgress(
   val lastUpdate: Long,
   val startedAt: Long,
   val finishedAt: Long? = null,
-)
+) : NetworkModel()

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/models/SearchResult.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/models/SearchResult.kt
@@ -1,5 +1,6 @@
 package app.campfire.network.models
 
+import app.campfire.network.envelopes.Envelope
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,7 +11,13 @@ data class SearchResult(
   val tags: List<TagSearchResult>,
   val genres: List<TagSearchResult>,
   val series: List<SeriesSearchResult>,
-) : NetworkModel() {
+) : Envelope() {
+
+  override fun applyPostage() {
+    book.forEach { b -> b.libraryItem.origin = origin }
+    authors.forEach { a -> a.origin = origin }
+    series.forEach { s -> s.books.forEach { sb -> sb.origin = origin } }
+  }
 
   fun toShortString(): String {
     return "SearchResult(books=${book.size}, narrators=${narrators.size}, authors=${authors.size}, " +

--- a/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
+++ b/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
@@ -10,6 +10,7 @@ import app.campfire.network.envelopes.AllLibrariesResponse
 import app.campfire.network.envelopes.AuthorResponse
 import app.campfire.network.envelopes.CollectionsResponse
 import app.campfire.network.envelopes.CreateBookmarkRequest
+import app.campfire.network.envelopes.Envelope
 import app.campfire.network.envelopes.LibraryItemsResponse
 import app.campfire.network.envelopes.LoginRequest
 import app.campfire.network.envelopes.LoginResponse
@@ -23,11 +24,9 @@ import app.campfire.network.models.Author
 import app.campfire.network.models.Collection
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
-import app.campfire.network.models.LibraryItemMinified
 import app.campfire.network.models.LibraryStats
 import app.campfire.network.models.ListeningStats
 import app.campfire.network.models.MediaProgress
-import app.campfire.network.models.MinifiedBookMetadata
 import app.campfire.network.models.NetworkModel
 import app.campfire.network.models.PlaybackSession
 import app.campfire.network.models.SearchResult
@@ -116,10 +115,11 @@ class KtorAudioBookShelfApi(
   override suspend fun getLibraryItems(
     libraryId: String,
     filter: String?,
-  ): Result<List<LibraryItemMinified<MinifiedBookMetadata>>> {
+  ): Result<List<LibraryItemExpanded>> {
     return trySendRequest<LibraryItemsResponse> {
       hydratedClientRequest({
         appendPathSegments("api", "libraries", libraryId, "items")
+        parameters.append("minified", "0")
         filter?.let { f -> parameters.append("filter", f) }
       })
     }.map { it.results }
@@ -269,6 +269,13 @@ class KtorAudioBookShelfApi(
         if (body is NetworkModel && originServerUrl != null) {
           body.origin = RequestOrigin.Url(originServerUrl)
         }
+
+        // If our response model is an [Envelope] be sure to apply
+        // its postage.
+        if (body is Envelope) {
+          body.applyPostage()
+        }
+
         Result.success(body)
       } else {
         Result.failure(ApiException(response.status.value, response.bodyAsText()))

--- a/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
+++ b/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
@@ -15,6 +15,7 @@ import app.campfire.network.envelopes.LibraryItemsResponse
 import app.campfire.network.envelopes.LoginRequest
 import app.campfire.network.envelopes.LoginResponse
 import app.campfire.network.envelopes.MediaProgressUpdatePayload
+import app.campfire.network.envelopes.MinifiedLibraryItemsResponse
 import app.campfire.network.envelopes.PingResponse
 import app.campfire.network.envelopes.SeriesResponse
 import app.campfire.network.envelopes.SyncLocalSessionsResult
@@ -24,9 +25,11 @@ import app.campfire.network.models.Author
 import app.campfire.network.models.Collection
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
+import app.campfire.network.models.LibraryItemMinified
 import app.campfire.network.models.LibraryStats
 import app.campfire.network.models.ListeningStats
 import app.campfire.network.models.MediaProgress
+import app.campfire.network.models.MinifiedBookMetadata
 import app.campfire.network.models.NetworkModel
 import app.campfire.network.models.PlaybackSession
 import app.campfire.network.models.SearchResult
@@ -120,6 +123,23 @@ class KtorAudioBookShelfApi(
       hydratedClientRequest({
         appendPathSegments("api", "libraries", libraryId, "items")
         parameters.append("minified", "0")
+        filter?.let { f -> parameters.append("filter", f) }
+      })
+    }.map { it.results }
+  }
+
+  @Deprecated(
+    "This endpoint is deprecated since it only returns the minified model",
+    replaceWith = ReplaceWith("getLibraryItems")
+  )
+  override suspend fun getLibraryItemsMinified(
+    libraryId: String,
+    filter: String?,
+  ): Result<List<LibraryItemMinified<MinifiedBookMetadata>>> {
+    return trySendRequest<MinifiedLibraryItemsResponse> {
+      hydratedClientRequest({
+        appendPathSegments("api", "libraries", libraryId, "items")
+        parameters.append("minified", "1")
         filter?.let { f -> parameters.append("filter", f) }
       })
     }.map { it.results }

--- a/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
+++ b/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
@@ -130,7 +130,7 @@ class KtorAudioBookShelfApi(
 
   @Deprecated(
     "This endpoint is deprecated since it only returns the minified model",
-    replaceWith = ReplaceWith("getLibraryItems")
+    replaceWith = ReplaceWith("getLibraryItems"),
   )
   override suspend fun getLibraryItemsMinified(
     libraryId: String,

--- a/data/network/impl/src/commonMain/kotlin/app.campfire.network/envelopes/CollectionsResponse.kt
+++ b/data/network/impl/src/commonMain/kotlin/app.campfire.network/envelopes/CollectionsResponse.kt
@@ -3,8 +3,17 @@ package app.campfire.network.envelopes
 import app.campfire.network.models.Collection
 import kotlinx.serialization.Serializable
 
-// TODO: This envelope is consistent across many endpoints and we should commonize it
 @Serializable
 class CollectionsResponse(
   val results: List<Collection>,
-)
+) : Envelope() {
+
+  override fun applyPostage() {
+    results.forEach { collection ->
+      collection.origin = origin
+      collection.books.forEach { book ->
+        book.origin = origin
+      }
+    }
+  }
+}

--- a/data/network/impl/src/commonMain/kotlin/app.campfire.network/envelopes/LibraryResponses.kt
+++ b/data/network/impl/src/commonMain/kotlin/app.campfire.network/envelopes/LibraryResponses.kt
@@ -2,7 +2,9 @@ package app.campfire.network.envelopes
 
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
+import app.campfire.network.models.LibraryItemMinified
 import app.campfire.network.models.MediaType
+import app.campfire.network.models.MinifiedBookMetadata
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -18,6 +20,25 @@ class AllLibrariesResponse(
 @Serializable
 class LibraryItemsResponse(
   val results: List<LibraryItemExpanded>,
+  val total: Int,
+  val limit: Int,
+  val page: Int,
+  val sortDesc: Boolean,
+  val mediaType: MediaType,
+  val minified: Boolean,
+  val collapseseries: Boolean,
+  val include: String,
+  val offset: Int,
+) : Envelope() {
+
+  override fun applyPostage() {
+    results.forEach { it.origin = origin }
+  }
+}
+
+@Serializable
+class MinifiedLibraryItemsResponse(
+  val results: List<LibraryItemMinified<MinifiedBookMetadata>>,
   val total: Int,
   val limit: Int,
   val page: Int,

--- a/data/network/impl/src/commonMain/kotlin/app.campfire.network/envelopes/LibraryResponses.kt
+++ b/data/network/impl/src/commonMain/kotlin/app.campfire.network/envelopes/LibraryResponses.kt
@@ -1,19 +1,23 @@
 package app.campfire.network.envelopes
 
 import app.campfire.network.models.Library
-import app.campfire.network.models.LibraryItemMinified
+import app.campfire.network.models.LibraryItemExpanded
 import app.campfire.network.models.MediaType
-import app.campfire.network.models.MinifiedBookMetadata
 import kotlinx.serialization.Serializable
 
 @Serializable
 class AllLibrariesResponse(
   val libraries: List<Library>,
-)
+) : Envelope() {
+
+  override fun applyPostage() {
+    libraries.forEach { it.origin = origin }
+  }
+}
 
 @Serializable
 class LibraryItemsResponse(
-  val results: List<LibraryItemMinified<MinifiedBookMetadata>>,
+  val results: List<LibraryItemExpanded>,
   val total: Int,
   val limit: Int,
   val page: Int,
@@ -23,4 +27,9 @@ class LibraryItemsResponse(
   val collapseseries: Boolean,
   val include: String,
   val offset: Int,
-)
+) : Envelope() {
+
+  override fun applyPostage() {
+    results.forEach { it.origin = origin }
+  }
+}

--- a/features/author/impl/src/commonMain/kotlin/app/campfire/author/store/AuthorDetailStoreModule.kt
+++ b/features/author/impl/src/commonMain/kotlin/app/campfire/author/store/AuthorDetailStoreModule.kt
@@ -74,8 +74,13 @@ interface AuthorDetailStoreModule {
                 author.libraryItems?.forEach { libraryItem ->
                   val dbLibraryItem = libraryItem.asDbModel(userSession.serverUrl!!)
                   val dbMedia = libraryItem.media.asDbModel(dbLibraryItem.id)
-                  db.libraryItemsQueries.insert(dbLibraryItem)
-                  db.mediaQueries.insert(dbMedia)
+
+                  // Various APIs return minified versions of the library item queries, which if
+                  // persisted as INSERT OR REPLACE will overwrite the expanded version stored
+                  // including a lot of useful information for display rich item details such as
+                  // chapters, tracks, author lists, and narrator lists.
+                  db.libraryItemsQueries.insertOrIgnore(dbLibraryItem)
+                  db.mediaQueries.insertOrIgnore(dbMedia)
                 }
               }
             }

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
@@ -74,7 +74,6 @@ class StoreLibraryRepository(
 
                 db.libraryItemsQueries.insertOrIgnore(libraryItem)
                 db.mediaQueries.insertOrIgnore(media)
-
               }
             }
           }

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
@@ -13,6 +13,7 @@ import app.campfire.core.session.serverUrl
 import app.campfire.data.mapping.asDbModel
 import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.asFetcherResult
+import app.campfire.data.mapping.dao.LibraryItemDao
 import app.campfire.data.mapping.model.LibraryItemWithMedia
 import app.campfire.data.mapping.model.mapToLibraryItem
 import app.campfire.libraries.api.LibraryRepository
@@ -42,6 +43,7 @@ class StoreLibraryRepository(
   private val userSession: UserSession,
   private val api: AudioBookShelfApi,
   private val db: CampfireDatabase,
+  private val libraryItemDao: LibraryItemDao,
   private val tokenHydrator: TokenHydrator,
   private val dispatcherProvider: DispatcherProvider,
 ) : LibraryRepository {
@@ -61,11 +63,10 @@ class StoreLibraryRepository(
           withContext(dispatcherProvider.databaseWrite) {
             db.transaction {
               data.forEach { item ->
-                val libraryItem = item.asDbModel(userSession.serverUrl!!)
-                val media = item.media.asDbModel(item.id)
-
-                db.libraryItemsQueries.insert(libraryItem)
-                db.mediaQueries.insert(media)
+                libraryItemDao.insert(
+                  item = item,
+                  asTransaction = false,
+                )
               }
             }
           }

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
@@ -51,7 +51,7 @@ class StoreLibraryRepository(
   private val libraryItemStore = StoreBuilder
     .from(
       fetcher = Fetcher.ofResult { libraryId: LibraryId ->
-        api.getLibraryItems(libraryId).asFetcherResult()
+        api.getLibraryItemsMinified(libraryId).asFetcherResult()
       },
       sourceOfTruth = SourceOfTruth.of(
         reader = { libraryId: LibraryId ->
@@ -63,10 +63,18 @@ class StoreLibraryRepository(
           withContext(dispatcherProvider.databaseWrite) {
             db.transaction {
               data.forEach { item ->
-                libraryItemDao.insert(
-                  item = item,
-                  asTransaction = false,
-                )
+                // TODO: Update when https://github.com/advplyr/audiobookshelf/pull/3945 is merged
+//                libraryItemDao.insert(
+//                  item = item,
+//                  asTransaction = false,
+//                )
+
+                val libraryItem = item.asDbModel(userSession.serverUrl!!)
+                val media = item.media.asDbModel(item.id)
+
+                db.libraryItemsQueries.insertOrIgnore(libraryItem)
+                db.mediaQueries.insertOrIgnore(media)
+
               }
             }
           }

--- a/features/search/impl/src/commonMain/kotlin/app/campfire/search/store/SearchSourceOfTruthFactory.kt
+++ b/features/search/impl/src/commonMain/kotlin/app/campfire/search/store/SearchSourceOfTruthFactory.kt
@@ -145,9 +145,6 @@ class SearchSourceOfTruthFactory(
       // Insert Books + Relations
       transactionWithResult {
         book.forEach { bookResult ->
-          // We need to pass the serverUrl origin to the library item object as it sets itself up
-          // as a child to the server column in the database.
-          bookResult.libraryItem.origin = result.origin
           libraryItemDao.insert(bookResult.libraryItem, asTransaction = false)
         }
       }
@@ -194,7 +191,6 @@ class SearchSourceOfTruthFactory(
           )
 
           seriesSearchResult.books.forEach { libraryItem ->
-            libraryItem.origin = result.origin
             libraryItemDao.insert(
               item = libraryItem,
               asTransaction = true,

--- a/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
+++ b/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
@@ -148,7 +148,6 @@ class StoreSeriesRepository(
               db.libraryItemsQueries.insertOrIgnore(libraryItem)
               db.mediaQueries.insertOrIgnore(media)
 
-
               // Insert junction entry
               db.seriesBookJoinQueries.insert(
                 SeriesBookJoin(

--- a/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
+++ b/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
@@ -15,6 +15,7 @@ import app.campfire.data.SeriesBookJoin
 import app.campfire.data.mapping.asDbModel
 import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.asFetcherResult
+import app.campfire.data.mapping.dao.LibraryItemDao
 import app.campfire.network.AudioBookShelfApi
 import app.campfire.network.models.Series as NetworkSeries
 import app.campfire.series.api.SeriesRepository
@@ -46,6 +47,7 @@ class StoreSeriesRepository(
   private val userSession: UserSession,
   private val api: AudioBookShelfApi,
   private val db: CampfireDatabase,
+  private val libraryItemDao: LibraryItemDao,
   private val userRepository: UserRepository,
   private val tokenHydrator: TokenHydrator,
   private val dispatcherProvider: DispatcherProvider,
@@ -83,8 +85,10 @@ class StoreSeriesRepository(
               series.books?.forEach { book ->
                 val libraryItem = book.asDbModel(serverUrl)
                 val media = book.media.asDbModel(book.id)
-                db.libraryItemsQueries.insert(libraryItem)
-                db.mediaQueries.insert(media)
+
+                // If these items exist, lets not overwrite their metadata
+                db.libraryItemsQueries.insertOrIgnore(libraryItem)
+                db.mediaQueries.insertOrIgnore(media)
 
                 // Insert junction entry
                 db.seriesBookJoinQueries.insert(
@@ -133,10 +137,10 @@ class StoreSeriesRepository(
         withContext(dispatcherProvider.databaseWrite) {
           db.transaction {
             items.forEach { item ->
-              val libraryItem = item.asDbModel(serverUrl)
-              val media = item.media.asDbModel(item.id)
-              db.libraryItemsQueries.insert(libraryItem)
-              db.mediaQueries.insert(media)
+              libraryItemDao.insert(
+                item = item,
+                asTransaction = false,
+              )
 
               // Insert junction entry
               db.seriesBookJoinQueries.insert(

--- a/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
+++ b/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
@@ -119,7 +119,7 @@ class StoreSeriesRepository(
   private val libraryItemStore = StoreBuilder.from(
     fetcher = Fetcher.ofResult { s: SeriesItems ->
       val encodedSeriesId = Base64.encode(s.seriesId.encodeToByteArray())
-      api.getLibraryItems(s.libraryId, "series.$encodedSeriesId").asFetcherResult()
+      api.getLibraryItemsMinified(s.libraryId, "series.$encodedSeriesId").asFetcherResult()
     },
     sourceOfTruth = SourceOfTruth.of(
       reader = { s: SeriesItems ->
@@ -137,10 +137,17 @@ class StoreSeriesRepository(
         withContext(dispatcherProvider.databaseWrite) {
           db.transaction {
             items.forEach { item ->
-              libraryItemDao.insert(
-                item = item,
-                asTransaction = false,
-              )
+              // TODO: Update when https://github.com/advplyr/audiobookshelf/pull/3945 is merged
+//              libraryItemDao.insert(
+//                item = item,
+//                asTransaction = false,
+//              )
+
+              val libraryItem = item.asDbModel(serverUrl)
+              val media = item.media.asDbModel(item.id)
+              db.libraryItemsQueries.insertOrIgnore(libraryItem)
+              db.mediaQueries.insertOrIgnore(media)
+
 
               // Insert junction entry
               db.seriesBookJoinQueries.insert(


### PR DESCRIPTION
Fixed how library items are persisted so we don't accidentally clobber existing metadata relations (i.e. chapters, tracks, etc)

Updated to be based off of fix to server that allows non-minified library item responses. 

Fixes #73 
Blocked by https://github.com/advplyr/audiobookshelf/pull/3945