### PR TITLE
Library Item Filtering

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -11,6 +11,6 @@
     <option name="scriptTemplatesClasspath" value="/opt/homebrew/opt/danger-kotlin/lib/danger/danger-kotlin.jar" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.2.0" />
+    <option name="version" value="2.2.10" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ TODO: Use https://github.com/ffurrer2/extract-release-notes when crafting a rele
 
 ### Added
 
+- Library item filtering
+
 ### Changed
 
 ### Deprecated

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/BottomSheets.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/BottomSheets.kt
@@ -1,0 +1,9 @@
+package app.campfire.common.compose.widgets
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+
+val bottomSheetShape = RoundedCornerShape(
+  topStart = 32.dp,
+  topEnd = 32.dp,
+)

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/FilterBar.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/FilterBar.kt
@@ -97,8 +97,9 @@ fun FilterBar(
         modifier = Modifier.offset(x = 12.dp),
       ) {
         Icon(
-          if (isFiltered) Icons.Rounded.FilterAltOff else Icons.Rounded.FilterAlt,
+          if (isFiltered) Icons.Rounded.FilterAlt else Icons.Rounded.FilterAltOff,
           contentDescription = null,
+          tint = if (isFiltered) MaterialTheme.colorScheme.primary else LocalContentColor.current,
         )
       }
     }

--- a/core/src/commonMain/kotlin/app.campfire.core/coroutines/FlowUtils.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/coroutines/FlowUtils.kt
@@ -1,0 +1,8 @@
+package app.campfire.core.coroutines
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+fun <T, R> Flow<T?>.mapIfNotNull(mapper: suspend (T) -> R): Flow<R?> = map {
+  if (it != null) mapper(it) else null
+}

--- a/core/src/commonMain/kotlin/app.campfire.core/model/FilterData.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/model/FilterData.kt
@@ -1,0 +1,20 @@
+package app.campfire.core.model
+
+data class FilterData(
+  val authors: List<Entity> = emptyList(),
+  val genres: List<String> = emptyList(),
+  val tags: List<String> = emptyList(),
+  val series: List<Entity> = emptyList(),
+  val narrators: List<String> = emptyList(),
+  val languages: List<String> = emptyList(),
+  val publishers: List<String> = emptyList(),
+  val publishedDecades: List<String> = emptyList(),
+  val bookCount: Int = 0,
+  val authorCount: Int = 0,
+  val seriesCount: Int = 0,
+  val podcastCount: Int = 0,
+  val numIssues: Int = 0,
+) {
+
+  data class Entity(val id: String, val name: String)
+}

--- a/core/src/commonMain/kotlin/app.campfire.core/model/Paged.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/model/Paged.kt
@@ -1,0 +1,18 @@
+package app.campfire.core.model
+
+class Paged<Data>(
+  val page: Int,
+  val limit: Int,
+  val total: Int,
+  val data: List<Data>,
+)
+
+
+inline fun <T, R> Paged<T>.map(transform: (T) -> R): Paged<R> {
+  return Paged(
+    page = page,
+    limit = limit,
+    total = total,
+    data = data.map(transform),
+  )
+}

--- a/core/src/commonMain/kotlin/app.campfire.core/model/Paged.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/model/Paged.kt
@@ -7,7 +7,6 @@ class Paged<Data>(
   val data: List<Data>,
 )
 
-
 inline fun <T, R> Paged<T>.map(transform: (T) -> R): Paged<R> {
   return Paged(
     page = page,

--- a/core/src/commonMain/kotlin/app.campfire.core/settings/SortMode.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/settings/SortMode.kt
@@ -1,13 +1,16 @@
 package app.campfire.core.settings
 
-enum class SortMode(override val storageKey: String) : EnumSetting {
-  Title("title"),
-  AuthorFL("author-first-last"),
-  AuthorLF("author-last-first"),
-  PublishYear("publish-year"),
-  AddedAt("added-at"),
-  Size("size"),
-  Duration("duration"),
+enum class SortMode(
+  override val storageKey: String,
+  val networkKey: String,
+) : EnumSetting {
+  Title("title", "media.metadata.title"),
+  AuthorFL("author-first-last", "media.metadata.authorName"),
+  AuthorLF("author-last-first", "media.metadata.authorNameLF"),
+  PublishYear("publish-year", "media.metadata.publishedYear"),
+  AddedAt("added-at", "addedAt"),
+  Size("size", "media.size"),
+  Duration("duration", "media.duration"),
   ;
 
   companion object : EnumSettingProvider<SortMode> {

--- a/data/db/src/commonMain/kotlin/app.campfire.db/DatabaseAdapters.kt
+++ b/data/db/src/commonMain/kotlin/app.campfire.db/DatabaseAdapters.kt
@@ -1,0 +1,10 @@
+package app.campfire.db
+
+import app.campfire.data.LibraryItem
+import app.campfire.data.Media
+
+interface DatabaseAdapters {
+
+  val libraryItemAdapter: LibraryItem.Adapter
+  val mediaAdapter: Media.Adapter
+}

--- a/data/db/src/commonMain/kotlin/app.campfire.db/DatabaseFactory.kt
+++ b/data/db/src/commonMain/kotlin/app.campfire.db/DatabaseFactory.kt
@@ -1,6 +1,7 @@
 package app.campfire.db
 
 import app.campfire.CampfireDatabase
+import app.campfire.core.di.AppScope
 import app.campfire.data.Authors
 import app.campfire.data.BookmarkFailedCreate
 import app.campfire.data.BookmarkFailedDelete
@@ -21,12 +22,34 @@ import app.campfire.data.User
 import app.cash.sqldelight.EnumColumnAdapter
 import app.cash.sqldelight.adapter.primitive.IntColumnAdapter
 import app.cash.sqldelight.db.SqlDriver
+import com.r0adkll.kimchi.annotations.ContributesBinding
 import me.tatarka.inject.annotations.Inject
 
+@ContributesBinding(AppScope::class)
 @Inject
 class DatabaseFactory(
   private val driver: SqlDriver,
-) {
+) : DatabaseAdapters {
+
+  override val libraryItemAdapter: LibraryItem.Adapter
+    get() = LibraryItem.Adapter(
+      mediaTypeAdapter = EnumColumnAdapter(),
+      numFilesAdapter = IntColumnAdapter,
+    )
+
+  override val mediaAdapter: Media.Adapter
+    get() = Media.Adapter(
+      tagsAdapter = StringListAdapter,
+      numTracksAdapter = IntColumnAdapter,
+      numChaptersAdapter = IntColumnAdapter,
+      numAudioFilesAdapter = IntColumnAdapter,
+      numMissingPartsAdapter = IntColumnAdapter,
+      numInvalidAudioFilesAdapter = IntColumnAdapter,
+      propertySizeAdapter = IntColumnAdapter,
+      metadata_genresAdapter = StringListAdapter,
+      metadata_series_sequenceAdapter = IntColumnAdapter,
+    )
+
   fun build(): CampfireDatabase = CampfireDatabase(
     driver = driver,
     serverAdapter = Server.Adapter(
@@ -51,21 +74,8 @@ class DatabaseFactory(
       displayOrderAdapter = IntColumnAdapter,
       coverAspectRatioAdapter = IntColumnAdapter,
     ),
-    libraryItemAdapter = LibraryItem.Adapter(
-      mediaTypeAdapter = EnumColumnAdapter(),
-      numFilesAdapter = IntColumnAdapter,
-    ),
-    mediaAdapter = Media.Adapter(
-      tagsAdapter = StringListAdapter,
-      numTracksAdapter = IntColumnAdapter,
-      numChaptersAdapter = IntColumnAdapter,
-      numAudioFilesAdapter = IntColumnAdapter,
-      numMissingPartsAdapter = IntColumnAdapter,
-      numInvalidAudioFilesAdapter = IntColumnAdapter,
-      propertySizeAdapter = IntColumnAdapter,
-      metadata_genresAdapter = StringListAdapter,
-      metadata_series_sequenceAdapter = IntColumnAdapter,
-    ),
+    libraryItemAdapter = libraryItemAdapter,
+    mediaAdapter = mediaAdapter,
     authorsAdapter = Authors.Adapter(
       numBooksAdapter = IntColumnAdapter,
     ),

--- a/data/db/src/commonMain/kotlin/app.campfire.db/DatabaseFactory.kt
+++ b/data/db/src/commonMain/kotlin/app.campfire.db/DatabaseFactory.kt
@@ -6,6 +6,7 @@ import app.campfire.data.Authors
 import app.campfire.data.BookmarkFailedCreate
 import app.campfire.data.BookmarkFailedDelete
 import app.campfire.data.Bookmarks
+import app.campfire.data.FilterData
 import app.campfire.data.Library
 import app.campfire.data.LibraryItem
 import app.campfire.data.Media
@@ -124,5 +125,18 @@ class DatabaseFactory(
     search_genresAdapter = Search_genres.Adapter(
       genresAdapter = BasicSearchResultListAdapter,
     ),
-  )
+    filterDataAdapter = FilterData.Adapter(
+      bookCountAdapter = IntColumnAdapter,
+      authorCountAdapter = IntColumnAdapter,
+      seriesCountAdapter = IntColumnAdapter,
+      podcastCountAdapter = IntColumnAdapter,
+      numIssuesAdapter = IntColumnAdapter,
+    ),
+  ).also {
+    CampfireDatabase.Schema.migrate(
+      driver = driver,
+      oldVersion = 0,
+      newVersion = CampfireDatabase.Schema.version,
+    )
+  }
 }

--- a/data/db/src/commonMain/sqldelight/app/campfire/data/filterData.sq
+++ b/data/db/src/commonMain/sqldelight/app/campfire/data/filterData.sq
@@ -1,0 +1,178 @@
+import kotlin.Int;
+
+CREATE TABLE filterData (
+  libraryId TEXT NOT NULL PRIMARY KEY,
+  bookCount INTEGER AS Int NOT NULL,
+  authorCount INTEGER AS Int NOT NULL,
+  seriesCount INTEGER AS Int NOT NULL,
+  podcastCount INTEGER AS Int NOT NULL,
+  numIssues INTEGER AS Int NOT NULL,
+  lastUpdated INTEGER NOT NULL
+);
+
+CREATE TABLE filterAuthors (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterGenres (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterTags (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterSeries (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterNarrators (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterLanguages (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterPublishers (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterPublishedDecades (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+-- Mutations
+
+insertFilterData:
+INSERT OR REPLACE INTO filterData
+VALUES ?;
+
+delete:
+DELETE FROM filterData
+WHERE libraryId = ?;
+
+clearFilteredData {
+  DELETE FROM filterAuthors
+  WHERE libraryId = :libraryId;
+
+  DELETE FROM filterGenres
+  WHERE libraryId = :libraryId;
+
+  DELETE FROM filterTags
+  WHERE libraryId = :libraryId;
+
+  DELETE FROM filterSeries
+  WHERE libraryId = :libraryId;
+
+  DELETE FROM filterNarrators
+  WHERE libraryId = :libraryId;
+
+  DELETE FROM filterLanguages
+  WHERE libraryId = :libraryId;
+
+  DELETE FROM filterPublishers
+  WHERE libraryId = :libraryId;
+
+  DELETE FROM filterPublishedDecades
+  WHERE libraryId = :libraryId;
+
+  -- Hack to until 2.1.1 of sqldelight is released
+  SELECT 0;
+}
+
+insertAuthors:
+INSERT INTO filterAuthors
+VALUES (:id, :name, :libraryId);
+
+insertGenres:
+INSERT INTO filterGenres
+VALUES (:text, :libraryId);
+
+insertTags:
+INSERT INTO filterTags
+VALUES (:text, :libraryId);
+
+insertSeries:
+INSERT INTO filterSeries
+VALUES (:id, :name, :libraryId);
+
+insertNarrators:
+INSERT INTO filterNarrators
+VALUES (:text, :libraryId);
+
+insertLanguages:
+INSERT INTO filterLanguages
+VALUES (:text, :libraryId);
+
+insertPublishers:
+INSERT INTO filterPublishers
+VALUES (:text, :libraryId);
+
+insertPublishedDecades:
+INSERT INTO filterPublishedDecades
+VALUES (:text, :libraryId);
+
+-- Queries
+
+getFilterData:
+SELECT * FROM filterData
+WHERE libraryId = ?;
+
+getFilterAuthors:
+SELECT id, name FROM filterAuthors
+WHERE libraryId = ?;
+
+getFilterGenres:
+SELECT text FROM filterGenres
+WHERE libraryId = ?;
+
+getFilterTags:
+SELECT text FROM filterTags
+WHERE libraryId = ?;
+
+getFilterSeries:
+SELECT id, name FROM filterSeries
+WHERE libraryId = ?;
+
+getFilterNarrators:
+SELECT text FROM filterNarrators
+WHERE libraryId = ?;
+
+getFilterLanguages:
+SELECT text FROM filterLanguages
+WHERE libraryId = ?;
+
+getFilterPublishers:
+SELECT text FROM filterPublishers
+WHERE libraryId = ?;
+
+getFilterPublishedDecades:
+SELECT text FROM filterPublishedDecades
+WHERE libraryId = ?;

--- a/data/db/src/commonMain/sqldelight/app/campfire/data/libraryItems.sq
+++ b/data/db/src/commonMain/sqldelight/app/campfire/data/libraryItems.sq
@@ -68,3 +68,11 @@ WHERE libraryId = ?;
 deleteForId:
 DELETE FROM libraryItem
 WHERE id = ?;
+
+-- Filterable - Count Queries
+
+countForLibrary:
+SELECT count(*) FROM libraryItem
+INNER JOIN media ON media.libraryItemId = libraryItem.id
+WHERE libraryItem.libraryId = ?;
+

--- a/data/db/src/commonMain/sqldelight/migrations/1.sqm
+++ b/data/db/src/commonMain/sqldelight/migrations/1.sqm
@@ -1,0 +1,67 @@
+CREATE TABLE filterData (
+  libraryId TEXT NOT NULL PRIMARY KEY,
+  bookCount INTEGER NOT NULL,
+  authorCount INTEGER NOT NULL,
+  seriesCount INTEGER NOT NULL,
+  podcastCount INTEGER NOT NULL,
+  numIssues INTEGER NOT NULL,
+  lastUpdated INTEGER NOT NULL
+);
+
+CREATE TABLE filterAuthors (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+
+    libraryId TEXT NOT NULL,
+    FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterGenres (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterTags (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterSeries (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterNarrators (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterLanguages (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterPublishers (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);
+
+CREATE TABLE filterPublishedDecades (
+  text TEXT NOT NULL PRIMARY KEY,
+
+  libraryId TEXT NOT NULL,
+  FOREIGN KEY (libraryId) REFERENCES filterData(libraryId) ON DELETE CASCADE
+);

--- a/data/mapping/src/commonMain/kotlin/app/campfire/data/mapping/FilterDataMapping.kt
+++ b/data/mapping/src/commonMain/kotlin/app/campfire/data/mapping/FilterDataMapping.kt
@@ -1,0 +1,25 @@
+package app.campfire.data.mapping
+
+import app.campfire.core.model.FilterData
+import app.campfire.network.models.FilterData as NetworkFilterData
+
+fun NetworkFilterData.asDomainModel(): FilterData {
+  return FilterData(
+    authors = authors.map { it.asDomainModel() },
+    genres = genres,
+    tags = tags,
+    series = series.map { it.asDomainModel() },
+    narrators = narrators,
+    languages = languages,
+    publishers = publishers,
+    publishedDecades = publishedDecades,
+    bookCount = bookCount,
+    authorCount = authorCount,
+    seriesCount = seriesCount,
+    podcastCount = podcastCount,
+  )
+}
+
+private fun NetworkFilterData.EntityInfo.asDomainModel(): FilterData.Entity {
+  return FilterData.Entity(id, name)
+}

--- a/data/mapping/src/commonMain/kotlin/app/campfire/data/mapping/dao/LibraryItemDao.kt
+++ b/data/mapping/src/commonMain/kotlin/app/campfire/data/mapping/dao/LibraryItemDao.kt
@@ -201,7 +201,6 @@ class SqlDelightLibraryItemDao(
       }
 
       // 3) Insert relations
-
       item.userMediaProgress?.let { progress ->
         // Only insert the media progress if the one we have locally isn't newer
         val existing = db.mediaProgressQueries.selectForLibraryItem(

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/AudioBookShelfApi.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/AudioBookShelfApi.kt
@@ -6,6 +6,7 @@ import app.campfire.network.envelopes.SyncLocalSessionsResult
 import app.campfire.network.models.AudioBookmark
 import app.campfire.network.models.Author
 import app.campfire.network.models.Collection
+import app.campfire.network.models.FilterData
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
 import app.campfire.network.models.LibraryItemFilter
@@ -239,6 +240,11 @@ interface AudioBookShelfApi {
    * This endpoint retrieves a user's listening statistics.
    */
   suspend fun getListeningStats(): Result<ListeningStats>
+
+  /**
+   * Get all the data that the user can filter the list of library items with
+   */
+  suspend fun getFilterData(libraryId: String): Result<FilterData>
 }
 
 const val INVALID = -1

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/AudioBookShelfApi.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/AudioBookShelfApi.kt
@@ -8,6 +8,7 @@ import app.campfire.network.models.Author
 import app.campfire.network.models.Collection
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
+import app.campfire.network.models.LibraryItemFilter
 import app.campfire.network.models.LibraryItemMinified
 import app.campfire.network.models.LibraryStats
 import app.campfire.network.models.ListeningStats
@@ -62,7 +63,11 @@ interface AudioBookShelfApi {
    */
   suspend fun getLibraryItems(
     libraryId: String,
-    filter: String? = null,
+    filter: LibraryItemFilter? = null,
+    sortMode: String? = null,
+    sortDescending: Boolean = false,
+    page: Int = 0,
+    limit: Int = 0,
   ): Result<List<LibraryItemExpanded>>
 
   /**
@@ -83,8 +88,12 @@ interface AudioBookShelfApi {
   )
   suspend fun getLibraryItemsMinified(
     libraryId: String,
-    filter: String? = null,
-  ): Result<List<LibraryItemMinified<MinifiedBookMetadata>>>
+    filter: LibraryItemFilter? = null,
+    sortMode: String? = null,
+    sortDescending: Boolean = false,
+    page: Int = INVALID,
+    limit: Int = INVALID,
+  ): Result<PagedResponse<LibraryItemMinified<MinifiedBookMetadata>>>
 
   /**
    * Fetch a single library item
@@ -231,3 +240,5 @@ interface AudioBookShelfApi {
    */
   suspend fun getListeningStats(): Result<ListeningStats>
 }
+
+const val INVALID = -1

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/PagedResponse.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/PagedResponse.kt
@@ -3,11 +3,7 @@ package app.campfire.network
 data class PagedResponse<Data>(
   val data: List<Data>,
   val page: Int,
-  val pageSize: Int,
-  val count: Int,
-  val totalCount: Int,
-) {
-
-  val hasMore: Boolean
-    get() = ((page - 1) * pageSize + count) < totalCount
-}
+  val limit: Int,
+  val total: Int,
+  val offset: Int,
+)

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/models/FilterData.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/models/FilterData.kt
@@ -1,0 +1,27 @@
+package app.campfire.network.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FilterData(
+  val authors: List<EntityInfo> = emptyList(),
+  val genres: List<String> = emptyList(),
+  val tags: List<String> = emptyList(),
+  val series: List<EntityInfo> = emptyList(),
+  val narrators: List<String> = emptyList(),
+  val languages: List<String> = emptyList(),
+  val publishers: List<String> = emptyList(),
+  val publishedDecades: List<String> = emptyList(),
+  val bookCount: Int = 0,
+  val authorCount: Int = 0,
+  val seriesCount: Int = 0,
+  val podcastCount: Int = 0,
+  val numIssues: Int = 0,
+) {
+
+  @Serializable
+  data class EntityInfo(
+    val id: String,
+    val name: String,
+  )
+}

--- a/data/network/api/src/commonMain/kotlin/app.campfire.network/models/LibraryItemFilter.kt
+++ b/data/network/api/src/commonMain/kotlin/app.campfire.network/models/LibraryItemFilter.kt
@@ -1,0 +1,6 @@
+package app.campfire.network.models
+
+data class LibraryItemFilter(
+  val group: String,
+  val value: String,
+)

--- a/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
+++ b/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
@@ -29,6 +29,7 @@ import app.campfire.network.models.Author
 import app.campfire.network.models.Collection
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
+import app.campfire.network.models.LibraryItemFilter
 import app.campfire.network.models.LibraryItemMinified
 import app.campfire.network.models.LibraryStats
 import app.campfire.network.models.ListeningStats
@@ -65,6 +66,7 @@ import io.ktor.http.encodeURLQueryComponent
 import io.ktor.http.isSuccess
 import io.ktor.http.takeFrom
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.util.encodeBase64
 import kotlinx.coroutines.withContext
 import kotlinx.io.IOException
 import me.tatarka.inject.annotations.Inject
@@ -121,13 +123,24 @@ class KtorAudioBookShelfApi(
 
   override suspend fun getLibraryItems(
     libraryId: String,
-    filter: String?,
+    filter: LibraryItemFilter?,
+    sortMode: String?,
+    sortDescending: Boolean,
+    page: Int,
+    limit: Int,
   ): Result<List<LibraryItemExpanded>> {
     return trySendRequest<LibraryItemsResponse> {
       hydratedClientRequest({
         appendPathSegments("api", "libraries", libraryId, "items")
         parameters.append("minified", "0")
-        filter?.let { f -> parameters.append("filter", f) }
+        filter?.let { f ->
+          val filterValue = "${f.group}.${f.value.encodeBase64().encodeURLQueryComponent()}"
+          parameters.append("filter", filterValue)
+        }
+        sortMode?.let { parameters.append("sort", it) }
+        if (sortDescending) parameters.append("sort_desc", "1")
+        parameters.append("page", page.toString())
+        parameters.append("limit", limit.toString())
       })
     }.map { it.results }
   }
@@ -138,15 +151,34 @@ class KtorAudioBookShelfApi(
   )
   override suspend fun getLibraryItemsMinified(
     libraryId: String,
-    filter: String?,
-  ): Result<List<LibraryItemMinified<MinifiedBookMetadata>>> {
+    filter: LibraryItemFilter?,
+    sortMode: String?,
+    sortDescending: Boolean,
+    page: Int,
+    limit: Int,
+  ): Result<PagedResponse<LibraryItemMinified<MinifiedBookMetadata>>> {
     return trySendRequest<MinifiedLibraryItemsResponse> {
       hydratedClientRequest({
         appendPathSegments("api", "libraries", libraryId, "items")
         parameters.append("minified", "1")
-        filter?.let { f -> parameters.append("filter", f) }
+        filter?.let { f ->
+          val filterValue = "${f.group}.${f.value.encodeBase64().encodeURLQueryComponent()}"
+          parameters.append("filter", filterValue)
+        }
+        sortMode?.let { parameters.append("sort", it) }
+        if (sortDescending) parameters.append("sort_desc", "1")
+        if (page != INVALID) parameters.append("page", page.toString())
+        if (limit != INVALID) parameters.append("limit", limit.toString())
       })
-    }.map { it.results }
+    }.map {
+      PagedResponse(
+        data = it.results,
+        page = it.page,
+        limit = it.limit,
+        total = it.total,
+        offset = it.offset,
+      )
+    }
   }
 
   override suspend fun getLibraryItem(itemId: String): Result<LibraryItemExpanded> {

--- a/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
+++ b/data/network/impl/src/commonMain/kotlin/app.campfire.network/KtorAudioBookShelfApi.kt
@@ -27,6 +27,7 @@ import app.campfire.network.envelopes.UpdateCollectionRequest
 import app.campfire.network.models.AudioBookmark
 import app.campfire.network.models.Author
 import app.campfire.network.models.Collection
+import app.campfire.network.models.FilterData
 import app.campfire.network.models.Library
 import app.campfire.network.models.LibraryItemExpanded
 import app.campfire.network.models.LibraryItemFilter
@@ -392,6 +393,12 @@ class KtorAudioBookShelfApi(
       ?: throw IllegalStateException("You must be logged in to perform this request")
     return trySendRequest {
       hydratedClientRequest("api/users/$currentUserId/listening-stats")
+    }
+  }
+
+  override suspend fun getFilterData(libraryId: String): Result<FilterData> {
+    return trySendRequest {
+      hydratedClientRequest("api/libraries/$libraryId/filterdata")
     }
   }
 

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryItemFilter.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryItemFilter.kt
@@ -1,6 +1,5 @@
 package app.campfire.libraries.api
 
-import app.campfire.core.model.Author
 import app.campfire.core.model.AuthorId
 import app.campfire.core.model.SeriesId
 
@@ -22,14 +21,16 @@ sealed interface LibraryItemFilter {
 
   class Series(
     override val value: SeriesId,
+    val seriesName: String,
   ) : LibraryItemFilter {
     override val group: String = "series"
   }
 
   class Authors(
-    val author: Author,
+    val authorId: AuthorId,
+    val authorName: String,
   ) : LibraryItemFilter {
-    override val value: String = author.id
+    override val value: String = authorId
     override val group: String = "authors"
   }
 

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryItemFilter.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryItemFilter.kt
@@ -1,0 +1,95 @@
+package app.campfire.libraries.api
+
+import app.campfire.core.model.Author
+import app.campfire.core.model.AuthorId
+import app.campfire.core.model.SeriesId
+
+sealed interface LibraryItemFilter {
+  val group: String
+  val value: String
+
+  class Genres(
+    override val value: String,
+  ) : LibraryItemFilter {
+    override val group: String = "genres"
+  }
+
+  class Tags(
+    override val value: String,
+  ) : LibraryItemFilter {
+    override val group: String = "tags"
+  }
+
+  class Series(
+    override val value: SeriesId,
+  ) : LibraryItemFilter {
+    override val group: String = "series"
+  }
+
+  class Authors(
+    val author: Author,
+  ) : LibraryItemFilter {
+    override val value: String = author.id
+    override val group: String = "authors"
+  }
+
+  class Progress(
+    val type: Type,
+  ) : LibraryItemFilter {
+    override val value: String = type.value
+    override val group: String = "progress"
+
+    enum class Type(val value: String) {
+      Finished("finished"),
+      NotStarted("not-started"),
+      NotFinished("not-finished"),
+      InProgress("in-progress"),
+    }
+  }
+
+  class Narrators(
+    override val value: String,
+  ) : LibraryItemFilter {
+    override val group: String = "narrators"
+  }
+
+  class Missing(
+    val type: Type,
+  ) : LibraryItemFilter {
+    override val value: String = type.value
+    override val group: String = "missing"
+
+    enum class Type(val value: String) {
+      ASIN("asin"),
+      ISBN("isbn"),
+      SUBTITLE("subtitle"),
+      AUTHORS("authors"),
+      PUBLISHED_YEAR("publishedYear"),
+      SERIES("series"),
+      DESCRIPTION("description"),
+      GENRES("genres"),
+      TAGS("tags"),
+      NARRATORS("narrators"),
+      PUBLISHER("publisher"),
+      LANGUAGE("language"),
+    }
+  }
+
+  class Languages(
+    override val value: String,
+  ) : LibraryItemFilter {
+    override val group: String = "languages"
+  }
+
+  class Tracks(
+    val type: Type,
+  ) : LibraryItemFilter {
+    override val value: String = type.value
+    override val group: String = "tracks"
+
+    enum class Type(val value: String) {
+      Single("single"),
+      Multi("multi"),
+    }
+  }
+}

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryRepository.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryRepository.kt
@@ -3,6 +3,8 @@ package app.campfire.libraries.api
 import app.campfire.core.model.Library
 import app.campfire.core.model.LibraryId
 import app.campfire.core.model.LibraryItem
+import app.campfire.core.settings.SortDirection
+import app.campfire.core.settings.SortMode
 import kotlinx.coroutines.flow.Flow
 
 interface LibraryRepository {
@@ -21,7 +23,11 @@ interface LibraryRepository {
    * Observe the library items for the current selected library
    * @return a [Flow] that will emit the list of [LibraryItem] for the given [LibraryId]
    */
-  fun observeLibraryItems(): Flow<List<LibraryItem>>
+  fun observeLibraryItems(
+    filter: LibraryItemFilter?,
+    sortMode: SortMode,
+    sortDirection: SortDirection,
+  ): Flow<List<LibraryItem>>
 
   /**
    * Set a library as the currently selected one

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/filtering/FilteringRepository.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/filtering/FilteringRepository.kt
@@ -1,0 +1,12 @@
+package app.campfire.libraries.api.filtering
+
+import app.campfire.core.model.FilterData
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * An interface to pulling the information needed to fully populate the item filtering
+ * UI.
+ */
+interface FilteringRepository {
+  fun observeFilterData(): Flow<FilterData>
+}

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/filtering/LibraryItemQuery.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/filtering/LibraryItemQuery.kt
@@ -1,4 +1,4 @@
-package app.campfire.libraries.api.paging
+package app.campfire.libraries.api.filtering
 
 import app.campfire.core.settings.SortDirection
 import app.campfire.core.settings.SortMode
@@ -6,6 +6,6 @@ import app.campfire.libraries.api.LibraryItemFilter
 
 data class LibraryItemQuery(
   val filter: LibraryItemFilter? = null,
-  val sortMode: SortMode = SortMode.Default,
-  val sortDirection: SortDirection = SortDirection.Default,
+  val sortMode: SortMode = SortMode.Companion.Default,
+  val sortDirection: SortDirection = SortDirection.Companion.Default,
 )

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/paging/LibraryItemQuery.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/paging/LibraryItemQuery.kt
@@ -1,0 +1,11 @@
+package app.campfire.libraries.api.paging
+
+import app.campfire.core.settings.SortDirection
+import app.campfire.core.settings.SortMode
+import app.campfire.libraries.api.LibraryItemFilter
+
+data class LibraryItemQuery(
+  val filter: LibraryItemFilter? = null,
+  val sortMode: SortMode = SortMode.Default,
+  val sortDirection: SortDirection = SortDirection.Default,
+)

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryItemRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryItemRepository.kt
@@ -10,7 +10,7 @@ import app.campfire.data.MediaAudioTracks
 import app.campfire.data.MediaChapters
 import app.campfire.data.MetadataAuthor
 import app.campfire.libraries.api.LibraryItemRepository
-import app.campfire.libraries.items.LibraryItemStore
+import app.campfire.libraries.item.LibraryItemStore
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNot

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
@@ -10,15 +10,16 @@ import app.campfire.core.model.LibraryId
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.UserId
 import app.campfire.core.session.UserSession
-import app.campfire.core.session.serverUrl
 import app.campfire.core.session.userId
+import app.campfire.core.settings.SortDirection
+import app.campfire.core.settings.SortMode
 import app.campfire.data.Library as DbLibrary
 import app.campfire.data.mapping.asDbModel
 import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.asFetcherResult
-import app.campfire.data.mapping.model.LibraryItemWithMedia
-import app.campfire.data.mapping.model.mapToLibraryItem
+import app.campfire.libraries.api.LibraryItemFilter
 import app.campfire.libraries.api.LibraryRepository
+import app.campfire.libraries.items.LibraryItemsStore
 import app.campfire.network.AudioBookShelfApi
 import app.campfire.user.api.UserRepository
 import app.cash.sqldelight.coroutines.asFlow
@@ -49,53 +50,13 @@ class StoreLibraryRepository(
   private val db: CampfireDatabase,
   private val userRepository: UserRepository,
   private val tokenHydrator: TokenHydrator,
+  private val libraryItemsStoreFactory: LibraryItemsStore.Factory,
   private val dispatcherProvider: DispatcherProvider,
 ) : LibraryRepository {
 
-  private val libraryItemStore = StoreBuilder
-    .from(
-      fetcher = Fetcher.ofResult { libraryId: LibraryId ->
-        api.getLibraryItemsMinified(libraryId).asFetcherResult()
-      },
-      sourceOfTruth = SourceOfTruth.of(
-        reader = { libraryId: LibraryId ->
-          db.libraryItemsQueries.selectForLibrary(libraryId, ::mapToLibraryItem)
-            .asFlow()
-            .mapToList(dispatcherProvider.databaseRead)
-        },
-        writer = { _, page ->
-          withContext(dispatcherProvider.databaseWrite) {
-            db.transaction {
-              page.data.forEach { item ->
-                // TODO: Update when https://github.com/advplyr/audiobookshelf/pull/3945 is merged
-//                libraryItemDao.insert(
-//                  item = item,
-//                  asTransaction = false,
-//                )
-
-                val libraryItem = item.asDbModel(userSession.serverUrl!!)
-                val media = item.media.asDbModel(item.id)
-
-                db.libraryItemsQueries.insertOrIgnore(libraryItem)
-                db.mediaQueries.insertOrIgnore(media)
-              }
-            }
-          }
-        },
-        delete = { libraryId: LibraryId ->
-          withContext(dispatcherProvider.databaseWrite) {
-            db.libraryItemsQueries.deleteForLibrary(libraryId)
-          }
-        },
-      ),
-    )
-    .cachePolicy(
-      MemoryPolicy.builder<LibraryId, List<LibraryItemWithMedia>>()
-        .setMaxSize(10)
-        .setExpireAfterAccess(15.minutes)
-        .build(),
-    )
-    .build()
+  private val libraryItemStore by lazy {
+    libraryItemsStoreFactory.create()
+  }
 
   data class SingleLibraryRequest(val userId: UserId, val libraryId: LibraryId)
 
@@ -179,11 +140,25 @@ class StoreLibraryRepository(
       }
   }
 
-  override fun observeLibraryItems(): Flow<List<LibraryItem>> {
+  override fun observeLibraryItems(
+    filter: LibraryItemFilter?,
+    sortMode: SortMode,
+    sortDirection: SortDirection,
+  ): Flow<List<LibraryItem>> {
     return userRepository.observeCurrentUser()
       .flatMapLatest { user ->
         libraryItemStore
-          .stream(StoreReadRequest.cached(user.selectedLibraryId, refresh = true))
+          .stream(
+            StoreReadRequest.cached(
+              LibraryItemsStore.Query(
+                libraryId = user.selectedLibraryId,
+                filter = filter,
+                sortMode = sortMode,
+                sortDirection = sortDirection,
+              ),
+              refresh = true,
+            ),
+          )
           .mapNotNull {
             it.dataOrNull()?.map { it.asDomainModel(tokenHydrator) }
           }

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
@@ -63,10 +63,10 @@ class StoreLibraryRepository(
             .asFlow()
             .mapToList(dispatcherProvider.databaseRead)
         },
-        writer = { _, data ->
+        writer = { _, page ->
           withContext(dispatcherProvider.databaseWrite) {
             db.transaction {
-              data.forEach { item ->
+              page.data.forEach { item ->
                 // TODO: Update when https://github.com/advplyr/audiobookshelf/pull/3945 is merged
 //                libraryItemDao.insert(
 //                  item = item,

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/AutoIncrementingSqlPreparedStatement.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/AutoIncrementingSqlPreparedStatement.kt
@@ -1,0 +1,36 @@
+package app.campfire.libraries.db
+
+import app.campfire.core.logging.bark
+import app.cash.sqldelight.db.SqlPreparedStatement
+
+class AutoIncrementingSqlPreparedStatement(
+  val delegate: SqlPreparedStatement,
+  val getAndIncrement: () -> Int,
+) : SqlPreparedStatement by delegate {
+
+  private val loggingGetAndIncrement = { method: String ->
+    getAndIncrement().also {
+      bark { "~~ getAndIncrement($method) => $it" }
+    }
+  }
+
+  fun bindBytes(bytes: ByteArray?) {
+    bindBytes(loggingGetAndIncrement("bindBytes"), bytes)
+  }
+
+  fun bindLong(long: Long?) {
+    bindLong(loggingGetAndIncrement("bindLong"), long)
+  }
+
+  fun bindDouble(double: Double?) {
+    bindDouble(loggingGetAndIncrement("bindDouble"), double)
+  }
+
+  fun bindString(string: String?) {
+    bindString(loggingGetAndIncrement("bindString"), string)
+  }
+
+  fun bindBoolean(boolean: Boolean?) {
+    bindBoolean(loggingGetAndIncrement("bindBoolean"), boolean)
+  }
+}

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/AutoIncrementingSqlPreparedStatement.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/AutoIncrementingSqlPreparedStatement.kt
@@ -19,18 +19,18 @@ class AutoIncrementingSqlPreparedStatement(
   }
 
   fun bindLong(long: Long?) {
-    bindLong(loggingGetAndIncrement("bindLong"), long)
+    bindLong(loggingGetAndIncrement("bindLong($long)"), long)
   }
 
   fun bindDouble(double: Double?) {
-    bindDouble(loggingGetAndIncrement("bindDouble"), double)
+    bindDouble(loggingGetAndIncrement("bindDouble($double)"), double)
   }
 
   fun bindString(string: String?) {
-    bindString(loggingGetAndIncrement("bindString"), string)
+    bindString(loggingGetAndIncrement("bindString($string)"), string)
   }
 
   fun bindBoolean(boolean: Boolean?) {
-    bindBoolean(loggingGetAndIncrement("bindBoolean"), boolean)
+    bindBoolean(loggingGetAndIncrement("bindBoolean($boolean)"), boolean)
   }
 }

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/FilteredItemQueryHelper.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/FilteredItemQueryHelper.kt
@@ -1,0 +1,457 @@
+package app.campfire.libraries.db
+
+import app.campfire.core.logging.bark
+import app.campfire.core.model.LibraryId
+import app.campfire.core.model.MediaType
+import app.campfire.core.settings.SortDirection
+import app.campfire.core.settings.SortMode
+import app.campfire.data.mapping.model.LibraryItemWithMedia
+import app.campfire.data.mapping.model.mapToLibraryItem
+import app.campfire.db.DatabaseAdapters
+import app.campfire.libraries.api.LibraryItemFilter
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+import me.tatarka.inject.annotations.Inject
+
+@Inject
+class FilteredItemQueryHelper(
+  private val sqlDriver: SqlDriver,
+  private val adapters: DatabaseAdapters,
+) {
+
+  fun count(
+    filter: LibraryItemFilter?,
+    sortMode: SortMode,
+    sortDirection: SortDirection,
+    libraryId: LibraryId,
+  ): Query<Long> {
+    return CountForFilteredItemQuery(
+      filter = filter,
+      sortMode = sortMode,
+      sortDirection = sortDirection,
+      libraryId = libraryId,
+      mapper = { cursor -> cursor.getLong(0)!! },
+    )
+  }
+
+  fun select(
+    filter: LibraryItemFilter?,
+    sortMode: SortMode,
+    sortDirection: SortDirection,
+    libraryId: LibraryId,
+    offset: Int,
+    limit: Int,
+  ): Query<LibraryItemWithMedia> {
+    return SelectFilteredItemQuery(
+      filter = filter,
+      sortMode = sortMode,
+      sortDirection = sortDirection,
+      libraryId = libraryId,
+      offset = offset,
+      limit = limit,
+      mapper = { cursor ->
+        mapCursorToLibraryItem(
+          cursor = cursor,
+          mapper = ::mapToLibraryItem,
+        )
+      },
+    )
+  }
+
+  /**
+   * This mapping adapter is super fragile and copied from the
+   * generated LibraryItemQueries of SQLDelight. If the schema for these tables
+   * are changed at all then this will need to be updated or it will break.
+   *
+   * TODO: Write unit tests around this
+   */
+  private fun <T> mapCursorToLibraryItem(
+    cursor: SqlCursor,
+    mapper: (
+      id: String,
+      ino: String,
+      libraryId: String,
+      oldLibraryItemId: String?,
+      folderId: String,
+      path: String,
+      relPath: String,
+      isFile: Boolean,
+      mtimeMs: Long,
+      ctimeMs: Long,
+      birthtimeMs: Long,
+      addedAt: Long,
+      updatedAt: Long,
+      isMissing: Boolean,
+      isInvalid: Boolean,
+      mediaType: MediaType,
+      numFiles: Int,
+      size: Long,
+      serverUrl: String,
+      mediaId: String,
+      coverPath: String?,
+      tags: List<String>?,
+      numTracks: Int,
+      numAudioFiles: Int,
+      numChapters: Int,
+      numMissingParts: Int,
+      numInvalidAudioFiles: Int,
+      durationInMillis: Long,
+      sizeInBytes: Long,
+      propertySize: Int?,
+      ebookFormat: String?,
+      metadata_title: String?,
+      metadata_subtitle: String?,
+      metadata_genres: List<String>?,
+      metadata_publishedYear: String?,
+      metadata_publishedDate: String?,
+      metadata_publisher: String?,
+      metadata_description: String?,
+      metadata_isbn: String?,
+      metadata_asin: String?,
+      metadata_language: String?,
+      metadata_explicit: Boolean,
+      metadata_abridged: Boolean,
+      metadata_titleIgnorePrefix: String?,
+      metadata_authorName: String?,
+      metadata_authorNameLF: String?,
+      metadata_narratorName: String?,
+      metadata_seriesName: String?,
+      metadata_series_id: String?,
+      metadata_series_name: String?,
+      metadata_series_sequence: Int?,
+      libraryItemId: String,
+    ) -> T,
+  ): T {
+    return mapper(
+      cursor.getString(0)!!,
+      cursor.getString(1)!!,
+      cursor.getString(2)!!,
+      cursor.getString(3),
+      cursor.getString(4)!!,
+      cursor.getString(5)!!,
+      cursor.getString(6)!!,
+      cursor.getBoolean(7)!!,
+      cursor.getLong(8)!!,
+      cursor.getLong(9)!!,
+      cursor.getLong(10)!!,
+      cursor.getLong(11)!!,
+      cursor.getLong(12)!!,
+      cursor.getBoolean(13)!!,
+      cursor.getBoolean(14)!!,
+      adapters.libraryItemAdapter.mediaTypeAdapter.decode(cursor.getString(15)!!),
+      adapters.libraryItemAdapter.numFilesAdapter.decode(cursor.getLong(16)!!),
+      cursor.getLong(17)!!,
+      cursor.getString(18)!!,
+      cursor.getString(19)!!,
+      cursor.getString(20),
+      cursor.getString(21)?.let { adapters.mediaAdapter.tagsAdapter.decode(it) },
+      adapters.mediaAdapter.numTracksAdapter.decode(cursor.getLong(22)!!),
+      adapters.mediaAdapter.numAudioFilesAdapter.decode(cursor.getLong(23)!!),
+      adapters.mediaAdapter.numChaptersAdapter.decode(cursor.getLong(24)!!),
+      adapters.mediaAdapter.numMissingPartsAdapter.decode(cursor.getLong(25)!!),
+      adapters.mediaAdapter.numInvalidAudioFilesAdapter.decode(cursor.getLong(26)!!),
+      cursor.getLong(27)!!,
+      cursor.getLong(28)!!,
+      cursor.getLong(29)?.let { adapters.mediaAdapter.propertySizeAdapter.decode(it) },
+      cursor.getString(30),
+      cursor.getString(31),
+      cursor.getString(32),
+      cursor.getString(33)?.let { adapters.mediaAdapter.metadata_genresAdapter.decode(it) },
+      cursor.getString(34),
+      cursor.getString(35),
+      cursor.getString(36),
+      cursor.getString(37),
+      cursor.getString(38),
+      cursor.getString(39),
+      cursor.getString(40),
+      cursor.getBoolean(41)!!,
+      cursor.getBoolean(42)!!,
+      cursor.getString(43),
+      cursor.getString(44),
+      cursor.getString(45),
+      cursor.getString(46),
+      cursor.getString(47),
+      cursor.getString(48),
+      cursor.getString(49),
+      cursor.getLong(50)?.let { adapters.mediaAdapter.metadata_series_sequenceAdapter.decode(it) },
+      cursor.getString(51)!!,
+    )
+  }
+
+  private inner class SelectFilteredItemQuery<out T : Any>(
+    val filter: LibraryItemFilter?,
+    val sortMode: SortMode,
+    val sortDirection: SortDirection,
+    val libraryId: LibraryId,
+    val offset: Int,
+    val limit: Int,
+    mapper: (SqlCursor) -> T,
+  ) : Query<T>(mapper) {
+
+    override fun addListener(listener: Listener) {
+      sqlDriver.addListener("libraryItem", "media", listener = listener)
+    }
+
+    override fun removeListener(listener: Listener) {
+      sqlDriver.removeListener("libraryItem", "media", listener = listener)
+    }
+
+    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+      val binderBuilder = PreparedSqlStatementBinderBuilder(1)
+      val query = binderBuilder.buildQuery(
+        """
+          |SELECT libraryItem.*,media.* FROM libraryItem
+          |INNER JOIN media ON media.libraryItemId = libraryItem.id
+          |LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
+          |WHERE libraryItem.libraryId = ?
+          """.trimMargin(),
+        filter,
+        sortMode,
+        sortDirection,
+        Page(limit, offset),
+      )
+      val numParameters = query.count { it == '?' }
+      return sqlDriver.executeQuery(100, query, mapper, numParameters.also { bark { "SelectFilteredItemQuery: $it" } }) {
+        bindString(0, libraryId)
+        binderBuilder.apply(this)
+      }.also { qr ->
+        bark { "SelectFilteredItemQuery Result: \n${qr.value}" }
+      }
+    }
+
+    override fun toString(): String {
+      return "libraryItems.sq:selectFiltered"
+    }
+  }
+
+  private inner class CountForFilteredItemQuery<out T : Any>(
+    val filter: LibraryItemFilter?,
+    val sortMode: SortMode,
+    val sortDirection: SortDirection,
+    val libraryId: LibraryId,
+    mapper: (SqlCursor) -> T,
+  ) : Query<T>(mapper) {
+
+    override fun addListener(listener: Listener) {
+      sqlDriver.addListener("libraryItem", "media", listener = listener)
+    }
+
+    override fun removeListener(listener: Listener) {
+      sqlDriver.removeListener("libraryItem", "media", listener = listener)
+    }
+
+    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+      val binderBuilder = PreparedSqlStatementBinderBuilder(1)
+      val query = binderBuilder.buildQuery(
+        """
+          |SELECT count(*) FROM libraryItem
+          |INNER JOIN media ON media.libraryItemId = libraryItem.id
+          |LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
+          |WHERE libraryItem.libraryId = ?
+          """.trimMargin(),
+        filter,
+        sortMode,
+        sortDirection,
+      )
+      val numParameters = query.count { it == '?' }
+      return sqlDriver.executeQuery(200, query, mapper, numParameters.also { bark { "CountForFilteredItemQuery: $it" } }) {
+        bindString(0, libraryId)
+        binderBuilder.apply(this)
+      }
+    }
+
+    override fun toString(): String {
+      return "libraryItems.sq:countFiltered"
+    }
+  }
+
+  private fun PreparedSqlStatementBinderBuilder.buildQuery(
+    initialQuery: String,
+    filter: LibraryItemFilter?,
+    sortMode: SortMode,
+    sortDirection: SortDirection,
+    page: Page? = null,
+  ): String {
+    return buildString {
+      appendLine(initialQuery)
+
+      when (filter) {
+        is LibraryItemFilter.Authors -> {
+          appendLine("AND media.metadata_authorName = ?")
+          bind {
+            bindString(filter.author.name)
+          }
+        }
+
+        is LibraryItemFilter.Genres -> {
+          appendLine("AND media.metadata_genres LIKE ?")
+          bind {
+            bindString("%${filter.value}%")
+          }
+        }
+
+        is LibraryItemFilter.Languages -> {
+          appendLine("AND media.metadata_language = ?")
+          bind {
+            bindString(filter.value)
+          }
+        }
+
+        is LibraryItemFilter.Missing -> when (filter.type) {
+          LibraryItemFilter.Missing.Type.ASIN -> {
+            appendLine("AND media.metadata_asin IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.ISBN -> {
+            appendLine("AND media.metadata_isbn IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.SUBTITLE -> {
+            appendLine("AND media.metadata_subtitle IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.AUTHORS -> {
+            appendLine("AND media.metadata_authorName IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.PUBLISHED_YEAR -> {
+            appendLine("AND media.metadata_publishedYear IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.SERIES -> {
+            appendLine("AND media.metadata_seriesName IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.DESCRIPTION -> {
+            appendLine("AND media.metadata_description IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.GENRES -> {
+            appendLine("AND media.metadata_genres IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.TAGS -> {
+            appendLine("AND media.tags IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.NARRATORS -> {
+            appendLine("AND media.metadata_narratorName IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.PUBLISHER -> {
+            appendLine("AND media.metadata_publisher IS NULL")
+          }
+
+          LibraryItemFilter.Missing.Type.LANGUAGE -> {
+            appendLine("AND media.metadata_language IS NULL")
+          }
+        }
+
+        is LibraryItemFilter.Narrators -> {
+          appendLine("AND media.metadata_narratorName = ?")
+          bind {
+            bindString(filter.value)
+          }
+        }
+
+        is LibraryItemFilter.Progress -> when (filter.type) {
+          LibraryItemFilter.Progress.Type.Finished -> {
+            appendLine("AND mediaProgress.isFinished = 1")
+          }
+
+          LibraryItemFilter.Progress.Type.NotFinished -> {
+            appendLine("AND mediaProgress.isFinished = 0")
+          }
+
+          LibraryItemFilter.Progress.Type.NotStarted -> {
+            appendLine("AND mediaProgress.id IS NULL")
+          }
+
+          LibraryItemFilter.Progress.Type.InProgress -> {
+            appendLine("AND mediaProgress.id IS NOT NULL AND mediaProgress.isFinished = 0")
+          }
+        }
+
+        is LibraryItemFilter.Series -> {
+          appendLine("AND media.metadata_seriesName = ?")
+          bind {
+            bindString(filter.value)
+          }
+        }
+
+        is LibraryItemFilter.Tags -> {
+          appendLine("AND media.tags LIKE ?")
+          bind {
+            bindString("%${filter.value}%")
+          }
+        }
+
+        is LibraryItemFilter.Tracks -> when (filter.type) {
+          LibraryItemFilter.Tracks.Type.Single -> {
+            appendLine("AND media.numTracks = 1")
+          }
+
+          LibraryItemFilter.Tracks.Type.Multi -> {
+            appendLine("AND media.numTracks > 1")
+          }
+        }
+
+        null -> Unit
+      }
+
+      append("ORDER BY ")
+      when (sortMode) {
+        SortMode.Title -> append("media.metadata_title")
+        SortMode.AuthorFL -> append("media.metadata_authorName")
+        SortMode.AuthorLF -> append("media.metadata_authorNameLF")
+        SortMode.PublishYear -> append("media.metadata_publishedYear")
+        SortMode.AddedAt -> append("libraryItem.addedAt")
+        SortMode.Size -> append("libraryItem.size")
+        SortMode.Duration -> append("media.durationInMillis")
+      }
+      append(" ")
+      appendLine(
+        when (sortDirection) {
+          SortDirection.Ascending -> "ASC"
+          SortDirection.Descending -> "DESC"
+        },
+      )
+
+      page?.let {
+        appendLine("LIMIT ? OFFSET ?")
+        bind {
+          bindLong(it.limit.toLong())
+          bindLong(it.offset.toLong())
+        }
+      }
+    }
+  }
+}
+
+class Page(
+  val limit: Int,
+  val offset: Int,
+)
+
+class PreparedSqlStatementBinderBuilder(initialIndex: Int = 0) {
+  private val binders = mutableListOf<SqlPreparedStatement.() -> Unit>()
+  private var currentIndex = initialIndex
+
+  fun bind(binder: AutoIncrementingSqlPreparedStatement.() -> Unit) {
+    binders.add(
+      {
+        AutoIncrementingSqlPreparedStatement(this) {
+          currentIndex++
+        }.binder()
+      },
+    )
+  }
+
+  fun apply(statement: SqlPreparedStatement) {
+    binders.forEach { it(statement) }
+  }
+}
+

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/FilteredItemQueryHelper.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/FilteredItemQueryHelper.kt
@@ -213,11 +213,10 @@ class FilteredItemQueryHelper(
       bark { "Querying:\n$query" }
       val numParameters = query.count { it == '?' }
       return sqlDriver.executeQuery(
-        100,
+        query.hashCode(),
         query,
         mapper,
-        numParameters
-          .also { bark { "SelectFilteredItemQuery: $it" } },
+        numParameters,
       ) {
         bindString(0, libraryId)
         binderBuilder.apply(this)
@@ -263,7 +262,7 @@ class FilteredItemQueryHelper(
       bark { "Querying:\n$query" }
       val numParameters = query.count { it == '?' }
       return sqlDriver.executeQuery(
-        200,
+        query.hashCode(),
         query,
         mapper,
         numParameters
@@ -298,9 +297,9 @@ class FilteredItemQueryHelper(
         }
 
         is LibraryItemFilter.Genres -> {
-          appendLine("AND media.metadata_genres LIKE ?")
+          appendLine("AND media.metadata_genres = ?")
           bind {
-            bindString("%${filter.value}%")
+            bindString(filter.value)
           }
         }
 

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/FilteredItemQueryHelper.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/db/FilteredItemQueryHelper.kt
@@ -42,16 +42,14 @@ class FilteredItemQueryHelper(
     sortMode: SortMode,
     sortDirection: SortDirection,
     libraryId: LibraryId,
-    offset: Int,
-    limit: Int,
+    page: Page? = null,
   ): Query<LibraryItemWithMedia> {
     return SelectFilteredItemQuery(
       filter = filter,
       sortMode = sortMode,
       sortDirection = sortDirection,
       libraryId = libraryId,
-      offset = offset,
-      limit = limit,
+      page = page,
       mapper = { cursor ->
         mapCursorToLibraryItem(
           cursor = cursor,
@@ -186,8 +184,7 @@ class FilteredItemQueryHelper(
     val sortMode: SortMode,
     val sortDirection: SortDirection,
     val libraryId: LibraryId,
-    val offset: Int,
-    val limit: Int,
+    val page: Page? = null,
     mapper: (SqlCursor) -> T,
   ) : Query<T>(mapper) {
 
@@ -207,14 +204,21 @@ class FilteredItemQueryHelper(
           |INNER JOIN media ON media.libraryItemId = libraryItem.id
           |LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
           |WHERE libraryItem.libraryId = ?
-          """.trimMargin(),
+        """.trimMargin(),
         filter,
         sortMode,
         sortDirection,
-        Page(limit, offset),
+        page,
       )
+      bark { "Querying:\n$query" }
       val numParameters = query.count { it == '?' }
-      return sqlDriver.executeQuery(100, query, mapper, numParameters.also { bark { "SelectFilteredItemQuery: $it" } }) {
+      return sqlDriver.executeQuery(
+        100,
+        query,
+        mapper,
+        numParameters
+          .also { bark { "SelectFilteredItemQuery: $it" } },
+      ) {
         bindString(0, libraryId)
         binderBuilder.apply(this)
       }.also { qr ->
@@ -251,13 +255,20 @@ class FilteredItemQueryHelper(
           |INNER JOIN media ON media.libraryItemId = libraryItem.id
           |LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
           |WHERE libraryItem.libraryId = ?
-          """.trimMargin(),
+        """.trimMargin(),
         filter,
         sortMode,
         sortDirection,
       )
+      bark { "Querying:\n$query" }
       val numParameters = query.count { it == '?' }
-      return sqlDriver.executeQuery(200, query, mapper, numParameters.also { bark { "CountForFilteredItemQuery: $it" } }) {
+      return sqlDriver.executeQuery(
+        200,
+        query,
+        mapper,
+        numParameters
+          .also { bark { "CountForFilteredItemQuery: $it" } },
+      ) {
         bindString(0, libraryId)
         binderBuilder.apply(this)
       }
@@ -282,7 +293,7 @@ class FilteredItemQueryHelper(
         is LibraryItemFilter.Authors -> {
           appendLine("AND media.metadata_authorName = ?")
           bind {
-            bindString(filter.author.name)
+            bindString(filter.authorName)
           }
         }
 
@@ -454,4 +465,3 @@ class PreparedSqlStatementBinderBuilder(initialIndex: Int = 0) {
     binders.forEach { it(statement) }
   }
 }
-

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/filtering/StoreFilteringRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/filtering/StoreFilteringRepository.kt
@@ -1,0 +1,41 @@
+package app.campfire.libraries.filtering
+
+import app.campfire.core.di.UserScope
+import app.campfire.core.model.FilterData
+import app.campfire.libraries.api.filtering.FilteringRepository
+import app.campfire.libraries.filtering.store.FilteringStore
+import app.campfire.user.api.UserRepository
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import me.tatarka.inject.annotations.Inject
+import org.mobilenativefoundation.store.store5.StoreReadRequest
+import org.mobilenativefoundation.store.store5.StoreReadResponse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ContributesBinding(UserScope::class)
+@Inject
+class StoreFilteringRepository(
+  private val userRepository: UserRepository,
+  private val filteringStoreFactory: FilteringStore.Factory,
+) : FilteringRepository {
+
+  private val store by lazy {
+    filteringStoreFactory.create()
+  }
+
+  override fun observeFilterData(): Flow<FilterData> {
+    return userRepository.observeCurrentUser()
+      .flatMapLatest { user ->
+        val request = StoreReadRequest.cached(user.selectedLibraryId, refresh = true)
+        store.stream(request)
+          .filterNot { it is StoreReadResponse.Loading || it is StoreReadResponse.NoNewData }
+          .map {
+            it.dataOrNull() ?: FilterData()
+          }
+      }
+  }
+}

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/filtering/store/FilterFetcherFactory.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/filtering/store/FilterFetcherFactory.kt
@@ -1,0 +1,16 @@
+package app.campfire.libraries.filtering.store
+
+import app.campfire.core.model.LibraryId
+import app.campfire.data.mapping.asFetcherResult
+import app.campfire.network.AudioBookShelfApi
+import app.campfire.network.models.FilterData
+import org.mobilenativefoundation.store.store5.Fetcher
+
+class FilterFetcherFactory(
+  private val api: AudioBookShelfApi,
+) {
+
+  fun create(): Fetcher<LibraryId, FilterData> = Fetcher.ofResult { libraryId ->
+    api.getFilterData(libraryId).asFetcherResult()
+  }
+}

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/filtering/store/FilterSourceOfTruthFactory.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/filtering/store/FilterSourceOfTruthFactory.kt
@@ -1,0 +1,109 @@
+package app.campfire.libraries.filtering.store
+
+import app.campfire.CampfireDatabase
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.coroutines.mapIfNotNull
+import app.campfire.core.model.FilterData
+import app.campfire.core.model.LibraryId
+import app.campfire.core.time.FatherTime
+import app.campfire.data.FilterData as DbFilterData
+import app.campfire.network.models.FilterData as NetworkFilterData
+import app.cash.sqldelight.async.coroutines.awaitAsList
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import org.mobilenativefoundation.store.store5.SourceOfTruth
+
+class FilterSourceOfTruthFactory(
+  private val db: CampfireDatabase,
+  private val dispatcherProvider: DispatcherProvider,
+  private val fatherTime: FatherTime,
+) {
+
+  fun create() = SourceOfTruth.of<LibraryId, NetworkFilterData, FilterData>(
+    reader = { libraryId ->
+      db.filterDataQueries
+        .getFilterData(libraryId)
+        .asFlow()
+        .mapToOneOrNull(dispatcherProvider.databaseRead)
+        .mapIfNotNull { filterData ->
+          val authors = db.filterDataQueries.getFilterAuthors(libraryId, ::mapToEntity).awaitAsList()
+          val genres = db.filterDataQueries.getFilterGenres(libraryId).awaitAsList()
+          val tags = db.filterDataQueries.getFilterTags(libraryId).awaitAsList()
+          val series = db.filterDataQueries.getFilterSeries(libraryId, ::mapToEntity).awaitAsList()
+          val narrators = db.filterDataQueries.getFilterNarrators(libraryId).awaitAsList()
+          val languages = db.filterDataQueries.getFilterLanguages(libraryId).awaitAsList()
+          val publishers = db.filterDataQueries.getFilterPublishers(libraryId).awaitAsList()
+          val publishedDecades = db.filterDataQueries.getFilterPublishedDecades(libraryId).awaitAsList()
+          FilterData(
+            authors = authors,
+            genres = genres,
+            tags = tags,
+            series = series,
+            narrators = narrators,
+            languages = languages,
+            publishers = publishers,
+            publishedDecades = publishedDecades,
+            bookCount = filterData.bookCount,
+            authorCount = filterData.authorCount,
+            seriesCount = filterData.seriesCount,
+            podcastCount = filterData.podcastCount,
+            numIssues = filterData.numIssues,
+          )
+        }
+    },
+    writer = { libraryId, filterData: NetworkFilterData ->
+      db.transaction {
+        db.filterDataQueries.insertFilterData(
+          DbFilterData(
+            libraryId = libraryId,
+            bookCount = filterData.bookCount,
+            authorCount = filterData.authorCount,
+            seriesCount = filterData.seriesCount,
+            podcastCount = filterData.podcastCount,
+            numIssues = filterData.numIssues,
+            lastUpdated = fatherTime.nowInEpochMillis(),
+          ),
+        )
+
+        db.filterDataQueries.clearFilteredData(libraryId)
+
+        filterData.authors.forEach { author ->
+          db.filterDataQueries.insertAuthors(author.id, author.name, libraryId)
+        }
+
+        filterData.genres.forEach { genre ->
+          db.filterDataQueries.insertGenres(genre, libraryId)
+        }
+
+        filterData.tags.forEach { tag ->
+          db.filterDataQueries.insertTags(tag, libraryId)
+        }
+
+        filterData.series.forEach { series ->
+          db.filterDataQueries.insertSeries(series.id, series.name, libraryId)
+        }
+
+        filterData.narrators.forEach { narrator ->
+          db.filterDataQueries.insertNarrators(narrator, libraryId)
+        }
+
+        filterData.languages.forEach { language ->
+          db.filterDataQueries.insertLanguages(language, libraryId)
+        }
+
+        filterData.publishers.forEach { publisher ->
+          db.filterDataQueries.insertPublishers(publisher, libraryId)
+        }
+
+        filterData.publishedDecades.forEach { publishedDecade ->
+          db.filterDataQueries.insertPublishedDecades(publishedDecade, libraryId)
+        }
+      }
+    },
+    delete = { libraryId ->
+      db.filterDataQueries.delete(libraryId)
+    },
+  )
+
+  private fun mapToEntity(id: String, name: String) = FilterData.Entity(id, name)
+}

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/filtering/store/FilteringStore.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/filtering/store/FilteringStore.kt
@@ -1,0 +1,40 @@
+package app.campfire.libraries.filtering.store
+
+import app.campfire.CampfireDatabase
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.model.FilterData
+import app.campfire.core.model.LibraryId
+import app.campfire.core.time.FatherTime
+import app.campfire.network.AudioBookShelfApi
+import kotlin.time.Duration.Companion.minutes
+import me.tatarka.inject.annotations.Inject
+import org.mobilenativefoundation.store.store5.MemoryPolicy
+import org.mobilenativefoundation.store.store5.Store
+import org.mobilenativefoundation.store.store5.StoreBuilder
+
+class FilteringStore private constructor() {
+
+  @Inject
+  class Factory(
+    api: AudioBookShelfApi,
+    db: CampfireDatabase,
+    dispatcherProvider: DispatcherProvider,
+    fatherTime: FatherTime,
+  ) {
+
+    private val filterFetcherFactory = FilterFetcherFactory(api)
+    private val filterSourceOfTruthFactory = FilterSourceOfTruthFactory(db, dispatcherProvider, fatherTime)
+
+    fun create(): Store<LibraryId, FilterData> = StoreBuilder.Companion
+      .from(
+        fetcher = filterFetcherFactory.create(),
+        sourceOfTruth = filterSourceOfTruthFactory.create(),
+      )
+      .cachePolicy(
+        MemoryPolicy.Companion.builder<LibraryId, FilterData>()
+          .setMaxSize(3)
+          .setExpireAfterAccess(5.minutes)
+          .build(),
+      ).build()
+  }
+}

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/item/LibraryItemFetcherFactory.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/item/LibraryItemFetcherFactory.kt
@@ -1,4 +1,4 @@
-package app.campfire.libraries.items
+package app.campfire.libraries.item
 
 import app.campfire.core.model.LibraryItemId
 import app.campfire.data.mapping.asFetcherResult

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/item/LibraryItemSourceOfTruthFactory.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/item/LibraryItemSourceOfTruthFactory.kt
@@ -1,4 +1,4 @@
-package app.campfire.libraries.items
+package app.campfire.libraries.item
 
 import app.campfire.CampfireDatabase
 import app.campfire.core.coroutines.DispatcherProvider

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/item/LibraryItemStore.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/item/LibraryItemStore.kt
@@ -1,4 +1,4 @@
-package app.campfire.libraries.items
+package app.campfire.libraries.item
 
 import app.campfire.CampfireDatabase
 import app.campfire.core.coroutines.DispatcherProvider

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/items/LibraryItemsFetcherFactory.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/items/LibraryItemsFetcherFactory.kt
@@ -1,0 +1,27 @@
+package app.campfire.libraries.items
+
+import app.campfire.core.settings.SortDirection
+import app.campfire.data.mapping.asFetcherResult
+import app.campfire.network.AudioBookShelfApi
+import app.campfire.network.models.LibraryItemFilter
+import app.campfire.network.models.LibraryItemMinified
+import app.campfire.network.models.MinifiedBookMetadata
+import org.mobilenativefoundation.store.store5.Fetcher
+
+class LibraryItemsFetcherFactory(
+  private val api: AudioBookShelfApi,
+) {
+
+  fun create(): Fetcher<LibraryItemsStore.Query, List<LibraryItemMinified<MinifiedBookMetadata>>> {
+    return Fetcher.ofResult { query ->
+      api.getLibraryItemsMinified(
+        libraryId = query.libraryId,
+        filter = query.filter?.let {
+          LibraryItemFilter(it.group, it.value)
+        },
+        sortMode = query.sortMode.networkKey,
+        sortDescending = query.sortDirection == SortDirection.Descending,
+      ).map { it.data }.asFetcherResult()
+    }
+  }
+}

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/items/LibraryItemsSourceOfTruthFactory.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/items/LibraryItemsSourceOfTruthFactory.kt
@@ -1,0 +1,53 @@
+package app.campfire.libraries.items
+
+import app.campfire.CampfireDatabase
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.session.UserSession
+import app.campfire.core.session.serverUrl
+import app.campfire.data.mapping.asDbModel
+import app.campfire.libraries.db.FilteredItemQueryHelper
+import app.campfire.libraries.items.LibraryItemsStore.Query
+import app.campfire.network.models.LibraryItemMinified
+import app.campfire.network.models.MinifiedBookMetadata
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import kotlinx.coroutines.withContext
+import org.mobilenativefoundation.store.store5.SourceOfTruth
+
+class LibraryItemsSourceOfTruthFactory(
+  private val db: CampfireDatabase,
+  private val userSession: UserSession,
+  private val filteredItemQueryHelper: FilteredItemQueryHelper,
+  private val dispatcherProvider: DispatcherProvider,
+) {
+
+  fun create() = SourceOfTruth.of(
+    reader = { query: Query ->
+      filteredItemQueryHelper.select(
+        filter = query.filter,
+        sortMode = query.sortMode,
+        sortDirection = query.sortDirection,
+        libraryId = query.libraryId,
+      ).asFlow()
+        .mapToList(dispatcherProvider.databaseRead)
+    },
+    writer = { query, networkItems: List<LibraryItemMinified<MinifiedBookMetadata>> ->
+      withContext(dispatcherProvider.databaseWrite) {
+        db.transaction {
+          networkItems.forEach { item ->
+            val libraryItem = item.asDbModel(userSession.serverUrl!!)
+            val media = item.media.asDbModel(item.id)
+
+            db.libraryItemsQueries.insertOrIgnore(libraryItem)
+            db.mediaQueries.insertOrIgnore(media)
+          }
+        }
+      }
+    },
+    delete = { query ->
+      withContext(dispatcherProvider.databaseWrite) {
+        db.libraryItemsQueries.deleteForLibrary(query.libraryId)
+      }
+    },
+  )
+}

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/items/LibraryItemsSourceOfTruthFactory.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/items/LibraryItemsSourceOfTruthFactory.kt
@@ -2,6 +2,8 @@ package app.campfire.libraries.items
 
 import app.campfire.CampfireDatabase
 import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.logging.LogPriority
+import app.campfire.core.logging.bark
 import app.campfire.core.session.UserSession
 import app.campfire.core.session.serverUrl
 import app.campfire.data.mapping.asDbModel
@@ -11,6 +13,7 @@ import app.campfire.network.models.LibraryItemMinified
 import app.campfire.network.models.MinifiedBookMetadata
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.withContext
 import org.mobilenativefoundation.store.store5.SourceOfTruth
 
@@ -29,6 +32,9 @@ class LibraryItemsSourceOfTruthFactory(
         sortDirection = query.sortDirection,
         libraryId = query.libraryId,
       ).asFlow()
+        .catch {
+          bark(LogPriority.ERROR, throwable = it) { "Error while reading library items" }
+        }
         .mapToList(dispatcherProvider.databaseRead)
     },
     writer = { query, networkItems: List<LibraryItemMinified<MinifiedBookMetadata>> ->

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/items/LibraryItemsStore.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/items/LibraryItemsStore.kt
@@ -1,0 +1,58 @@
+package app.campfire.libraries.items
+
+import app.campfire.CampfireDatabase
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.logging.Cork
+import app.campfire.core.model.LibraryId
+import app.campfire.core.session.UserSession
+import app.campfire.core.settings.SortDirection
+import app.campfire.core.settings.SortMode
+import app.campfire.data.mapping.model.LibraryItemWithMedia
+import app.campfire.libraries.api.LibraryItemFilter
+import app.campfire.libraries.db.FilteredItemQueryHelper
+import app.campfire.network.AudioBookShelfApi
+import me.tatarka.inject.annotations.Inject
+import org.mobilenativefoundation.store.store5.MemoryPolicy
+import org.mobilenativefoundation.store.store5.Store
+import org.mobilenativefoundation.store.store5.StoreBuilder
+
+object LibraryItemsStore : Cork {
+
+  override val tag: String = "LibraryItemsStore"
+
+  @Inject
+  class Factory(
+    userSession: UserSession,
+    api: AudioBookShelfApi,
+    db: CampfireDatabase,
+    dispatcherProvider: DispatcherProvider,
+    filteredItemQueryHelper: FilteredItemQueryHelper,
+  ) {
+
+    private val fetcherFactory = LibraryItemsFetcherFactory(api)
+    private val sourceOfTruthFactory = LibraryItemsSourceOfTruthFactory(
+      db = db,
+      userSession = userSession,
+      filteredItemQueryHelper = filteredItemQueryHelper,
+      dispatcherProvider = dispatcherProvider,
+    )
+
+    fun create(): Store<Query, List<LibraryItemWithMedia>> {
+      return StoreBuilder.from(
+        fetcher = fetcherFactory.create(),
+        sourceOfTruth = sourceOfTruthFactory.create(),
+      ).cachePolicy(
+        MemoryPolicy.builder<Query, List<LibraryItemWithMedia>>()
+          .setMaxSize(200)
+          .build(),
+      ).build()
+    }
+  }
+
+  data class Query(
+    val libraryId: LibraryId,
+    val filter: LibraryItemFilter?,
+    val sortMode: SortMode,
+    val sortDirection: SortDirection,
+  )
+}

--- a/features/libraries/ui/build.gradle.kts
+++ b/features/libraries/ui/build.gradle.kts
@@ -7,11 +7,12 @@ kotlin {
     commonMain {
       dependencies {
         implementation(projects.infra.audioplayer.api)
+        implementation(projects.features.author.api)
+        implementation(projects.features.collections.api)
         implementation(projects.features.libraries.api)
         implementation(projects.features.series.api)
         implementation(projects.features.sessions.api)
         implementation(projects.features.user.api)
-        implementation(projects.features.collections.api)
         implementation(projects.ui.appbar)
 
         implementation(compose.components.resources)

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -47,4 +47,36 @@
   <string name="dialog_download_do_not_show_label">Do not show again</string>
   <string name="dialog_download_action_confirm">Download</string>
   <string name="dialog_download_action_dismiss">Cancel</string>
+
+  <string name="filter_category_genre">Genre</string>
+  <string name="filter_category_tag">Tag</string>
+  <string name="filter_category_series">Series</string>
+  <string name="filter_category_author">Author</string>
+  <string name="filter_category_narrator">Narrator</string>
+  <string name="filter_category_language">Language</string>
+  <string name="filter_category_progress">Progress</string>
+  <string name="filter_category_missing">Missing</string>
+  <string name="filter_category_tracks">Tracks</string>
+
+  <string name="filter_value_progress_finished">Finished</string>
+  <string name="filter_value_progress_not_started">Not Started</string>
+  <string name="filter_value_progress_not_finished">Not Finished</string>
+  <string name="filter_value_progress_in_progress">In Progress</string>
+
+  <string name="filter_value_missing_asin">ASIN</string>
+  <string name="filter_value_missing_isbn">ISBN</string>
+  <string name="filter_value_missing_subtitle">Subtitle</string>
+  <string name="filter_value_missing_authors">Author</string>
+  <string name="filter_value_missing_publishedYear">Publish year</string>
+  <string name="filter_value_missing_series">Series</string>
+  <string name="filter_value_missing_description">Description</string>
+  <string name="filter_value_missing_genres">Genres</string>
+  <string name="filter_value_missing_tags">Tags</string>
+  <string name="filter_value_missing_narrators">Narrator</string>
+  <string name="filter_value_missing_publisher">Publisher</string>
+  <string name="filter_value_missing_language">Language</string>
+
+  <string name="filter_value_tracks_single">Single-track</string>
+  <string name="filter_value_tracks_multi">Multi-track</string>
+
 </resources>

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
@@ -77,7 +77,7 @@ class LibraryPresenter(
     return LibraryUiState(
       contentState = contentState,
       sort = LibrarySort(sortMode, sortDirection),
-      filter = null,
+      filter = itemFilter,
       offlineStates = offlineDownloads,
       itemDisplayState = itemDisplayState,
     ) { event ->

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
@@ -2,18 +2,18 @@ package app.campfire.libraries.ui.list
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.screens.LibraryItemScreen
 import app.campfire.common.screens.LibraryScreen
 import app.campfire.core.coroutines.LoadState
-import app.campfire.core.coroutines.map
 import app.campfire.core.di.UserScope
 import app.campfire.core.settings.ItemDisplayState
-import app.campfire.core.util.LibraryItemComparator
+import app.campfire.libraries.api.LibraryItemFilter
 import app.campfire.libraries.api.LibraryRepository
 import app.campfire.settings.api.CampfireSettings
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
@@ -39,6 +39,12 @@ class LibraryPresenter(
 
   @Composable
   override fun present(): LibraryUiState {
+    // TODO: We should store this in user preferences so it persists
+    //  between UI and process changes
+    var itemFilter by remember {
+      mutableStateOf<LibraryItemFilter?>(null)
+    }
+
     val sortMode by remember {
       settings.observeSortMode()
     }.collectAsState(settings.sortMode)
@@ -47,23 +53,18 @@ class LibraryPresenter(
       settings.observeSortDirection()
     }.collectAsState(settings.sortDirection)
 
-    val contentState by remember {
-      repository.observeLibraryItems()
+    val contentState by remember(sortMode, sortDirection, itemFilter) {
+      repository.observeLibraryItems(
+        filter = itemFilter,
+        sortMode = sortMode,
+        sortDirection = sortDirection,
+      )
         .map { LoadState.Loaded(it) }
         .catch { LoadState.Error }
     }.collectAsState(LoadState.Loading)
 
     val itemDisplayState by settings.observeLibraryItemDisplayState()
       .collectAsState(ItemDisplayState.List)
-
-    // TODO: Keep filter state and filter the above loaded content
-    val filteredContentState by remember {
-      derivedStateOf {
-        contentState.map { items ->
-          items.sortedWith(LibraryItemComparator(sortMode, sortDirection))
-        }
-      }
-    }
 
     val offlineDownloads by remember {
       snapshotFlow { contentState.dataOrNull }
@@ -74,16 +75,13 @@ class LibraryPresenter(
     }.collectAsState(emptyMap())
 
     return LibraryUiState(
-      contentState = filteredContentState,
+      contentState = contentState,
       sort = LibrarySort(sortMode, sortDirection),
+      filter = null,
       offlineStates = offlineDownloads,
       itemDisplayState = itemDisplayState,
     ) { event ->
       when (event) {
-        LibraryUiEvent.FilterClick -> {
-          // TODO: Navigate to bottom sheet filter, with result
-        }
-
         LibraryUiEvent.ToggleItemDisplayState -> {
           settings.libraryItemDisplayState = when (itemDisplayState) {
             ItemDisplayState.List -> ItemDisplayState.Grid
@@ -96,6 +94,10 @@ class LibraryPresenter(
             settings.sortDirection = sortDirection.flip()
           }
           settings.sortMode = event.mode
+        }
+
+        is LibraryUiEvent.ItemFilterSelected -> {
+          itemFilter = event.filter
         }
 
         is LibraryUiEvent.ItemClick -> navigator.goTo(LibraryItemScreen(event.libraryItem.id))

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryUi.kt
@@ -51,8 +51,10 @@ import app.campfire.core.offline.OfflineStatus
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SortDirection
 import app.campfire.core.settings.SortMode
-import app.campfire.libraries.ui.sort.SortModeResult
-import app.campfire.libraries.ui.sort.showSortModeBottomSheet
+import app.campfire.libraries.ui.list.sheets.filters.LibraryItemFilterResult
+import app.campfire.libraries.ui.list.sheets.filters.showItemFilterOverlay
+import app.campfire.libraries.ui.list.sheets.sort.SortModeResult
+import app.campfire.libraries.ui.list.sheets.sort.showSortModeBottomSheet
 import app.campfire.ui.appbar.CampfireAppBar
 import campfire.features.libraries.ui.generated.resources.Res
 import campfire.features.libraries.ui.generated.resources.empty_library_items_message
@@ -104,7 +106,17 @@ fun LibraryUi(
         onItemClick = { state.eventSink(LibraryUiEvent.ItemClick(it)) },
         itemDisplayState = state.itemDisplayState,
         onDisplayStateClick = { state.eventSink(LibraryUiEvent.ToggleItemDisplayState) },
-        onFilterClick = { state.eventSink(LibraryUiEvent.FilterClick) },
+        onFilterClick = {
+          coroutineScope.launch {
+            val result = overlayHost.showItemFilterOverlay(
+              filter = state.filter,
+            )
+
+            if (result is LibraryItemFilterResult.Selected) {
+              state.eventSink(LibraryUiEvent.ItemFilterSelected(result.filter))
+            }
+          }
+        },
         sortMode = state.sort.mode,
         sortDirection = state.sort.direction,
         onSortClick = {

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryUi.kt
@@ -51,6 +51,7 @@ import app.campfire.core.offline.OfflineStatus
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SortDirection
 import app.campfire.core.settings.SortMode
+import app.campfire.libraries.api.LibraryItemFilter
 import app.campfire.libraries.ui.list.sheets.filters.LibraryItemFilterResult
 import app.campfire.libraries.ui.list.sheets.filters.showItemFilterOverlay
 import app.campfire.libraries.ui.list.sheets.sort.SortModeResult
@@ -106,6 +107,7 @@ fun LibraryUi(
         onItemClick = { state.eventSink(LibraryUiEvent.ItemClick(it)) },
         itemDisplayState = state.itemDisplayState,
         onDisplayStateClick = { state.eventSink(LibraryUiEvent.ToggleItemDisplayState) },
+        filter = state.filter,
         onFilterClick = {
           coroutineScope.launch {
             val result = overlayHost.showItemFilterOverlay(
@@ -143,6 +145,7 @@ private fun LoadedContent(
   onItemClick: (LibraryItem) -> Unit,
   itemDisplayState: ItemDisplayState,
   onDisplayStateClick: () -> Unit,
+  filter: LibraryItemFilter?,
   onFilterClick: () -> Unit,
   sortMode: SortMode,
   sortDirection: SortDirection,
@@ -157,6 +160,7 @@ private fun LoadedContent(
       onItemClick = onItemClick,
       itemDisplayState = itemDisplayState,
       onDisplayStateClick = onDisplayStateClick,
+      filter = filter,
       onFilterClick = onFilterClick,
       sortMode = sortMode,
       sortDirection = sortDirection,
@@ -171,6 +175,7 @@ private fun LoadedContent(
       onItemClick = onItemClick,
       itemDisplayState = itemDisplayState,
       onDisplayStateClick = onDisplayStateClick,
+      filter = filter,
       onFilterClick = onFilterClick,
       sortMode = sortMode,
       sortDirection = sortDirection,
@@ -196,6 +201,7 @@ private fun LibraryGrid(
   onItemClick: (LibraryItem) -> Unit,
   itemDisplayState: ItemDisplayState,
   onDisplayStateClick: () -> Unit,
+  filter: LibraryItemFilter?,
   onFilterClick: () -> Unit,
   sortMode: SortMode,
   sortDirection: SortDirection,
@@ -219,7 +225,7 @@ private fun LibraryGrid(
         itemCount = items.size,
         itemDisplayState = itemDisplayState,
         onDisplayStateClick = onDisplayStateClick,
-        isFiltered = false,
+        isFiltered = filter != null,
         onFilterClick = onFilterClick,
         sortMode = sortMode,
         sortDirection = sortDirection,
@@ -249,6 +255,7 @@ fun LibraryList(
   onItemClick: (LibraryItem) -> Unit,
   itemDisplayState: ItemDisplayState,
   onDisplayStateClick: () -> Unit,
+  filter: LibraryItemFilter?,
   onFilterClick: () -> Unit,
   sortMode: SortMode,
   sortDirection: SortDirection,
@@ -267,7 +274,7 @@ fun LibraryList(
         itemCount = items.size,
         itemDisplayState = itemDisplayState,
         onDisplayStateClick = onDisplayStateClick,
-        isFiltered = false,
+        isFiltered = filter != null,
         onFilterClick = onFilterClick,
         sortMode = sortMode,
         sortDirection = sortDirection,

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryUiState.kt
@@ -8,6 +8,7 @@ import app.campfire.core.model.LibraryItemId
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SortDirection
 import app.campfire.core.settings.SortMode
+import app.campfire.libraries.api.LibraryItemFilter
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 
@@ -15,6 +16,7 @@ data class LibraryUiState(
   val contentState: LoadState<out List<LibraryItem>>,
   val itemDisplayState: ItemDisplayState,
   val sort: LibrarySort,
+  val filter: LibraryItemFilter?,
   val offlineStates: Map<LibraryItemId, OfflineDownload>,
   val eventSink: (LibraryUiEvent) -> Unit,
 ) : CircuitUiState
@@ -27,7 +29,7 @@ data class LibrarySort(
 
 sealed interface LibraryUiEvent : CircuitUiEvent {
   data object ToggleItemDisplayState : LibraryUiEvent
-  data object FilterClick : LibraryUiEvent
   data class SortModeSelected(val mode: SortMode) : LibraryUiEvent
+  data class ItemFilterSelected(val filter: LibraryItemFilter?) : LibraryUiEvent
   data class ItemClick(val libraryItem: LibraryItem) : LibraryUiEvent
 }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/ItemFilterPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/ItemFilterPresenter.kt
@@ -1,0 +1,78 @@
+package app.campfire.libraries.ui.list.sheets.filters
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import app.campfire.core.model.FilterData
+import app.campfire.libraries.api.LibraryItemFilter
+import app.campfire.libraries.api.filtering.FilteringRepository
+import com.slack.circuit.runtime.presenter.Presenter
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import me.tatarka.inject.annotations.Assisted
+import me.tatarka.inject.annotations.Inject
+
+typealias ItemFilterPresenterFactory = (LibraryItemFilter?, (LibraryItemFilter?) -> Unit) -> ItemFilterPresenter
+
+@Inject
+class ItemFilterPresenter(
+  @Assisted private val previousFilter: LibraryItemFilter?,
+  @Assisted private val onFilterSelected: (LibraryItemFilter?) -> Unit,
+  private val filteringRepository: FilteringRepository,
+) : Presenter<ItemFilterUiState> {
+
+  @Composable
+  override fun present(): ItemFilterUiState {
+    val filterData by remember {
+      filteringRepository.observeFilterData()
+    }.collectAsState(FilterData())
+
+    return ItemFilterUiState(
+      selected = previousFilter,
+      filters = persistentListOf(
+        UiItemFilter.Genres(filterData.genres.toPersistentList()),
+        UiItemFilter.Tags(filterData.tags.toPersistentList()),
+        UiItemFilter.Series(filterData.series.toPersistentList()),
+        UiItemFilter.Authors(filterData.authors.toPersistentList()),
+        UiItemFilter.Narrators(filterData.narrators.toPersistentList()),
+        UiItemFilter.Languages(filterData.languages.toPersistentList()),
+
+        UiItemFilter.Progress(
+          values = LibraryItemFilter.Progress.Type.entries.toPersistentList(),
+        ),
+
+        UiItemFilter.Missing(
+          values = LibraryItemFilter.Missing.Type.entries.toPersistentList(),
+        ),
+
+        UiItemFilter.Tracks(
+          values = LibraryItemFilter.Tracks.Type.entries.toPersistentList(),
+        ),
+      ),
+    ) { event ->
+      when (event) {
+        is ItemFilterUiEvent.FilterSelected<*> -> {
+          val newFilter = when (event.filter) {
+            is UiItemFilter.Authors -> {
+              val entity = event.value as FilterData.Entity
+              LibraryItemFilter.Authors(entity.id, entity.name)
+            }
+            is UiItemFilter.Genres -> LibraryItemFilter.Genres(event.value as String)
+            is UiItemFilter.Languages -> LibraryItemFilter.Languages(event.value as String)
+            is UiItemFilter.Missing -> LibraryItemFilter.Missing(event.value as LibraryItemFilter.Missing.Type)
+            is UiItemFilter.Narrators -> LibraryItemFilter.Narrators(event.value as String)
+            is UiItemFilter.Progress -> LibraryItemFilter.Progress(event.value as LibraryItemFilter.Progress.Type)
+            is UiItemFilter.Series -> {
+              val entity = event.value as FilterData.Entity
+              LibraryItemFilter.Series(entity.id, entity.name)
+            }
+            is UiItemFilter.Tags -> LibraryItemFilter.Tags(event.value as String)
+            is UiItemFilter.Tracks -> LibraryItemFilter.Tracks(event.value as LibraryItemFilter.Tracks.Type)
+          }
+          onFilterSelected(newFilter)
+        }
+      }
+    }
+  }
+}

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/ItemFilterPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/ItemFilterPresenter.kt
@@ -72,6 +72,8 @@ class ItemFilterPresenter(
           }
           onFilterSelected(newFilter)
         }
+
+        ItemFilterUiEvent.ClearFilter -> onFilterSelected(null)
       }
     }
   }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/ItemFilterUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/ItemFilterUiState.kt
@@ -1,0 +1,236 @@
+package app.campfire.libraries.ui.list.sheets.filters
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import app.campfire.core.model.FilterData
+import app.campfire.libraries.api.LibraryItemFilter
+import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.filter_category_author
+import campfire.features.libraries.ui.generated.resources.filter_category_genre
+import campfire.features.libraries.ui.generated.resources.filter_category_language
+import campfire.features.libraries.ui.generated.resources.filter_category_missing
+import campfire.features.libraries.ui.generated.resources.filter_category_narrator
+import campfire.features.libraries.ui.generated.resources.filter_category_progress
+import campfire.features.libraries.ui.generated.resources.filter_category_series
+import campfire.features.libraries.ui.generated.resources.filter_category_tag
+import campfire.features.libraries.ui.generated.resources.filter_category_tracks
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_asin
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_authors
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_description
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_genres
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_isbn
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_language
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_narrators
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_publishedYear
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_publisher
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_series
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_subtitle
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_tags
+import campfire.features.libraries.ui.generated.resources.filter_value_progress_finished
+import campfire.features.libraries.ui.generated.resources.filter_value_progress_in_progress
+import campfire.features.libraries.ui.generated.resources.filter_value_progress_not_finished
+import campfire.features.libraries.ui.generated.resources.filter_value_progress_not_started
+import campfire.features.libraries.ui.generated.resources.filter_value_tracks_multi
+import campfire.features.libraries.ui.generated.resources.filter_value_tracks_single
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import kotlinx.collections.immutable.ImmutableList
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+@Immutable
+data class ItemFilterUiState(
+  val selected: LibraryItemFilter?,
+  val filters: ImmutableList<UiItemFilter<*>>,
+  val eventSink: (ItemFilterUiEvent) -> Unit,
+) : CircuitUiState
+
+sealed interface UiItemFilter<Value : Any> {
+  val name: StringResource
+  val values: ImmutableList<Value>
+
+  fun isValueSelectedFor(filter: LibraryItemFilter, value: Value): Boolean
+
+  @Composable
+  fun valueLabel(value: Value): String
+
+  data class Genres(
+    override val values: ImmutableList<String>,
+  ) : UiItemFilter<String> {
+    override val name = Res.string.filter_category_genre
+
+    @Composable
+    override fun valueLabel(value: String): String = value
+
+    override fun isValueSelectedFor(filter: LibraryItemFilter, value: String): Boolean {
+      return when (filter) {
+        is LibraryItemFilter.Genres -> value == filter.value
+        else -> false
+      }
+    }
+  }
+
+  data class Tags(
+    override val values: ImmutableList<String>,
+  ) : UiItemFilter<String> {
+    override val name = Res.string.filter_category_tag
+
+    @Composable
+    override fun valueLabel(value: String): String = value
+
+    override fun isValueSelectedFor(filter: LibraryItemFilter, value: String): Boolean {
+      return when (filter) {
+        is LibraryItemFilter.Tags -> value == filter.value
+        else -> false
+      }
+    }
+  }
+
+  data class Series(
+    override val values: ImmutableList<FilterData.Entity>,
+  ) : UiItemFilter<FilterData.Entity> {
+    override val name = Res.string.filter_category_series
+
+    @Composable
+    override fun valueLabel(value: FilterData.Entity): String = value.name
+
+    override fun isValueSelectedFor(filter: LibraryItemFilter, value: FilterData.Entity): Boolean {
+      return when (filter) {
+        is LibraryItemFilter.Series -> value.id == filter.value
+        else -> false
+      }
+    }
+  }
+
+  data class Authors(
+    override val values: ImmutableList<FilterData.Entity>,
+  ) : UiItemFilter<FilterData.Entity> {
+    override val name = Res.string.filter_category_author
+
+    @Composable
+    override fun valueLabel(value: FilterData.Entity): String = value.name
+
+    override fun isValueSelectedFor(filter: LibraryItemFilter, value: FilterData.Entity): Boolean {
+      return when (filter) {
+        is LibraryItemFilter.Authors -> value.id == filter.value
+        else -> false
+      }
+    }
+  }
+
+  data class Progress(
+    override val values: ImmutableList<LibraryItemFilter.Progress.Type>,
+  ) : UiItemFilter<LibraryItemFilter.Progress.Type> {
+    override val name = Res.string.filter_category_progress
+
+    @Composable
+    override fun valueLabel(value: LibraryItemFilter.Progress.Type): String {
+      return when (value) {
+        LibraryItemFilter.Progress.Type.Finished -> stringResource(Res.string.filter_value_progress_finished)
+        LibraryItemFilter.Progress.Type.NotStarted -> stringResource(Res.string.filter_value_progress_not_started)
+        LibraryItemFilter.Progress.Type.NotFinished -> stringResource(Res.string.filter_value_progress_not_finished)
+        LibraryItemFilter.Progress.Type.InProgress -> stringResource(Res.string.filter_value_progress_in_progress)
+      }
+    }
+
+    override fun isValueSelectedFor(filter: LibraryItemFilter, value: LibraryItemFilter.Progress.Type): Boolean {
+      return when (filter) {
+        is LibraryItemFilter.Progress -> value.value == filter.value
+        else -> false
+      }
+    }
+  }
+
+  data class Narrators(
+    override val values: ImmutableList<String>,
+  ) : UiItemFilter<String> {
+    override val name = Res.string.filter_category_narrator
+
+    @Composable
+    override fun valueLabel(value: String): String = value
+
+    override fun isValueSelectedFor(filter: LibraryItemFilter, value: String): Boolean {
+      return when (filter) {
+        is LibraryItemFilter.Narrators -> value == filter.value
+        else -> false
+      }
+    }
+  }
+
+  data class Missing(
+    override val values: ImmutableList<LibraryItemFilter.Missing.Type>,
+  ) : UiItemFilter<LibraryItemFilter.Missing.Type> {
+    override val name = Res.string.filter_category_missing
+
+    @Composable
+    override fun valueLabel(value: LibraryItemFilter.Missing.Type): String {
+      return when (value) {
+        LibraryItemFilter.Missing.Type.ASIN -> stringResource(Res.string.filter_value_missing_asin)
+        LibraryItemFilter.Missing.Type.ISBN -> stringResource(Res.string.filter_value_missing_isbn)
+        LibraryItemFilter.Missing.Type.SUBTITLE -> stringResource(Res.string.filter_value_missing_subtitle)
+        LibraryItemFilter.Missing.Type.AUTHORS -> stringResource(Res.string.filter_value_missing_authors)
+        LibraryItemFilter.Missing.Type.PUBLISHED_YEAR -> stringResource(Res.string.filter_value_missing_publishedYear)
+        LibraryItemFilter.Missing.Type.SERIES -> stringResource(Res.string.filter_value_missing_series)
+        LibraryItemFilter.Missing.Type.DESCRIPTION -> stringResource(Res.string.filter_value_missing_description)
+        LibraryItemFilter.Missing.Type.GENRES -> stringResource(Res.string.filter_value_missing_genres)
+        LibraryItemFilter.Missing.Type.TAGS -> stringResource(Res.string.filter_value_missing_tags)
+        LibraryItemFilter.Missing.Type.NARRATORS -> stringResource(Res.string.filter_value_missing_narrators)
+        LibraryItemFilter.Missing.Type.PUBLISHER -> stringResource(Res.string.filter_value_missing_publisher)
+        LibraryItemFilter.Missing.Type.LANGUAGE -> stringResource(Res.string.filter_value_missing_language)
+      }
+    }
+
+    override fun isValueSelectedFor(filter: LibraryItemFilter, value: LibraryItemFilter.Missing.Type): Boolean {
+      return when (filter) {
+        is LibraryItemFilter.Missing -> value.value == filter.value
+        else -> false
+      }
+    }
+  }
+
+  data class Languages(
+    override val values: ImmutableList<String>,
+  ) : UiItemFilter<String> {
+    override val name = Res.string.filter_category_language
+
+    @Composable
+    override fun valueLabel(value: String): String = value
+
+    override fun isValueSelectedFor(filter: LibraryItemFilter, value: String): Boolean {
+      return when (filter) {
+        is LibraryItemFilter.Languages -> value == filter.value
+        else -> false
+      }
+    }
+  }
+
+  data class Tracks(
+    override val values: ImmutableList<LibraryItemFilter.Tracks.Type>,
+  ) : UiItemFilter<LibraryItemFilter.Tracks.Type> {
+    override val name = Res.string.filter_category_tracks
+
+    @Composable
+    override fun valueLabel(value: LibraryItemFilter.Tracks.Type): String {
+      return when (value) {
+        LibraryItemFilter.Tracks.Type.Single -> stringResource(Res.string.filter_value_tracks_single)
+        LibraryItemFilter.Tracks.Type.Multi -> stringResource(Res.string.filter_value_tracks_multi)
+      }
+    }
+
+    override fun isValueSelectedFor(
+      filter: LibraryItemFilter,
+      value: LibraryItemFilter.Tracks.Type,
+    ): Boolean = when (filter) {
+      is LibraryItemFilter.Tracks -> value.value == filter.value
+      else -> false
+    }
+  }
+}
+
+sealed interface ItemFilterUiEvent : CircuitUiEvent {
+
+  data class FilterSelected<Value : Any>(
+    val filter: UiItemFilter<Value>,
+    val value: Any,
+  ) : ItemFilterUiEvent
+}

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/ItemFilterUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/ItemFilterUiState.kt
@@ -2,6 +2,7 @@ package app.campfire.libraries.ui.list.sheets.filters
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import app.campfire.core.logging.bark
 import app.campfire.core.model.FilterData
 import app.campfire.libraries.api.LibraryItemFilter
 import campfire.features.libraries.ui.generated.resources.Res
@@ -64,7 +65,10 @@ sealed interface UiItemFilter<Value : Any> {
 
     override fun isValueSelectedFor(filter: LibraryItemFilter, value: String): Boolean {
       return when (filter) {
-        is LibraryItemFilter.Genres -> value == filter.value
+        is LibraryItemFilter.Genres -> {
+          bark { "${filter.value} == $value" }
+          value == filter.value
+        }
         else -> false
       }
     }
@@ -228,7 +232,7 @@ sealed interface UiItemFilter<Value : Any> {
 }
 
 sealed interface ItemFilterUiEvent : CircuitUiEvent {
-
+  data object ClearFilter : ItemFilterUiEvent
   data class FilterSelected<Value : Any>(
     val filter: UiItemFilter<Value>,
     val value: Any,

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/LibraryItemFilterBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/LibraryItemFilterBottomSheet.kt
@@ -1,7 +1,6 @@
 package app.campfire.libraries.ui.list.sheets.filters
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
@@ -365,7 +364,7 @@ private fun filterValueLabel(
   is LibraryItemFilter.Languages,
   is LibraryItemFilter.Narrators,
   is LibraryItemFilter.Tags,
-    -> filter.value
+  -> filter.value
 
   is LibraryItemFilter.Missing -> when (filter.type) {
     LibraryItemFilter.Missing.Type.ASIN -> stringResource(Res.string.filter_value_missing_asin)

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/LibraryItemFilterBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/LibraryItemFilterBottomSheet.kt
@@ -19,10 +19,15 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.ArrowRight
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -33,11 +38,44 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.di.rememberComponent
 import app.campfire.common.compose.widgets.bottomSheetShape
 import app.campfire.core.di.UserScope
+import app.campfire.core.extensions.fluentIf
 import app.campfire.libraries.api.LibraryItemFilter
+import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.filter_category_author
+import campfire.features.libraries.ui.generated.resources.filter_category_genre
+import campfire.features.libraries.ui.generated.resources.filter_category_language
+import campfire.features.libraries.ui.generated.resources.filter_category_missing
+import campfire.features.libraries.ui.generated.resources.filter_category_narrator
+import campfire.features.libraries.ui.generated.resources.filter_category_progress
+import campfire.features.libraries.ui.generated.resources.filter_category_series
+import campfire.features.libraries.ui.generated.resources.filter_category_tag
+import campfire.features.libraries.ui.generated.resources.filter_category_tracks
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_asin
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_authors
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_description
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_genres
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_isbn
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_language
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_narrators
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_publishedYear
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_publisher
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_series
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_subtitle
+import campfire.features.libraries.ui.generated.resources.filter_value_missing_tags
+import campfire.features.libraries.ui.generated.resources.filter_value_progress_finished
+import campfire.features.libraries.ui.generated.resources.filter_value_progress_in_progress
+import campfire.features.libraries.ui.generated.resources.filter_value_progress_not_finished
+import campfire.features.libraries.ui.generated.resources.filter_value_progress_not_started
+import campfire.features.libraries.ui.generated.resources.filter_value_tracks_multi
+import campfire.features.libraries.ui.generated.resources.filter_value_tracks_single
 import com.r0adkll.kimchi.annotations.ContributesTo
 import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuitx.overlays.BottomSheetOverlay
@@ -110,11 +148,16 @@ private fun LibraryItemFilterBottomSheet(
       if (state == null) {
         FilterGroupList(
           filters = viewState.filters,
+          currentItemFilter = viewState.selected,
           onItemClick = { selectedFilter = it },
+          onClearClick = {
+            viewState.eventSink(ItemFilterUiEvent.ClearFilter)
+          },
         )
       } else {
         FilterGroupOptionList(
           selectedFilter = state,
+          currentItemFilter = viewState.selected,
           onBackClick = { selectedFilter = null },
           onFilterOptionClick = { value ->
             viewState.eventSink(ItemFilterUiEvent.FilterSelected(state, value))
@@ -128,19 +171,63 @@ private fun LibraryItemFilterBottomSheet(
 @Composable
 private fun FilterGroupList(
   filters: List<UiItemFilter<*>>,
+  currentItemFilter: LibraryItemFilter?,
   onItemClick: (UiItemFilter<*>) -> Unit,
+  onClearClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  LazyColumn(
-    modifier = modifier,
-  ) {
-    items(filters) { filter ->
-      FilterGroupListItem(
-        filter = filter,
-        onClick = { onItemClick(filter) },
+  Column(modifier = modifier) {
+    if (currentItemFilter != null) {
+      CurrentFilterListItem(
+        currentItemFilter = currentItemFilter,
+        onClearClick = onClearClick,
       )
     }
+    LazyColumn {
+      items(filters) { filter ->
+        FilterGroupListItem(
+          filter = filter,
+          onClick = { onItemClick(filter) },
+        )
+      }
+    }
   }
+}
+
+@Composable
+private fun CurrentFilterListItem(
+  currentItemFilter: LibraryItemFilter,
+  onClearClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  ListItem(
+    modifier = modifier,
+    headlineContent = {
+      Text(
+        buildAnnotatedString {
+          withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+            append(filterGroupLabel(currentItemFilter))
+            append(':')
+          }
+          append(' ')
+          append(filterValueLabel(currentItemFilter))
+        },
+      )
+    },
+    trailingContent = {
+      Button(
+        onClick = onClearClick,
+      ) {
+        Text("Clear")
+      }
+    },
+    colors = ListItemDefaults.colors(
+      containerColor = MaterialTheme.colorScheme.primaryContainer,
+      headlineColor = MaterialTheme.colorScheme.onPrimaryContainer,
+      leadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+      trailingIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    ),
+  )
 }
 
 @Composable
@@ -157,9 +244,10 @@ private fun FilterGroupListItem(
         Text(
           text = filter.values.size.toString(),
           style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSecondaryContainer,
           modifier = Modifier
             .background(
-              color = MaterialTheme.colorScheme.primaryContainer,
+              color = MaterialTheme.colorScheme.secondaryContainer,
               shape = MaterialTheme.shapes.small,
             )
             .padding(
@@ -180,6 +268,7 @@ private fun FilterGroupListItem(
 @Composable
 private fun <T : Any> FilterGroupOptionList(
   selectedFilter: UiItemFilter<T>,
+  currentItemFilter: LibraryItemFilter?,
   onBackClick: () -> Unit,
   onFilterOptionClick: (Any) -> Unit,
   modifier: Modifier = Modifier,
@@ -209,6 +298,7 @@ private fun <T : Any> FilterGroupOptionList(
         FilterOptionListItem(
           filter = selectedFilter,
           value = option,
+          selected = currentItemFilter != null && selectedFilter.isValueSelectedFor(currentItemFilter, option),
           onClick = { onFilterOptionClick(option) },
         )
       }
@@ -220,6 +310,7 @@ private fun <T : Any> FilterGroupOptionList(
 private fun <T : Any> FilterOptionListItem(
   filter: UiItemFilter<T>,
   value: T,
+  selected: Boolean,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -227,7 +318,76 @@ private fun <T : Any> FilterOptionListItem(
     text = {
       Text(filter.valueLabel(value))
     },
+    colors = if (selected) {
+      MenuDefaults.itemColors()
+    } else {
+      MenuDefaults.itemColors()
+    },
+    trailingIcon = if (selected) {
+      { Icon(Icons.Rounded.Check, contentDescription = null) }
+    } else {
+      null
+    },
     onClick = onClick,
-    modifier = modifier,
+    modifier = modifier
+      .fluentIf(selected) {
+        background(MaterialTheme.colorScheme.primaryContainer)
+      },
   )
+}
+
+@Composable
+private fun filterGroupLabel(
+  filter: LibraryItemFilter,
+): String = when (filter) {
+  is LibraryItemFilter.Authors -> stringResource(Res.string.filter_category_author)
+  is LibraryItemFilter.Genres -> stringResource(Res.string.filter_category_genre)
+  is LibraryItemFilter.Languages -> stringResource(Res.string.filter_category_language)
+  is LibraryItemFilter.Missing -> stringResource(Res.string.filter_category_missing)
+  is LibraryItemFilter.Narrators -> stringResource(Res.string.filter_category_narrator)
+  is LibraryItemFilter.Progress -> stringResource(Res.string.filter_category_progress)
+  is LibraryItemFilter.Series -> stringResource(Res.string.filter_category_series)
+  is LibraryItemFilter.Tags -> stringResource(Res.string.filter_category_tag)
+  is LibraryItemFilter.Tracks -> stringResource(Res.string.filter_category_tracks)
+}
+
+@Composable
+private fun filterValueLabel(
+  filter: LibraryItemFilter,
+): String = when (filter) {
+  is LibraryItemFilter.Authors -> filter.authorName
+  is LibraryItemFilter.Series -> filter.seriesName
+
+  is LibraryItemFilter.Genres,
+  is LibraryItemFilter.Languages,
+  is LibraryItemFilter.Narrators,
+  is LibraryItemFilter.Tags,
+  -> filter.value
+
+  is LibraryItemFilter.Missing -> when (filter.type) {
+    LibraryItemFilter.Missing.Type.ASIN -> stringResource(Res.string.filter_value_missing_asin)
+    LibraryItemFilter.Missing.Type.ISBN -> stringResource(Res.string.filter_value_missing_isbn)
+    LibraryItemFilter.Missing.Type.SUBTITLE -> stringResource(Res.string.filter_value_missing_subtitle)
+    LibraryItemFilter.Missing.Type.AUTHORS -> stringResource(Res.string.filter_value_missing_authors)
+    LibraryItemFilter.Missing.Type.PUBLISHED_YEAR -> stringResource(Res.string.filter_value_missing_publishedYear)
+    LibraryItemFilter.Missing.Type.SERIES -> stringResource(Res.string.filter_value_missing_series)
+    LibraryItemFilter.Missing.Type.DESCRIPTION -> stringResource(Res.string.filter_value_missing_description)
+    LibraryItemFilter.Missing.Type.GENRES -> stringResource(Res.string.filter_value_missing_genres)
+    LibraryItemFilter.Missing.Type.TAGS -> stringResource(Res.string.filter_value_missing_tags)
+    LibraryItemFilter.Missing.Type.NARRATORS -> stringResource(Res.string.filter_value_missing_narrators)
+    LibraryItemFilter.Missing.Type.PUBLISHER -> stringResource(Res.string.filter_value_missing_publisher)
+    LibraryItemFilter.Missing.Type.LANGUAGE -> stringResource(Res.string.filter_value_missing_language)
+  }
+
+  is LibraryItemFilter.Progress -> when (filter.type) {
+    LibraryItemFilter.Progress.Type.Finished -> stringResource(Res.string.filter_value_progress_finished)
+    LibraryItemFilter.Progress.Type.NotStarted -> stringResource(Res.string.filter_value_progress_not_started)
+    LibraryItemFilter.Progress.Type.NotFinished -> stringResource(Res.string.filter_value_progress_not_finished)
+    LibraryItemFilter.Progress.Type.InProgress -> stringResource(Res.string.filter_value_progress_in_progress)
+  }
+
+  is LibraryItemFilter.Tracks -> when (filter.type) {
+    LibraryItemFilter.Tracks.Type.Single -> stringResource(Res.string.filter_value_tracks_single)
+    LibraryItemFilter.Tracks.Type.Multi -> stringResource(Res.string.filter_value_tracks_multi)
+  }
 }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/LibraryItemFilterBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/LibraryItemFilterBottomSheet.kt
@@ -1,0 +1,233 @@
+package app.campfire.libraries.ui.list.sheets.filters
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowRight
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.di.rememberComponent
+import app.campfire.common.compose.widgets.bottomSheetShape
+import app.campfire.core.di.UserScope
+import app.campfire.libraries.api.LibraryItemFilter
+import com.r0adkll.kimchi.annotations.ContributesTo
+import com.slack.circuit.overlay.OverlayHost
+import com.slack.circuitx.overlays.BottomSheetOverlay
+import org.jetbrains.compose.resources.stringResource
+
+sealed interface LibraryItemFilterResult {
+  data object None : LibraryItemFilterResult
+  data class Selected(val filter: LibraryItemFilter?) : LibraryItemFilterResult
+}
+
+private sealed interface ItemFilter {
+  data object None : ItemFilter
+  data class Current(val filter: LibraryItemFilter) : ItemFilter
+}
+
+@ContributesTo(UserScope::class)
+interface LibraryItemFilterBottomSheetComponent {
+  val itemFilterPresenterFactory: ItemFilterPresenterFactory
+}
+
+suspend fun OverlayHost.showItemFilterOverlay(
+  filter: LibraryItemFilter?,
+): LibraryItemFilterResult {
+  return show(
+    BottomSheetOverlay<ItemFilter, LibraryItemFilterResult>(
+      model = filter?.let { ItemFilter.Current(it) } ?: ItemFilter.None,
+      onDismiss = { LibraryItemFilterResult.None },
+      sheetShape = bottomSheetShape,
+      skipPartiallyExpandedState = true,
+    ) { filter, overlayNavigator ->
+      LibraryItemFilterBottomSheet(
+        filter = (filter as? ItemFilter.Current)?.filter,
+        onSelected = {
+          overlayNavigator.finish(LibraryItemFilterResult.Selected(it))
+        },
+      )
+      Spacer(
+        Modifier.navigationBarsPadding(),
+      )
+    },
+  )
+}
+
+@Composable
+private fun LibraryItemFilterBottomSheet(
+  filter: LibraryItemFilter?,
+  onSelected: (LibraryItemFilter?) -> Unit,
+  modifier: Modifier = Modifier,
+  component: LibraryItemFilterBottomSheetComponent = rememberComponent(),
+) {
+  val presenter = remember { component.itemFilterPresenterFactory(filter, onSelected) }
+  val viewState = presenter.present()
+
+  Column(
+    modifier = modifier
+      .navigationBarsPadding(),
+  ) {
+    var selectedFilter by remember { mutableStateOf<UiItemFilter<*>?>(null) }
+
+    AnimatedContent(
+      targetState = selectedFilter,
+      transitionSpec = {
+        (
+          fadeIn(animationSpec = tween(220, delayMillis = 90)) +
+            slideInHorizontally(animationSpec = tween(220, delayMillis = 90)) { it }
+          )
+          .togetherWith(slideOutHorizontally(animationSpec = tween(90)) { it })
+      },
+    ) { state ->
+      if (state == null) {
+        FilterGroupList(
+          filters = viewState.filters,
+          onItemClick = { selectedFilter = it },
+        )
+      } else {
+        FilterGroupOptionList(
+          selectedFilter = state,
+          onBackClick = { selectedFilter = null },
+          onFilterOptionClick = { value ->
+            viewState.eventSink(ItemFilterUiEvent.FilterSelected(state, value))
+          },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun FilterGroupList(
+  filters: List<UiItemFilter<*>>,
+  onItemClick: (UiItemFilter<*>) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  LazyColumn(
+    modifier = modifier,
+  ) {
+    items(filters) { filter ->
+      FilterGroupListItem(
+        filter = filter,
+        onClick = { onItemClick(filter) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun FilterGroupListItem(
+  filter: UiItemFilter<*>,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  DropdownMenuItem(
+    text = {
+      Row {
+        Text(stringResource(filter.name))
+        Spacer(Modifier.width(8.dp))
+        Text(
+          text = filter.values.size.toString(),
+          style = MaterialTheme.typography.labelSmall,
+          modifier = Modifier
+            .background(
+              color = MaterialTheme.colorScheme.primaryContainer,
+              shape = MaterialTheme.shapes.small,
+            )
+            .padding(
+              horizontal = 8.dp,
+              vertical = 4.dp,
+            ),
+        )
+      }
+    },
+    trailingIcon = {
+      Icon(Icons.AutoMirrored.Rounded.ArrowRight, contentDescription = null)
+    },
+    onClick = onClick,
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun <T : Any> FilterGroupOptionList(
+  selectedFilter: UiItemFilter<T>,
+  onBackClick: () -> Unit,
+  onFilterOptionClick: (Any) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = modifier,
+  ) {
+    TopAppBar(
+      navigationIcon = {
+        IconButton(
+          onClick = onBackClick,
+        ) {
+          Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+        }
+      },
+      title = {
+        Text(text = stringResource(selectedFilter.name))
+      },
+      windowInsets = WindowInsets(0),
+      colors = TopAppBarDefaults.topAppBarColors(
+        containerColor = Color.Transparent,
+      ),
+    )
+
+    LazyColumn {
+      items(selectedFilter.values) { option ->
+        FilterOptionListItem(
+          filter = selectedFilter,
+          value = option,
+          onClick = { onFilterOptionClick(option) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun <T : Any> FilterOptionListItem(
+  filter: UiItemFilter<T>,
+  value: T,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  DropdownMenuItem(
+    text = {
+      Text(filter.valueLabel(value))
+    },
+    onClick = onClick,
+    modifier = modifier,
+  )
+}

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/LibraryItemFilterBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/filters/LibraryItemFilterBottomSheet.kt
@@ -3,6 +3,7 @@ package app.campfire.libraries.ui.list.sheets.filters
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
@@ -138,11 +139,13 @@ private fun LibraryItemFilterBottomSheet(
     AnimatedContent(
       targetState = selectedFilter,
       transitionSpec = {
-        (
-          fadeIn(animationSpec = tween(220, delayMillis = 90)) +
-            slideInHorizontally(animationSpec = tween(220, delayMillis = 90)) { it }
-          )
-          .togetherWith(slideOutHorizontally(animationSpec = tween(90)) { it })
+        if (targetState == null) {
+          (fadeIn() + slideInHorizontally { -it })
+            .togetherWith(slideOutHorizontally { it })
+        } else {
+          slideInHorizontally { it }
+            .togetherWith(fadeOut() + slideOutHorizontally { -it })
+        }
       },
     ) { state ->
       if (state == null) {
@@ -362,7 +365,7 @@ private fun filterValueLabel(
   is LibraryItemFilter.Languages,
   is LibraryItemFilter.Narrators,
   is LibraryItemFilter.Tags,
-  -> filter.value
+    -> filter.value
 
   is LibraryItemFilter.Missing -> when (filter.type) {
     LibraryItemFilter.Missing.Type.ASIN -> stringResource(Res.string.filter_value_missing_asin)

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/sort/SortModeBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/sheets/sort/SortModeBottomSheet.kt
@@ -1,4 +1,4 @@
-package app.campfire.libraries.ui.sort
+package app.campfire.libraries.ui.list.sheets.sort
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column

--- a/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
+++ b/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
@@ -17,6 +17,7 @@ import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.asFetcherResult
 import app.campfire.data.mapping.dao.LibraryItemDao
 import app.campfire.network.AudioBookShelfApi
+import app.campfire.network.models.LibraryItemFilter
 import app.campfire.network.models.Series as NetworkSeries
 import app.campfire.series.api.SeriesRepository
 import app.campfire.user.api.UserRepository
@@ -119,8 +120,13 @@ class StoreSeriesRepository(
   @OptIn(ExperimentalEncodingApi::class)
   private val libraryItemStore = StoreBuilder.from(
     fetcher = Fetcher.ofResult { s: SeriesItems ->
-      val encodedSeriesId = Base64.encode(s.seriesId.encodeToByteArray())
-      api.getLibraryItemsMinified(s.libraryId, "series.$encodedSeriesId").asFetcherResult()
+      api.getLibraryItemsMinified(
+        libraryId = s.libraryId,
+        filter = LibraryItemFilter(
+          group = "series",
+          value = s.seriesId,
+        ),
+      ).asFetcherResult()
     },
     sourceOfTruth = SourceOfTruth.of(
       reader = { s: SeriesItems ->
@@ -137,7 +143,7 @@ class StoreSeriesRepository(
       writer = { s, items ->
         withContext(dispatcherProvider.databaseWrite) {
           db.transaction {
-            items.forEach { item ->
+            items.data.forEach { item ->
               // TODO: Update when https://github.com/advplyr/audiobookshelf/pull/3945 is merged
 //              libraryItemDao.insert(
 //                item = item,

--- a/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
+++ b/features/series/impl/src/commonMain/kotlin/app/campfire/series/StoreSeriesRepository.kt
@@ -25,7 +25,6 @@ import app.cash.sqldelight.async.coroutines.awaitAsList
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.r0adkll.kimchi.annotations.ContributesBinding
-import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/bookmarks/BookmarksBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/bookmarks/BookmarksBottomSheet.kt
@@ -62,6 +62,7 @@ import app.campfire.common.compose.icons.rounded.Bookmark
 import app.campfire.common.compose.icons.rounded.BookmarkStar
 import app.campfire.common.compose.widgets.FilledTonalIconButton
 import app.campfire.common.compose.widgets.SizedIcon
+import app.campfire.common.compose.widgets.bottomSheetShape
 import app.campfire.common.compose.widgets.circularReveal
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.coroutines.onError
@@ -120,10 +121,7 @@ suspend fun OverlayHost.showBookmarksBottomSheet(libraryItemId: LibraryItemId): 
     BottomSheetOverlay<LibraryItemId, BookmarkResult>(
       model = libraryItemId,
       onDismiss = { BookmarkResult.None },
-      sheetShape = RoundedCornerShape(
-        topStart = 32.dp,
-        topEnd = 32.dp,
-      ),
+      sheetShape = bottomSheetShape,
       skipPartiallyExpandedState = true,
     ) { id, overlayNavigator ->
       SessionSheetLayout(


### PR DESCRIPTION
Add a new bottom sheet to the library items tab that lets you filter based on filtering data returned from the server. Such as genres, tags, narrators, authors, etc

![Screen_recording_20251001_103741](https://github.com/user-attachments/assets/7afbdd32-c513-41f0-aab0-403c807df02a)
