### PR TITLE
Fixing session restoration

### DIFF
--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
@@ -100,7 +100,9 @@ private fun PlaybackSpeedBottomSheet(
     Spacer(Modifier.height(16.dp))
 
     SingleChoiceSegmentedButtonRow(
-      modifier = Modifier.align(Alignment.CenterHorizontally),
+      modifier = Modifier
+        .align(Alignment.CenterHorizontally)
+        .padding(horizontal = 16.dp),
     ) {
       speedOptions.forEachIndexed { index, defaultSpeed ->
         val isCurrentSpeed = currentSpeed == defaultSpeed

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/AudioPlayer.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/AudioPlayer.kt
@@ -67,6 +67,7 @@ interface AudioPlayer {
     duration: Duration = DefaultFadeDuration,
     tickRate: Long = DefaultFadeTickRate,
   ): Job
+
   fun playPause()
   fun stop()
   fun seekTo(itemIndex: Int)
@@ -85,6 +86,7 @@ interface AudioPlayer {
 
   enum class State {
     Disabled,
+    Initializing,
     Buffering,
     Playing,
     Paused,

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -128,6 +128,7 @@ class ExoPlayerAudioPlayer(
     chapterId: Int?,
   ) = withContext(Dispatchers.Main) {
     preparedSession = session
+    state.value = AudioPlayer.State.Initializing
 
     val mediaItems = MediaItemBuilder.build(session).asPlatformMediaItems()
 

--- a/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/IosAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/IosAudioPlayer.kt
@@ -96,6 +96,7 @@ class IosAudioPlayer(
     chapterId: Int?,
   ) {
     preparedSession = session
+    player.prePrepare()
 
     setupRemoteTransportControls()
 

--- a/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/player/IosPlayer.kt
+++ b/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/player/IosPlayer.kt
@@ -211,6 +211,13 @@ class IosPlayer(
   }
 
   /**
+   * Work around to put the state into initialization mode while we prepare the player
+   */
+  fun prePrepare() {
+    _state.value = AudioPlayer.State.Initializing
+  }
+
+  /**
    * Prepare this player for playback, feeding it an option to start playback immediately when its ready
    * or to wait. Also give the starting overall time position of where to resume/start playback.
    * @param playImmediately start playback immediately

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/DesktopPlaybackController.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/DesktopPlaybackController.kt
@@ -9,7 +9,6 @@ import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.di.qualifier.ForScope
 import app.campfire.core.model.LibraryItemId
-import app.campfire.core.time.FatherTime
 import app.campfire.settings.api.PlaybackSettings
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.launch
@@ -22,7 +21,6 @@ class DesktopPlaybackController(
   private val playbackSessionManager: PlaybackSessionManager,
   private val playbackSettings: PlaybackSettings,
   private val audioPlayerHolder: AudioPlayerHolder,
-  private val fatherTime: FatherTime,
   private val sleepTimerManagerFactory: SleepTimerManager.Factory,
   @ForScope(UserScope::class) private val userScopeHolder: CoroutineScopeHolder,
 ) : PlaybackController {
@@ -47,7 +45,7 @@ class DesktopPlaybackController(
 
   private fun initializeAudioPlayerIfNeeded() {
     if (audioPlayerHolder.currentPlayer.value == null) {
-      audioPlayerHolder.setCurrentPlayer(VlcAudioPlayer(playbackSettings, fatherTime, sleepTimerManagerFactory))
+      audioPlayerHolder.setCurrentPlayer(VlcAudioPlayer(playbackSettings, sleepTimerManagerFactory))
     }
   }
 }

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/VlcAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/VlcAudioPlayer.kt
@@ -12,7 +12,6 @@ import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.core.extensions.seconds
 import app.campfire.core.logging.bark
 import app.campfire.core.model.Session
-import app.campfire.core.time.FatherTime
 import app.campfire.settings.api.PlaybackSettings
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -27,7 +26,6 @@ import kotlinx.coroutines.flow.StateFlow
 
 class VlcAudioPlayer(
   private val settings: PlaybackSettings,
-  private val fatherTime: FatherTime,
   sleepTimerManagerFactory: SleepTimerManager.Factory,
 ) : AudioPlayer {
 
@@ -60,6 +58,7 @@ class VlcAudioPlayer(
     chapterId: Int?,
   ) {
     preparedSession = session
+    state.value = AudioPlayer.State.Initializing
 
     // Build and set media items for the current session
     val mediaItems = MediaItemBuilder.build(session)

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/player/VlcPlayer.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/player/VlcPlayer.kt
@@ -9,8 +9,7 @@ import app.campfire.audioplayer.impl.vlcj.play
 import app.campfire.audioplayer.impl.vlcj.seekBackward
 import app.campfire.audioplayer.impl.vlcj.seekForward
 import app.campfire.audioplayer.impl.vlcj.stop
-import app.campfire.core.logging.LogPriority
-import app.campfire.core.logging.bark
+import app.campfire.core.logging.Cork
 import app.campfire.core.util.runIf
 import kotlin.math.floor
 import kotlin.math.roundToLong
@@ -183,9 +182,9 @@ class VlcPlayer {
 
       val result = mediaPlayer.media().start(item.uri, *options)
       if (result) {
-        bark(LogPriority.DEBUG, TAG) { "Starting '${item.metadata?.title}', with ${options.joinToString()}" }
+        dbark { "Starting '${item.metadata?.title}', with ${options.joinToString()}" }
       } else {
-        bark(LogPriority.ERROR, TAG) { "Unable to start playback for '${item.metadata?.title}'" }
+        dbark { "Unable to start playback for '${item.metadata?.title}'" }
       }
     }
   }
@@ -217,50 +216,50 @@ class VlcPlayer {
 
   private inner class EventListener : MediaPlayerEventAdapter() {
     override fun mediaPlayerReady(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "mediaPlayerReady()" }
+      dbark { "mediaPlayerReady()" }
       mediaPlayer?.syncStateToListener()
     }
 
     override fun mediaChanged(mediaPlayer: MediaPlayer?, media: MediaRef?) {
-      bark(TAG) { "mediaChanged($media)" }
+      dbark { "mediaChanged($media)" }
       mediaPlayer?.syncStateToListener()
     }
 
     override fun opening(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "opening()" }
+      dbark { "opening()" }
       mediaPlayer?.syncStateToListener()
     }
 
     override fun buffering(mediaPlayer: MediaPlayer?, newCache: Float) {
-      bark(TAG) { "buffering(newCache=$newCache)" }
+      dbark { "buffering(newCache=$newCache)" }
       mediaPlayer?.syncStateToListener()
     }
 
     override fun playing(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "playing" }
+      dbark { "playing" }
       mediaPlayer?.syncStateToListener()
     }
 
     override fun paused(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "paused()" }
+      dbark { "paused()" }
       mediaPlayer?.syncStateToListener()
     }
 
     override fun stopped(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "stopped()" }
+      dbark { "stopped()" }
       mediaPlayer?.syncStateToListener()
     }
 
     override fun forward(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "forward()" }
+      dbark { "forward()" }
     }
 
     override fun backward(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "backward()" }
+      dbark { "backward()" }
     }
 
     override fun finished(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "finished($mediaPlayer)" }
+      dbark { "finished($mediaPlayer)" }
       listener?.onPositionChanged(0L)
       mediaPlayer?.submit {
         skipToNext()
@@ -268,19 +267,19 @@ class VlcPlayer {
     }
 
     override fun seekableChanged(mediaPlayer: MediaPlayer?, newSeekable: Int) {
-      bark(TAG) { "seekableChanged(newSeekable=$newSeekable)" }
+      dbark { "seekableChanged(newSeekable=$newSeekable)" }
     }
 
     override fun pausableChanged(mediaPlayer: MediaPlayer?, newPausable: Int) {
-      bark(TAG) { "pausableChanged(newPausable=$newPausable)" }
+      dbark { "pausableChanged(newPausable=$newPausable)" }
     }
 
     override fun titleChanged(mediaPlayer: MediaPlayer?, newTitle: Int) {
-      bark(TAG) { "titleChanged(newTitle=$newTitle)" }
+      dbark { "titleChanged(newTitle=$newTitle)" }
     }
 
     override fun lengthChanged(mediaPlayer: MediaPlayer?, newLength: Long) {
-      bark(TAG) { "lengthChanged(newLength=$newLength)" }
+      dbark { "lengthChanged(newLength=$newLength)" }
 
       // If the current media item has a clipping configuration set then
       // we'll just want to report its duration since the underlying
@@ -294,7 +293,7 @@ class VlcPlayer {
     }
 
     override fun timeChanged(mediaPlayer: MediaPlayer?, newTime: Long) {
-      bark(TAG) { "timeChanged(newTime=$newTime)" }
+      dbark { "timeChanged(newTime=$newTime)" }
 
       // If the current media item has a clipping configuration set then
       // we'll want to adjust the current time here to be within the clip
@@ -309,23 +308,23 @@ class VlcPlayer {
     }
 
     override fun corked(mediaPlayer: MediaPlayer?, corked: Boolean) {
-      bark(TAG) { "corked(corked=$corked)" }
+      dbark { "corked(corked=$corked)" }
     }
 
     override fun muted(mediaPlayer: MediaPlayer?, muted: Boolean) {
-      bark(TAG) { "muted(muted=$muted)" }
+      dbark { "muted(muted=$muted)" }
     }
 
     override fun audioDeviceChanged(mediaPlayer: MediaPlayer?, audioDevice: String?) {
-      bark(TAG) { "audioDeviceChanged(audioDevice=$audioDevice)" }
+      dbark { "audioDeviceChanged(audioDevice=$audioDevice)" }
     }
 
     override fun chapterChanged(mediaPlayer: MediaPlayer?, newChapter: Int) {
-      bark(TAG) { "chapterChanged(newChapter=$newChapter)" }
+      dbark { "chapterChanged(newChapter=$newChapter)" }
     }
 
     override fun error(mediaPlayer: MediaPlayer?) {
-      bark(TAG) { "error(${mediaPlayer?.status()?.state()})" }
+      dbark { "error(${mediaPlayer?.status()?.state()})" }
       mediaPlayer?.syncStateToListener()
     }
 
@@ -348,6 +347,11 @@ class VlcPlayer {
       listener?.onStateChanged(playerState)
     }
   }
+
+  companion object : Cork {
+    override val tag: String = "VlcPlayer"
+    override val enabled: Boolean = false
+  }
 }
 
 sealed class VlcOption(val option: String) {
@@ -359,5 +363,3 @@ sealed class VlcOption(val option: String) {
 private fun List<VlcOption>.toOptionArray(): Array<String> {
   return map { it.option }.toTypedArray()
 }
-
-private const val TAG = "VlcPlayer"

--- a/infra/shake/src/androidMain/kotlin/app/campfire/shake/SeismicShakeDetector.kt
+++ b/infra/shake/src/androidMain/kotlin/app/campfire/shake/SeismicShakeDetector.kt
@@ -4,7 +4,6 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
-import app.campfire.core.logging.bark
 
 class SeismicShakeDetector(
   private val listener: Listener,
@@ -75,8 +74,6 @@ class SeismicShakeDetector(
       event.values[2].toDouble(),
       event.timestamp,
     )
-
-    bark("ShakeDetector") { "Accelerometer event: $accelerometerEvent" }
 
     samplingShakeDetector.addAccelerometerEvent(accelerometerEvent)
   }

--- a/infra/shake/src/commonMain/kotlin/app/campfire/shake/SamplingShakeDetector.kt
+++ b/infra/shake/src/commonMain/kotlin/app/campfire/shake/SamplingShakeDetector.kt
@@ -1,7 +1,5 @@
 package app.campfire.shake
 
-import app.campfire.core.logging.bark
-
 /**
  * Detects phone shaking. If more than 75% of the samples taken in the past 0.5s are
  * accelerating, the device is a) shaking, or b) free falling 1.84m (h =
@@ -47,7 +45,6 @@ class SamplingShakeDetector(
     // compare their squares. This is equivalent and doesn't need the
     // actual magnitude, which would be computed using (expensive) Math.sqrt().
     val magnitudeSquared = (ax * ax + ay * ay + az * az).toDouble()
-    bark("ShakeDetector") { "Magnitude($magnitudeSquared) > ${sensitivity.valueSquared}" }
     return magnitudeSquared > sensitivity.valueSquared
   }
 


### PR DESCRIPTION
Fixes #106

Added a new `Initializing` state to `AudioPlayer.State` to add a state for when we are preparing an audio player. This allows the check in `SessionHostLayout` to not double-submit sessions when instantiating.