### PR TITLE
Fix BuildConfig not working for non-jvm platforms

### DIFF
--- a/features/auth/ui/build.gradle.kts
+++ b/features/auth/ui/build.gradle.kts
@@ -8,6 +8,7 @@ buildConfig {
   buildConfigField("String?", "TEST_SERVER_URL", providers.gradleProperty("campfire_server_url").orNull)
   buildConfigField("String?", "TEST_USERNAME", providers.gradleProperty("campfire_username").orNull)
   buildConfigField("String?", "TEST_PASSWORD", providers.gradleProperty("campfire_password").orNull)
+  useKotlinOutput()
 }
 
 kotlin {


### PR DESCRIPTION
By default that plugin generates java output. Not sure how this ever worked, but fixed by having it output Kotlin source