### PR TITLE
Fixes to session syncing

### DIFF
--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ TODO: Use https://github.com/ffurrer2/extract-release-notes when crafting a rele
 
 - HTML is no rendered properly on the item detail page description
 - Fixed sleep timer fading-to-pause when set as "End of Chapter"
+- Fixed how PlayMethod not reporting offline play correctly
 
 ### Other Notes & Contributions
 

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
@@ -4,7 +4,6 @@ import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.seconds
-import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.PlayMethod
 import app.campfire.core.model.Session

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
@@ -4,6 +4,7 @@ import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.seconds
+import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.PlayMethod
 import app.campfire.core.model.Session

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SqlDelightSessionDataSource.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SqlDelightSessionDataSource.kt
@@ -150,8 +150,8 @@ class SqlDelightSessionDataSource(
         // Important! We deactivate all prior sessions before inserting this,
         // and this MUST be true for the change to be picked up
         isActive = true,
-        playMethod = PlayMethod.DirectPlay,
-        mediaPlayer = "campfire",
+        playMethod = playMethod,
+        mediaPlayer = mediaPlayer,
         timeListening = 0.seconds,
         startTime = newStartTime,
         currentTime = newCurrentTime,

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/LocalSessionUpdateSynchronizer.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/LocalSessionUpdateSynchronizer.kt
@@ -4,6 +4,7 @@ import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.sync.PlaybackSynchronizer
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.ComponentHolder
+import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.logging.Cork
 import app.campfire.core.model.LibraryItemId
@@ -13,6 +14,7 @@ import com.r0adkll.kimchi.annotations.ContributesMultibinding
 import com.r0adkll.kimchi.annotations.ContributesTo
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.uuid.Uuid
 import me.tatarka.inject.annotations.Inject
 
 @ContributesTo(UserScope::class)
@@ -22,6 +24,7 @@ interface LocalSessionComponent {
 }
 
 @Inject
+@SingleIn(AppScope::class)
 @ContributesMultibinding(AppScope::class)
 class LocalSessionUpdateSynchronizer(
   private val fatherTime: FatherTime,
@@ -36,21 +39,22 @@ class LocalSessionUpdateSynchronizer(
   private var lastPlayedTime = mutableMapOf<String, Long>()
 
   override suspend fun onStateChanged(
+    sessionId: Uuid,
     libraryItemId: LibraryItemId,
     state: AudioPlayer.State,
     previousState: AudioPlayer.State,
   ) {
     if (state == AudioPlayer.State.Playing) {
-      lastPlayedTime[libraryItemId] = fatherTime.nowInEpochMillis()
+      lastPlayedTime[sessionId.toHexString()] = fatherTime.nowInEpochMillis()
     } else if (
       state == AudioPlayer.State.Paused ||
       state == AudioPlayer.State.Disabled ||
       state == AudioPlayer.State.Finished
     ) {
-      val lastPlayed = lastPlayedTime[libraryItemId]
+      val lastPlayed = lastPlayedTime[sessionId.toHexString()]
       if (lastPlayed != null) {
         val elapsed = (fatherTime.nowInEpochMillis() - lastPlayed).milliseconds
-        ibark { "Adding $elapsed time listening to $libraryItemId" }
+        ibark { "Adding $elapsed time listening to $libraryItemId for ${sessionId.toHexDashString()})" }
         component.sessionsRepository.addTimeListening(libraryItemId, elapsed)
         component.remoteSessionsUpdater.update(skipInterval = true)
       }

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/LocalSessionUpdateSynchronizer.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/LocalSessionUpdateSynchronizer.kt
@@ -14,6 +14,7 @@ import com.r0adkll.kimchi.annotations.ContributesMultibinding
 import com.r0adkll.kimchi.annotations.ContributesTo
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.uuid.Uuid
 import me.tatarka.inject.annotations.Inject
 
@@ -36,7 +37,7 @@ class LocalSessionUpdateSynchronizer(
   private val component: LocalSessionComponent
     get() = ComponentHolder.component<LocalSessionComponent>()
 
-  private var lastPlayedTime = mutableMapOf<String, Long>()
+  private var lastPlayedTime: Long? = null
 
   override suspend fun onStateChanged(
     sessionId: Uuid,
@@ -45,18 +46,19 @@ class LocalSessionUpdateSynchronizer(
     previousState: AudioPlayer.State,
   ) {
     if (state == AudioPlayer.State.Playing) {
-      lastPlayedTime[sessionId.toHexString()] = fatherTime.nowInEpochMillis()
+      lastPlayedTime = fatherTime.nowInEpochMillis()
+      ibark { "Setting lastPlayedTime to $lastPlayedTime for $libraryItemId" }
     } else if (
       state == AudioPlayer.State.Paused ||
       state == AudioPlayer.State.Disabled ||
       state == AudioPlayer.State.Finished
     ) {
-      val lastPlayed = lastPlayedTime[sessionId.toHexString()]
-      if (lastPlayed != null) {
-        val elapsed = (fatherTime.nowInEpochMillis() - lastPlayed).milliseconds
+      if (lastPlayedTime != null) {
+        val elapsed = (fatherTime.nowInEpochMillis() - lastPlayedTime!!).milliseconds
         ibark { "Adding $elapsed time listening to $libraryItemId for ${sessionId.toHexDashString()})" }
         component.sessionsRepository.addTimeListening(libraryItemId, elapsed)
         component.remoteSessionsUpdater.update(skipInterval = true)
+        lastPlayedTime = null
       }
     }
   }
@@ -64,11 +66,23 @@ class LocalSessionUpdateSynchronizer(
   override suspend fun onOverallTimeChanged(libraryItemId: LibraryItemId, overallTime: Duration) {
     component.sessionsRepository.updateCurrentTime(libraryItemId, overallTime)
 
+    // Check if its been too long since we synced listening time
+    if (lastPlayedTime != null) {
+      val elapsed = (fatherTime.nowInEpochMillis() - lastPlayedTime!!).milliseconds
+      if (elapsed > MAX_TIME_LISTENING_INTERVAL) {
+        ibark { "Timeout adding $elapsed time listening to $libraryItemId)" }
+        component.sessionsRepository.addTimeListening(libraryItemId, elapsed)
+        lastPlayedTime = fatherTime.nowInEpochMillis()
+      }
+    }
+
     // Trigger an update if conditions are right
     component.remoteSessionsUpdater.update()
   }
 
   companion object : Cork {
     override val tag: String = LocalSessionUpdateSynchronizer::class.simpleName!!
+
+    private val MAX_TIME_LISTENING_INTERVAL = 1.minutes
   }
 }

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/MediaProgressSynchronizer.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/MediaProgressSynchronizer.kt
@@ -14,6 +14,7 @@ import app.campfire.user.api.MediaProgressRepository
 import com.r0adkll.kimchi.annotations.ContributesMultibinding
 import com.r0adkll.kimchi.annotations.ContributesTo
 import kotlin.time.Duration
+import kotlin.uuid.Uuid
 import me.tatarka.inject.annotations.Inject
 
 @ContributesTo(UserScope::class)
@@ -39,6 +40,7 @@ class MediaProgressSynchronizer(
   }
 
   override suspend fun onStateChanged(
+    sessionId: Uuid,
     libraryItemId: LibraryItemId,
     state: AudioPlayer.State,
     previousState: AudioPlayer.State,

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadManager.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadManager.kt
@@ -14,6 +14,13 @@ interface OfflineDownloadManager {
   fun observeForItem(item: LibraryItem): Flow<OfflineDownload>
 
   /**
+   * Get the current download status for a given item
+   * @param item The [LibraryItem] to get the download status for.
+   * @return The [OfflineDownload] for the given item, or null if there is no download.
+   */
+  fun getForItem(item: LibraryItem): OfflineDownload
+
+  /**
    * Observe the current download status for a list of items
    * @param items The list of [LibraryItem]s to observe.
    * @return A [Flow] of a map of [LibraryItemId] to [OfflineDownload] for the given items.

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/sync/PlaybackSynchronizer.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/sync/PlaybackSynchronizer.kt
@@ -5,11 +5,13 @@ import app.campfire.audioplayer.model.Metadata
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.Session
 import kotlin.time.Duration
+import kotlin.uuid.Uuid
 
 interface PlaybackSynchronizer {
   val rank: Int get() = RANK_DEFAULT
 
   suspend fun onStateChanged(
+    sessionId: Uuid,
     libraryItemId: LibraryItemId,
     state: AudioPlayer.State,
     previousState: AudioPlayer.State,

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/AndroidOfflineDownloadManager.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/AndroidOfflineDownloadManager.kt
@@ -46,6 +46,10 @@ class AndroidOfflineDownloadManager(
       }
   }
 
+  override fun getForItem(item: LibraryItem): OfflineDownload {
+    return downloadTracker.getOfflineDownload(item)
+  }
+
   @kotlin.OptIn(ExperimentalCoroutinesApi::class)
   override fun observeForItems(items: List<LibraryItem>): Flow<Map<LibraryItemId, OfflineDownload>> {
     return downloadTracker.observe()

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/sync/CompositePlaybackSynchronizer.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/sync/CompositePlaybackSynchronizer.kt
@@ -8,6 +8,7 @@ import app.campfire.core.di.SingleIn
 import app.campfire.core.model.LibraryItemId
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlin.time.Duration
+import kotlin.uuid.Uuid
 import me.tatarka.inject.annotations.Inject
 
 @SingleIn(AppScope::class)
@@ -20,12 +21,13 @@ class CompositePlaybackSynchronizer(
   private val sortedSynchros = synchros.sortedBy { it.rank }
 
   override suspend fun onStateChanged(
+    sessionId: Uuid,
     libraryItemId: LibraryItemId,
     state: AudioPlayer.State,
     previousState: AudioPlayer.State,
   ) {
     sortedSynchros.forEach { s ->
-      s.onStateChanged(libraryItemId, state, previousState)
+      s.onStateChanged(sessionId, libraryItemId, state, previousState)
     }
   }
 

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/sync/LoggingSynchronizer.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/sync/LoggingSynchronizer.kt
@@ -26,7 +26,7 @@ object LoggingSynchronizer : PlaybackSynchronizer, Cork {
     state: AudioPlayer.State,
     previousState: AudioPlayer.State,
   ) {
-    dbark { "onStateChanged(sessionId=${sessionId}, id=$libraryItemId, state=$state, previousState=$previousState)" }
+    dbark { "onStateChanged(sessionId=$sessionId, id=$libraryItemId, state=$state, previousState=$previousState)" }
   }
 
   override suspend fun onOverallTimeChanged(libraryItemId: LibraryItemId, overallTime: Duration) {

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/sync/LoggingSynchronizer.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/sync/LoggingSynchronizer.kt
@@ -8,6 +8,7 @@ import app.campfire.core.logging.Cork
 import app.campfire.core.model.LibraryItemId
 import com.r0adkll.kimchi.annotations.ContributesMultibinding
 import kotlin.time.Duration
+import kotlin.uuid.Uuid
 
 @ContributesMultibinding(AppScope::class, boundType = PlaybackSynchronizer::class)
 object LoggingSynchronizer : PlaybackSynchronizer, Cork {
@@ -20,11 +21,12 @@ object LoggingSynchronizer : PlaybackSynchronizer, Cork {
   override val enabled: Boolean = false
 
   override suspend fun onStateChanged(
+    sessionId: Uuid,
     libraryItemId: LibraryItemId,
     state: AudioPlayer.State,
     previousState: AudioPlayer.State,
   ) {
-    dbark { "onStateChanged(id=$libraryItemId, state=$state, previousState=$previousState)" }
+    dbark { "onStateChanged(sessionId=${sessionId}, id=$libraryItemId, state=$state, previousState=$previousState)" }
   }
 
   override suspend fun onOverallTimeChanged(libraryItemId: LibraryItemId, overallTime: Duration) {

--- a/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/offline/IosOfflineDownloadManager.kt
+++ b/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/offline/IosOfflineDownloadManager.kt
@@ -20,6 +20,10 @@ class IosOfflineDownloadManager : OfflineDownloadManager {
     return emptyFlow()
   }
 
+  override fun getForItem(item: LibraryItem): OfflineDownload {
+    return OfflineDownload(item)
+  }
+
   override fun observeForItems(items: List<LibraryItem>): Flow<Map<LibraryItemId, OfflineDownload>> {
     return emptyFlow()
   }

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/offline/DesktopOfflineDownloadManager.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/offline/DesktopOfflineDownloadManager.kt
@@ -20,6 +20,10 @@ class DesktopOfflineDownloadManager : OfflineDownloadManager {
     return emptyFlow()
   }
 
+  override fun getForItem(item: LibraryItem): OfflineDownload {
+    return OfflineDownload(item)
+  }
+
   override fun observeForItems(items: List<LibraryItem>): Flow<Map<LibraryItemId, OfflineDownload>> {
     return emptyFlow()
   }

--- a/ui/widgets/api/src/commonMain/kotlin/app/campfire/widgets/WidgetUpdater.kt
+++ b/ui/widgets/api/src/commonMain/kotlin/app/campfire/widgets/WidgetUpdater.kt
@@ -1,9 +1,15 @@
 package app.campfire.widgets
 
+import kotlin.time.Duration
+
 interface WidgetUpdater {
 
   /**
    * Update any homescreen widgets with the lastest information from the app.
    */
-  suspend fun updatePlayerWidget()
+  suspend fun updatePlayerWidget(
+    currentTime: Duration? = null,
+    currentDuration: Duration? = null,
+    playbackSpeed: Float? = null,
+  )
 }

--- a/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/AndroidWidgetUpdater.kt
+++ b/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/AndroidWidgetUpdater.kt
@@ -1,29 +1,32 @@
 package app.campfire.widgets
 
 import android.app.Application
-import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.state.updateAppWidgetState
 import app.campfire.core.di.AppScope
-import app.campfire.core.time.FatherTime
+import app.campfire.core.extensions.asSeconds
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlin.time.Duration
 import me.tatarka.inject.annotations.Inject
 
 @ContributesBinding(AppScope::class)
 @Inject
 class AndroidWidgetUpdater(
   private val application: Application,
-  private val fatherTime: FatherTime,
 ) : WidgetUpdater {
 
-  override suspend fun updatePlayerWidget() {
-//    PlayerWidget().updateAll(application)
-
+  override suspend fun updatePlayerWidget(
+    currentTime: Duration?,
+    currentDuration: Duration?,
+    playbackSpeed: Float?,
+  ) {
     // Update the widget with the new data
     val glanceIds = GlanceAppWidgetManager(application).getGlanceIds(PlayerWidget::class.java)
     glanceIds.forEach { id ->
-      updateAppWidgetState(application, id) {
-        it[longPreferencesKey("now")] = fatherTime.nowInEpochMillis()
+      updateAppWidgetState(application, id) { state ->
+        currentTime?.let { state[PlayerWidget.KEY_CURRENT_TIME] = it.asSeconds() }
+        currentDuration?.let { state[PlayerWidget.KEY_CURRENT_DURATION] = it.asSeconds() }
+        playbackSpeed?.let { state[PlayerWidget.KEY_PLAYBACK_SPEED] = it }
       }
       PlayerWidget().update(application, id)
     }

--- a/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/ChapterListContent.kt
+++ b/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/ChapterListContent.kt
@@ -24,7 +24,7 @@ internal fun ColumnScope.ChapterListContent(
       .defaultWeight(),
   ) {
     items(
-      items = item.media.chapters,
+      items = item.media.chapters.take(13),
       itemId = { it.title.hashCode().toLong() },
     ) { chapter ->
       ChapterListItem(

--- a/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/PlaybackContent.kt
+++ b/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/PlaybackContent.kt
@@ -186,7 +186,7 @@ internal fun RowScope.PlaybackContent(
         if (currentDuration > Duration.ZERO) {
           val currentRemainingDuration = (currentDuration - currentTime).div(playbackSpeed.toDouble())
           Text(
-            text = currentRemainingDuration.readoutFormat() + " remaining",
+            text = currentRemainingDuration.readoutFormat(largestOnly = true) + " remaining",
             style = TextStyle(
               color = LocalContentColorProvider.current,
               fontSize = 11.sp,
@@ -220,7 +220,7 @@ internal fun RowScope.PlaybackContent(
 
       val currentRemainingDuration = (currentDuration - currentTime).div(playbackSpeed.toDouble())
       Text(
-        text = currentRemainingDuration.readoutFormat() + " remaining",
+        text = currentRemainingDuration.readoutFormat(largestOnly = true) + " remaining",
         style = TextStyle(
           color = LocalContentColorProvider.current,
           fontSize = 11.sp,

--- a/ui/widgets/impl/src/commonMain/kotlin/app/campfire/widgets/WidgetUpdatePlaybackSynchronizer.kt
+++ b/ui/widgets/impl/src/commonMain/kotlin/app/campfire/widgets/WidgetUpdatePlaybackSynchronizer.kt
@@ -4,7 +4,9 @@ import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.sync.PlaybackSynchronizer
 import app.campfire.core.di.AppScope
+import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.time.FatherTime
 import com.r0adkll.kimchi.annotations.ContributesMultibinding
 import kotlin.time.Duration
 import kotlin.uuid.Uuid
@@ -15,6 +17,7 @@ import me.tatarka.inject.annotations.Inject
 class WidgetUpdatePlaybackSynchronizer(
   private val widgetUpdater: WidgetUpdater,
   private val widgetPinRequester: WidgetPinRequester,
+  private val fatherTime: FatherTime,
 ) : PlaybackSynchronizer {
 
   override suspend fun onStateChanged(
@@ -23,6 +26,7 @@ class WidgetUpdatePlaybackSynchronizer(
     state: AudioPlayer.State,
     previousState: AudioPlayer.State,
   ) {
+    bark { "onStateChanged($state)" }
     widgetUpdater.updatePlayerWidget()
 
     // Prompt the user to pin the playback widget if they haven't seen it yet
@@ -35,20 +39,44 @@ class WidgetUpdatePlaybackSynchronizer(
     libraryItemId: LibraryItemId,
     metadata: Metadata,
   ) {
+    bark { "onMetadataChanged: $metadata" }
     widgetUpdater.updatePlayerWidget()
   }
 
+  var lastCurrentTimeUpdate = 0L
   override suspend fun onCurrentTimeChanged(
     libraryItemId: LibraryItemId,
     currentTime: Duration,
   ) {
-    widgetUpdater.updatePlayerWidget()
+    // Updating this too frequently is a performance concern
+    // Limit this update to every 2 seconds
+    val elapsed = (fatherTime.nowInEpochMillis() - lastCurrentTimeUpdate)
+    if (elapsed > TIME_UPDATE_INTERVAL_MS) {
+      bark { "onCurrentTimeChanged: $currentTime" }
+      widgetUpdater.updatePlayerWidget(currentTime = currentTime)
+      lastCurrentTimeUpdate = fatherTime.nowInEpochMillis()
+    }
   }
 
   override suspend fun onCurrentDurationChanged(
     libraryItemId: LibraryItemId,
     currentDuration: Duration,
   ) {
-    widgetUpdater.updatePlayerWidget()
+    bark { "onCurrentDurationChanged: $currentDuration" }
+    widgetUpdater.updatePlayerWidget(
+      currentDuration = currentDuration.takeIf { it.isFinite() } ?: Duration.ZERO,
+    )
+  }
+
+  override suspend fun onPlaybackSpeedChanged(
+    libraryItemId: LibraryItemId,
+    playbackSpeed: Float,
+  ) {
+    bark { "onPlaybackSpeedChanged: $playbackSpeed" }
+    widgetUpdater.updatePlayerWidget(playbackSpeed = playbackSpeed)
+  }
+
+  companion object {
+    private const val TIME_UPDATE_INTERVAL_MS = 5000L
   }
 }

--- a/ui/widgets/impl/src/commonMain/kotlin/app/campfire/widgets/WidgetUpdatePlaybackSynchronizer.kt
+++ b/ui/widgets/impl/src/commonMain/kotlin/app/campfire/widgets/WidgetUpdatePlaybackSynchronizer.kt
@@ -7,6 +7,7 @@ import app.campfire.core.di.AppScope
 import app.campfire.core.model.LibraryItemId
 import com.r0adkll.kimchi.annotations.ContributesMultibinding
 import kotlin.time.Duration
+import kotlin.uuid.Uuid
 import me.tatarka.inject.annotations.Inject
 
 @ContributesMultibinding(AppScope::class)
@@ -17,6 +18,7 @@ class WidgetUpdatePlaybackSynchronizer(
 ) : PlaybackSynchronizer {
 
   override suspend fun onStateChanged(
+    sessionId: Uuid,
     libraryItemId: LibraryItemId,
     state: AudioPlayer.State,
     previousState: AudioPlayer.State,

--- a/ui/widgets/impl/src/iosMain/kotlin/app/campfire/widgets/IosWidgetUpdater.kt
+++ b/ui/widgets/impl/src/iosMain/kotlin/app/campfire/widgets/IosWidgetUpdater.kt
@@ -2,12 +2,17 @@ package app.campfire.widgets
 
 import app.campfire.core.di.AppScope
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlin.time.Duration
 import me.tatarka.inject.annotations.Inject
 
 @ContributesBinding(AppScope::class)
 @Inject
 class IosWidgetUpdater : WidgetUpdater {
-  override suspend fun updatePlayerWidget() {
+  override suspend fun updatePlayerWidget(
+    currentTime: Duration?,
+    currentDuration: Duration?,
+    playbackSpeed: Float?,
+  ) {
     // Do nothing.
   }
 }

--- a/ui/widgets/impl/src/jvmMain/kotlin/app/campfire/widgets/DesktopWidgetUpdater.kt
+++ b/ui/widgets/impl/src/jvmMain/kotlin/app/campfire/widgets/DesktopWidgetUpdater.kt
@@ -2,12 +2,17 @@ package app.campfire.widgets
 
 import app.campfire.core.di.AppScope
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlin.time.Duration
 import me.tatarka.inject.annotations.Inject
 
 @ContributesBinding(AppScope::class)
 @Inject
 class DesktopWidgetUpdater : WidgetUpdater {
-  override suspend fun updatePlayerWidget() {
+  override suspend fun updatePlayerWidget(
+    currentTime: Duration?,
+    currentDuration: Duration?,
+    playbackSpeed: Float?,
+  ) {
     // Do nothing
   }
 }


### PR DESCRIPTION
Synced sessions now correctly reflect the offline state of items.
Keyed how we accumulate time played to the session id instead of the item Id.