### PR TITLE
Firebase AppDistribution auto updates to separate module

### DIFF
--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -118,7 +118,6 @@ dependencies {
   implementation(platform(libs.google.firebase.bom))
   implementation(libs.google.firebase.analytics)
   implementation(libs.google.firebase.crashlytics)
-  implementation(libs.google.firebase.appdistribution.api)
 
   implementation(projects.app.common)
   implementation(projects.common.screens)

--- a/app/android/src/beta/kotlin/app/campfire/android/updates/FirebaseAppUpdateSource.kt
+++ b/app/android/src/beta/kotlin/app/campfire/android/updates/FirebaseAppUpdateSource.kt
@@ -1,0 +1,49 @@
+package app.campfire.android.updates
+
+import app.campfire.core.app.ApplicationInfo
+import app.campfire.core.di.AppScope
+import app.campfire.core.logging.LogPriority
+import app.campfire.core.logging.bark
+import app.campfire.updates.source.AppUpdateSource
+import com.google.firebase.appdistribution.FirebaseAppDistribution
+import com.google.firebase.appdistribution.FirebaseAppDistributionException
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.coroutines.tasks.await
+import me.tatarka.inject.annotations.Inject
+
+@ContributesBinding(AppScope::class)
+@Inject
+class FirebaseAppUpdateSource(
+  private val appInfo: ApplicationInfo,
+) : AppUpdateSource {
+
+  private val appDistribution by lazy {
+    FirebaseAppDistribution.getInstance()
+  }
+
+  override fun isSignedIn(): Boolean {
+    return appDistribution.isTesterSignedIn
+  }
+
+  override suspend fun signIn() {
+    try {
+      appDistribution.signInTester()
+        .await()
+    } catch (e: FirebaseAppDistributionException) {
+      bark(LogPriority.WARN, throwable = e) { "Unable to sign-in" }
+    }
+  }
+
+  override suspend fun isUpdateAvailable(): Boolean {
+    try {
+      val update = appDistribution.checkForNewRelease().await()
+      return update.versionCode > appInfo.versionCode
+    } catch (e: Exception) {
+      return false
+    }
+  }
+
+  override suspend fun installUpdate() {
+    appDistribution.updateApp().await()
+  }
+}

--- a/app/android/src/main/java/app/campfire/android/MainActivity.kt
+++ b/app/android/src/main/java/app/campfire/android/MainActivity.kt
@@ -20,8 +20,6 @@ import app.campfire.core.ActivityIntentProvider
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.ComponentHolder
 import app.campfire.core.logging.bark
-import com.google.firebase.appdistribution.FirebaseAppDistribution
-import com.google.firebase.appdistribution.FirebaseAppDistributionException
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import me.tatarka.inject.annotations.Inject
 
@@ -63,30 +61,6 @@ class MainActivity : ComponentActivity() {
     super.onStart()
     bark { "MainActivity::onStart()" }
     component.mediaControllerConnector.connect()
-  }
-
-  override fun onResume() {
-    super.onResume()
-
-    val firebaseAppDistribution = FirebaseAppDistribution.getInstance()
-    firebaseAppDistribution.updateIfNewReleaseAvailable()
-      .addOnProgressListener { updateProgress ->
-        // (Optional) Implement custom progress updates in addition to
-        // automatic NotificationManager updates.
-      }
-      .addOnFailureListener { e ->
-        // (Optional) Handle errors.
-        if (e is FirebaseAppDistributionException) {
-          when (e.errorCode) {
-            FirebaseAppDistributionException.Status.NOT_IMPLEMENTED -> {
-              // SDK did nothing. This is expected when building for Play.
-            }
-            else -> {
-              bark { "Error updating to a new release: ${e.message}" }
-            }
-          }
-        }
-      }
   }
 
   override fun onStop() {

--- a/app/android/src/standard/kotlin/app/campfire/android/updates/GooglePlayAppUpdateSource.kt
+++ b/app/android/src/standard/kotlin/app/campfire/android/updates/GooglePlayAppUpdateSource.kt
@@ -1,0 +1,24 @@
+package app.campfire.android.updates
+
+import app.campfire.core.di.AppScope
+import app.campfire.updates.source.AppUpdateSource
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import me.tatarka.inject.annotations.Inject
+
+@ContributesBinding(AppScope::class)
+@Inject
+class GooglePlayAppUpdateSource : AppUpdateSource {
+  override fun isSignedIn(): Boolean {
+    return true
+  }
+
+  override suspend fun signIn() {
+  }
+
+  override suspend fun isUpdateAvailable(): Boolean {
+    return false
+  }
+
+  override suspend fun installUpdate() {
+  }
+}

--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
         // Infra Modules
         api(projects.infra.audioplayer.impl)
         api(projects.infra.audioplayer.publicUi)
+        api(projects.infra.updates.impl)
 
         // Feature Modules
         api(projects.features.home.impl)

--- a/app/desktop/src/main/kotlin/app/campfire/updates/DesktopAppUpdateSource.kt
+++ b/app/desktop/src/main/kotlin/app/campfire/updates/DesktopAppUpdateSource.kt
@@ -1,0 +1,21 @@
+package app.campfire.updates
+
+import app.campfire.core.di.AppScope
+import app.campfire.updates.source.AppUpdateSource
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import me.tatarka.inject.annotations.Inject
+
+@ContributesBinding(AppScope::class)
+@Inject
+class DesktopAppUpdateSource : AppUpdateSource {
+
+  override fun isSignedIn(): Boolean = true
+
+  override suspend fun signIn() {
+  }
+
+  override suspend fun isUpdateAvailable(): Boolean = false
+
+  override suspend fun installUpdate() {
+  }
+}

--- a/app/ios/src/iosMain/kotlin/app/campfire/ios/updates/IosAppUpdateSource.kt
+++ b/app/ios/src/iosMain/kotlin/app/campfire/ios/updates/IosAppUpdateSource.kt
@@ -1,0 +1,24 @@
+package app.campfire.ios.updates
+
+import app.campfire.core.di.AppScope
+import app.campfire.updates.source.AppUpdateSource
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Update this with a TestFlight based implementation?
+ */
+@ContributesBinding(AppScope::class)
+@Inject
+class IosAppUpdateSource : AppUpdateSource {
+
+  override fun isSignedIn(): Boolean = true
+
+  override suspend fun signIn() {
+  }
+
+  override suspend fun isUpdateAvailable(): Boolean = false
+
+  override suspend fun installUpdate() {
+  }
+}

--- a/infra/updates/api/build.gradle.kts
+++ b/infra/updates/api/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+  id("app.campfire.multiplatform")
+  id("app.campfire.compose")
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation(projects.core)
+        implementation(compose.runtime)
+        implementation(compose.ui)
+      }
+    }
+  }
+}

--- a/infra/updates/api/src/commonMain/kotlin/app/campfire/updates/AppUpdateWidget.kt
+++ b/infra/updates/api/src/commonMain/kotlin/app/campfire/updates/AppUpdateWidget.kt
@@ -1,0 +1,19 @@
+package app.campfire.updates
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * A widget implementation that dynamically shows UI to prompt the user to update the app.
+ * On Beta builds:
+ *   - This will check if the user is signed into the app tester account.
+ *   - If so, it will show a prompt to update the app.
+ * On StandardRelease builds:
+ *   - This will use the GooglePlay InAppUpdates to check for new releases
+ *   - If so, it will prompt the user to update the app.
+ */
+interface AppUpdateWidget {
+
+  @Composable
+  fun Content(modifier: Modifier)
+}

--- a/infra/updates/impl/build.gradle.kts
+++ b/infra/updates/impl/build.gradle.kts
@@ -1,0 +1,27 @@
+import app.campfire.convention.addKspDependencyForAllTargets
+
+plugins {
+  id("app.campfire.android.library")
+  id("app.campfire.multiplatform")
+  id("app.campfire.compose")
+  alias(libs.plugins.ksp)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.infra.updates.api)
+
+        implementation(projects.core)
+        implementation(projects.common.compose)
+
+        implementation(compose.runtime)
+        implementation(compose.ui)
+      }
+    }
+  }
+}
+
+addKspDependencyForAllTargets(libs.kimchi.compiler)

--- a/infra/updates/impl/src/commonMain/kotlin/app/campfire/updates/AppUpdateWidgetImpl.kt
+++ b/infra/updates/impl/src/commonMain/kotlin/app/campfire/updates/AppUpdateWidgetImpl.kt
@@ -95,7 +95,7 @@ class AppUpdateWidgetImpl(
           appUpdateSource.signIn()
           invalidator++
         }
-      }
+      },
     ) {
       TitleBar(
         title = "Sign-in required",
@@ -122,7 +122,7 @@ class AppUpdateWidgetImpl(
           appUpdateSource.installUpdate()
           invalidator++
         }
-      }
+      },
     ) {
       TitleBar(
         title = "New version is available!",
@@ -163,12 +163,12 @@ class AppUpdateWidgetImpl(
         .height(48.dp)
         .padding(horizontal = 16.dp),
       verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(8.dp)
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
       Icon(
         icon,
         contentDescription = null,
-        modifier = Modifier.size(18.dp)
+        modifier = Modifier.size(18.dp),
       )
       Text(
         text = title,
@@ -190,7 +190,7 @@ class AppUpdateWidgetImpl(
         .padding(
           start = 16.dp,
           end = 16.dp,
-        )
+        ),
     )
 
     Spacer(Modifier.height(16.dp))
@@ -201,7 +201,7 @@ class AppUpdateWidgetImpl(
       fontWeight = FontWeight.SemiBold,
       modifier = Modifier
         .align(Alignment.Start)
-        .padding(horizontal = 16.dp)
+        .padding(horizontal = 16.dp),
     )
 
     Spacer(Modifier.height(16.dp))

--- a/infra/updates/impl/src/commonMain/kotlin/app/campfire/updates/AppUpdateWidgetImpl.kt
+++ b/infra/updates/impl/src/commonMain/kotlin/app/campfire/updates/AppUpdateWidgetImpl.kt
@@ -1,0 +1,214 @@
+package app.campfire.updates
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Login
+import androidx.compose.material.icons.rounded.Login
+import androidx.compose.material.icons.rounded.SystemUpdate
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.campfire.core.di.AppScope
+import app.campfire.updates.source.AppUpdateSource
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import me.tatarka.inject.annotations.Inject
+
+@ContributesBinding(AppScope::class)
+@Inject
+class AppUpdateWidgetImpl(
+  private val appUpdateSource: AppUpdateSource,
+) : AppUpdateWidget {
+
+  private var invalidator by mutableIntStateOf(0)
+
+  @Composable
+  override fun Content(modifier: Modifier) {
+    val state by remember(invalidator) {
+      flow {
+        val isSignedIn = appUpdateSource.isSignedIn()
+        if (!isSignedIn) {
+          emit(
+            AppUpdateState(
+              isSignedIn = false,
+              isUpdateAvailable = false,
+            ),
+          )
+        } else {
+          val isUpdateAvailable = appUpdateSource.isUpdateAvailable()
+          emit(
+            AppUpdateState(
+              isSignedIn = true,
+              isUpdateAvailable = isUpdateAvailable,
+            ),
+          )
+        }
+      }
+    }.collectAsState(AppUpdateState())
+
+    Content(state, modifier)
+  }
+
+  @Composable
+  private fun Content(
+    state: AppUpdateState,
+    modifier: Modifier = Modifier,
+  ) {
+    when {
+      state.isSignedIn && state.isUpdateAvailable -> UpdateContent(modifier)
+      !state.isSignedIn -> SignInContent(modifier)
+      else -> Unit
+    }
+  }
+
+  @Composable
+  private fun SignInContent(
+    modifier: Modifier = Modifier,
+  ) {
+    val scope = rememberCoroutineScope()
+
+    AppUpdateCard(
+      modifier = modifier,
+      onClick = {
+        scope.launch {
+          appUpdateSource.signIn()
+          invalidator++
+        }
+      }
+    ) {
+      TitleBar(
+        title = "Sign-in required",
+        icon = Icons.AutoMirrored.Rounded.Login,
+      )
+      CardContent(
+        text = "Automatic app updates require you to be signed into the Firebase " +
+          "AppTester platform.",
+        action = "Sign in",
+      )
+    }
+  }
+
+  @Composable
+  private fun UpdateContent(
+    modifier: Modifier = Modifier,
+  ) {
+    val scope = rememberCoroutineScope()
+
+    AppUpdateCard(
+      modifier = modifier,
+      onClick = {
+        scope.launch {
+          appUpdateSource.installUpdate()
+          invalidator++
+        }
+      }
+    ) {
+      TitleBar(
+        title = "New version is available!",
+        icon = Icons.Rounded.SystemUpdate,
+      )
+      CardContent(
+        text = "A new version of the app is available to update",
+        action = "Update now",
+      )
+    }
+  }
+
+  @Composable
+  private fun AppUpdateCard(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
+  ) {
+    ElevatedCard(
+      onClick = onClick,
+      colors = CardDefaults.elevatedCardColors(
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+      ),
+      content = content,
+      modifier = modifier.padding(16.dp),
+    )
+  }
+
+  @Composable
+  private fun TitleBar(
+    title: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+  ) {
+    Row(
+      modifier = modifier
+        .height(48.dp)
+        .padding(horizontal = 16.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+      Icon(
+        icon,
+        contentDescription = null,
+        modifier = Modifier.size(18.dp)
+      )
+      Text(
+        text = title,
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.SemiBold,
+      )
+    }
+  }
+
+  @Composable
+  private fun ColumnScope.CardContent(
+    text: String,
+    action: String,
+  ) {
+    Text(
+      text = text,
+      style = MaterialTheme.typography.bodyMedium,
+      modifier = Modifier
+        .padding(
+          start = 16.dp,
+          end = 16.dp,
+        )
+    )
+
+    Spacer(Modifier.height(16.dp))
+
+    Text(
+      text = action,
+      style = MaterialTheme.typography.labelLarge,
+      fontWeight = FontWeight.SemiBold,
+      modifier = Modifier
+        .align(Alignment.Start)
+        .padding(horizontal = 16.dp)
+    )
+
+    Spacer(Modifier.height(16.dp))
+  }
+}
+
+data class AppUpdateState(
+  val isSignedIn: Boolean = false,
+  val isUpdateAvailable: Boolean = false,
+)

--- a/infra/updates/impl/src/commonMain/kotlin/app/campfire/updates/source/AppUpdateSource.kt
+++ b/infra/updates/impl/src/commonMain/kotlin/app/campfire/updates/source/AppUpdateSource.kt
@@ -1,0 +1,28 @@
+package app.campfire.updates.source
+
+/**
+ * Implementations for this will live in the respective app platform modules
+ */
+interface AppUpdateSource {
+
+  /**
+   * Whether or not the user is signed-in to receive app updates. This is need for Beta
+   * updates, but on production builds this will always be true
+   */
+  fun isSignedIn(): Boolean
+
+  /**
+   * Start the tester sign-in process on Beta builds. This is a no-op on production builds
+   */
+  suspend fun signIn()
+
+  /**
+   * Whether or not there is an update available for this user
+   */
+  suspend fun isUpdateAvailable(): Boolean
+
+  /**
+   * Kick of the update installation process
+   */
+  suspend fun installUpdate()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -72,6 +72,8 @@ include(
   ":infra:audioplayer:public-ui",
   ":infra:shake",
   ":infra:debug",
+  ":infra:updates:api",
+  ":infra:updates:impl",
 )
 include(
   ":common:screens",

--- a/ui/drawer/build.gradle.kts
+++ b/ui/drawer/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
         api(projects.common.compose)
         api(projects.data.account.api)
         api(projects.data.account.ui)
+        api(projects.infra.updates.api)
 
         implementation(compose.components.resources)
       }

--- a/ui/drawer/src/commonMain/kotlin/app/campfire/ui/drawer/DrawerScreen.kt
+++ b/ui/drawer/src/commonMain/kotlin/app/campfire/ui/drawer/DrawerScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.campfire.account.ui.picker.AccountPickerResult
@@ -137,7 +136,7 @@ fun Drawer(
 
     appUpdateWidget.Content(
       Modifier
-        .fillMaxWidth()
+        .fillMaxWidth(),
     )
   }
 }

--- a/ui/drawer/src/commonMain/kotlin/app/campfire/ui/drawer/DrawerScreen.kt
+++ b/ui/drawer/src/commonMain/kotlin/app/campfire/ui/drawer/DrawerScreen.kt
@@ -2,6 +2,7 @@ package app.campfire.ui.drawer
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -19,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.campfire.account.ui.picker.AccountPickerResult
@@ -51,6 +53,7 @@ import app.campfire.common.screens.SettingsScreen
 import app.campfire.common.screens.StatisticsScreen
 import app.campfire.core.di.UserScope
 import app.campfire.core.isDebug
+import app.campfire.updates.AppUpdateWidget
 import campfire.ui.drawer.generated.resources.Res
 import campfire.ui.drawer.generated.resources.nav_authors_content_description
 import campfire.ui.drawer.generated.resources.nav_authors_label
@@ -75,6 +78,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun Drawer(
   state: DrawerUiState,
+  appUpdateWidget: AppUpdateWidget,
   modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()
@@ -128,6 +132,13 @@ fun Drawer(
           ),
       )
     }
+
+    Spacer(Modifier.weight(1f))
+
+    appUpdateWidget.Content(
+      Modifier
+        .fillMaxWidth()
+    )
   }
 }
 


### PR DESCRIPTION
Before, it was just showing a dialog on activity start for all beta builds which is very very annoying.

This moves all the checks to ONLY beta builds, and puts them as an opt-in interactive card in the drawer so its there if desired, otherwise completely ignorable.

I will probably update this in the future to be dismissible, but for now this works