### PR TITLE
Fixed remaining search target destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ TODO: Use https://github.com/ffurrer2/extract-release-notes when crafting a rele
 
 ### Fixed
 
+- Navigating from search for Narrators, Genres, and Tags now works
+
 ### Other Notes & Contributions
 
 ## [0.4.0-alpha] - 2025-07-07

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/HomeUi.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/HomeUi.kt
@@ -298,7 +298,7 @@ private fun HomeNavigationRail(
         icon = {
           HomeNavigationItemIcon(
             item = item,
-            selected = item.screen.instanceOf(selectedNavigation::class)
+            selected = item.screen.instanceOf(selectedNavigation::class),
           )
         },
         alwaysShowLabel = false,

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/HomeUi.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/HomeUi.kt
@@ -57,13 +57,13 @@ import app.campfire.common.screens.CollectionsScreen
 import app.campfire.common.screens.DrawerScreen
 import app.campfire.common.screens.EmptyScreen
 import app.campfire.common.screens.HomeScreen
-import app.campfire.common.screens.LibraryScreen
 import app.campfire.common.screens.SeriesScreen
 import app.campfire.common.screens.SettingsScreen
 import app.campfire.core.Platform
 import app.campfire.core.currentPlatform
 import app.campfire.core.extensions.fluentIf
 import app.campfire.core.logging.bark
+import app.campfire.libraries.api.screen.LibraryScreen
 import app.campfire.search.ui.CampfireDockedSearchBar
 import app.campfire.search.ui.showSearchOverlay
 import app.campfire.sessions.ui.PlaybackBar
@@ -91,6 +91,7 @@ import com.slack.circuit.overlay.rememberOverlayHost
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuitx.gesturenavigation.GestureNavigationDecorationFactory
+import io.ktor.util.reflect.instanceOf
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
@@ -255,7 +256,7 @@ private fun HomeNavigationBar(
         icon = {
           HomeNavigationItemIcon(
             item = item,
-            selected = selectedNavigation == item.screen,
+            selected = item.screen.instanceOf(selectedNavigation::class),
           )
         },
         label = { Text(text = item.label) },
@@ -297,7 +298,7 @@ private fun HomeNavigationRail(
         icon = {
           HomeNavigationItemIcon(
             item = item,
-            selected = selectedNavigation == item.screen,
+            selected = item.screen.instanceOf(selectedNavigation::class)
           )
         },
         alwaysShowLabel = false,
@@ -361,7 +362,7 @@ private fun buildNavigationItems(): List<HomeNavigationItem> {
       selectedImageVector = Icons.Filled.Home,
     ),
     HomeNavigationItem(
-      screen = LibraryScreen,
+      screen = LibraryScreen(),
       label = stringResource(Res.string.nav_library_label),
       contentDescription = stringResource(Res.string.nav_library_content_description),
       iconImageVector = Icons.Outlined.Library,

--- a/common/screens/build.gradle.kts
+++ b/common/screens/build.gradle.kts
@@ -1,9 +1,7 @@
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
-
 plugins {
   id("app.campfire.android.library")
   id("app.campfire.multiplatform")
-  alias(libs.plugins.kotlin.parcelize)
+  id("app.campfire.parcelize")
 }
 
 kotlin {
@@ -13,22 +11,6 @@ kotlin {
         api(projects.core)
         api(libs.circuit.runtime)
         api(libs.circuit.retained)
-      }
-    }
-  }
-
-  targets.configureEach {
-    val isAndroidTarget = platformType == KotlinPlatformType.androidJvm
-    compilations.configureEach {
-      compileTaskProvider.configure {
-        compilerOptions {
-          if (isAndroidTarget) {
-            freeCompilerArgs.addAll(
-              "-P",
-              "plugin:org.jetbrains.kotlin.parcelize:additionalAnnotation=app.campfire.common.screens.Parcelize",
-            )
-          }
-        }
       }
     }
   }

--- a/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
+++ b/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
@@ -2,7 +2,6 @@ package app.campfire.common.screens
 
 import app.campfire.core.model.AuthorId
 import app.campfire.core.model.CollectionId
-import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.SeriesId
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.screen.StaticScreen
@@ -49,11 +48,6 @@ data object HomeScreen : BaseScreen(name = "Home()")
 
 @Parcelize
 data object DrawerScreen : StaticScreen
-
-@Parcelize
-data class LibraryItemScreen(
-  val libraryItemId: LibraryItemId,
-) : DetailScreen(name = "LibraryItem()")
 
 @Parcelize
 data object SeriesScreen : BaseScreen(name = "Series()")

--- a/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
+++ b/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
@@ -3,9 +3,9 @@ package app.campfire.common.screens
 import app.campfire.core.model.AuthorId
 import app.campfire.core.model.CollectionId
 import app.campfire.core.model.SeriesId
+import app.campfire.core.parcelize.Parcelize
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.screen.StaticScreen
-import app.campfire.core.parcelize.Parcelize
 
 //region App Screens
 

--- a/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
+++ b/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
@@ -6,6 +6,7 @@ import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.SeriesId
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.runtime.screen.StaticScreen
+import app.campfire.core.parcelize.Parcelize
 
 //region App Screens
 
@@ -48,9 +49,6 @@ data object HomeScreen : BaseScreen(name = "Home()")
 
 @Parcelize
 data object DrawerScreen : StaticScreen
-
-@Parcelize
-data object LibraryScreen : BaseScreen(name = "Library()")
 
 @Parcelize
 data class LibraryItemScreen(

--- a/core/src/androidMain/kotlin/app.campfire.core/parcelize/Parcelable.android.kt
+++ b/core/src/androidMain/kotlin/app.campfire.core/parcelize/Parcelable.android.kt
@@ -1,0 +1,5 @@
+package app.campfire.core.parcelize
+
+import android.os.Parcelable
+
+actual typealias Parcelable = Parcelable

--- a/core/src/commonMain/kotlin/app.campfire.core/parcelize/Parcelable.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/parcelize/Parcelable.kt
@@ -1,0 +1,3 @@
+package app.campfire.core.parcelize
+
+expect interface Parcelable

--- a/core/src/commonMain/kotlin/app.campfire.core/parcelize/Parcelize.kt
+++ b/core/src/commonMain/kotlin/app.campfire.core/parcelize/Parcelize.kt
@@ -1,4 +1,4 @@
-package app.campfire.common.screens
+package app.campfire.core.parcelize
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)

--- a/core/src/iosMain/kotlin/app.campfire.core/parcelize/Parcelable.ios.kt
+++ b/core/src/iosMain/kotlin/app.campfire.core/parcelize/Parcelable.ios.kt
@@ -1,0 +1,3 @@
+package app.campfire.core.parcelize
+
+actual interface Parcelable

--- a/core/src/jvmMain/kotlin/app.campfire.core/parcelize/Parcelable.jvm.kt
+++ b/core/src/jvmMain/kotlin/app.campfire.core/parcelize/Parcelable.jvm.kt
@@ -1,0 +1,3 @@
+package app.campfire.core.parcelize
+
+actual interface Parcelable

--- a/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailPresenter.kt
+++ b/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailPresenter.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.author.api.AuthorRepository
 import app.campfire.common.screens.AuthorDetailScreen
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject

--- a/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailPresenter.kt
+++ b/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailPresenter.kt
@@ -8,9 +8,9 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.author.api.AuthorRepository
 import app.campfire.common.screens.AuthorDetailScreen
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/CollectionDetailPresenter.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/CollectionDetailPresenter.kt
@@ -9,9 +9,9 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.collections.api.CollectionsRepository
 import app.campfire.common.screens.CollectionDetailScreen
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/CollectionDetailPresenter.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/CollectionDetailPresenter.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.collections.api.CollectionsRepository
 import app.campfire.common.screens.CollectionDetailScreen
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject

--- a/features/home/ui/src/commonMain/kotlin/app/campfire/home/ui/HomePresenter.kt
+++ b/features/home/ui/src/commonMain/kotlin/app/campfire/home/ui/HomePresenter.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.screens.AuthorDetailScreen
 import app.campfire.common.screens.HomeScreen
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope

--- a/features/home/ui/src/commonMain/kotlin/app/campfire/home/ui/HomePresenter.kt
+++ b/features/home/ui/src/commonMain/kotlin/app/campfire/home/ui/HomePresenter.kt
@@ -8,12 +8,12 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.screens.AuthorDetailScreen
 import app.campfire.common.screens.HomeScreen
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryItem
 import app.campfire.home.api.HomeRepository
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter

--- a/features/libraries/api/build.gradle.kts
+++ b/features/libraries/api/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
+  id("app.campfire.android.library")
   id("app.campfire.multiplatform")
+  id("app.campfire.parcelize")
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -8,6 +10,7 @@ kotlin {
     commonMain {
       dependencies {
         implementation(projects.core)
+        implementation(projects.common.screens)
       }
     }
   }

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryItemFilter.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryItemFilter.kt
@@ -2,23 +2,29 @@ package app.campfire.libraries.api
 
 import app.campfire.core.model.AuthorId
 import app.campfire.core.model.SeriesId
+import app.campfire.core.parcelize.Parcelable
+import app.campfire.core.parcelize.Parcelize
 
-sealed interface LibraryItemFilter {
+@Parcelize
+sealed interface LibraryItemFilter : Parcelable {
   val group: String
   val value: String
 
+  @Parcelize
   class Genres(
     override val value: String,
   ) : LibraryItemFilter {
     override val group: String = "genres"
   }
 
+  @Parcelize
   class Tags(
     override val value: String,
   ) : LibraryItemFilter {
     override val group: String = "tags"
   }
 
+  @Parcelize
   class Series(
     override val value: SeriesId,
     val seriesName: String,
@@ -26,6 +32,7 @@ sealed interface LibraryItemFilter {
     override val group: String = "series"
   }
 
+  @Parcelize
   class Authors(
     val authorId: AuthorId,
     val authorName: String,
@@ -34,6 +41,7 @@ sealed interface LibraryItemFilter {
     override val group: String = "authors"
   }
 
+  @Parcelize
   class Progress(
     val type: Type,
   ) : LibraryItemFilter {
@@ -48,12 +56,14 @@ sealed interface LibraryItemFilter {
     }
   }
 
+  @Parcelize
   class Narrators(
     override val value: String,
   ) : LibraryItemFilter {
     override val group: String = "narrators"
   }
 
+  @Parcelize
   class Missing(
     val type: Type,
   ) : LibraryItemFilter {
@@ -76,12 +86,14 @@ sealed interface LibraryItemFilter {
     }
   }
 
+  @Parcelize
   class Languages(
     override val value: String,
   ) : LibraryItemFilter {
     override val group: String = "languages"
   }
 
+  @Parcelize
   class Tracks(
     val type: Type,
   ) : LibraryItemFilter {

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryRepository.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryRepository.kt
@@ -3,7 +3,6 @@ package app.campfire.libraries.api
 import app.campfire.core.model.Library
 import app.campfire.core.model.LibraryId
 import app.campfire.core.model.LibraryItem
-import app.campfire.libraries.api.LibraryItemFilter
 import app.campfire.core.settings.SortDirection
 import app.campfire.core.settings.SortMode
 import kotlinx.coroutines.flow.Flow

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryRepository.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryRepository.kt
@@ -3,6 +3,7 @@ package app.campfire.libraries.api
 import app.campfire.core.model.Library
 import app.campfire.core.model.LibraryId
 import app.campfire.core.model.LibraryItem
+import app.campfire.libraries.api.LibraryItemFilter
 import app.campfire.core.settings.SortDirection
 import app.campfire.core.settings.SortMode
 import kotlinx.coroutines.flow.Flow

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/screen/LibraryItemScreen.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/screen/LibraryItemScreen.kt
@@ -1,0 +1,10 @@
+package app.campfire.libraries.api.screen
+
+import app.campfire.common.screens.DetailScreen
+import app.campfire.core.model.LibraryItemId
+import app.campfire.core.parcelize.Parcelize
+
+@Parcelize
+data class LibraryItemScreen(
+  val libraryItemId: LibraryItemId,
+) : DetailScreen(name = "LibraryItem()")

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/screen/LibraryScreen.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/screen/LibraryScreen.kt
@@ -1,0 +1,10 @@
+package app.campfire.libraries.api.screen
+
+import app.campfire.common.screens.BaseScreen
+import app.campfire.core.parcelize.Parcelize
+import app.campfire.libraries.api.LibraryItemFilter
+
+@Parcelize
+data class LibraryScreen(
+  val filter: LibraryItemFilter? = null,
+) : BaseScreen(name = "Library()")

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
@@ -9,11 +9,11 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.audioplayer.PlaybackController
 import app.campfire.audioplayer.offline.OfflineDownloadManager
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.libraries.api.LibraryItemRepository
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.series.api.SeriesRepository
 import app.campfire.sessions.api.SessionsRepository
 import app.campfire.settings.api.CampfireSettings

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.audioplayer.PlaybackController
 import app.campfire.audioplayer.offline.OfflineDownloadManager
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
@@ -59,7 +59,6 @@ import app.campfire.common.compose.widgets.CoverImage
 import app.campfire.common.compose.widgets.ErrorListState
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.MetadataHeader
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.coroutines.onLoaded
 import app.campfire.core.di.UserScope
@@ -67,6 +66,7 @@ import app.campfire.core.extensions.seconds
 import app.campfire.core.model.Chapter
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.MediaProgress
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.libraries.ui.detail.composables.AuthorNarratorBar
 import app.campfire.libraries.ui.detail.composables.ControlBar
 import app.campfire.libraries.ui.detail.composables.DurationListItem

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
@@ -59,7 +59,7 @@ import app.campfire.common.compose.widgets.CoverImage
 import app.campfire.common.compose.widgets.ErrorListState
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.MetadataHeader
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.coroutines.onLoaded
 import app.campfire.core.di.UserScope

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
@@ -8,11 +8,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.settings.ItemDisplayState
-import app.campfire.libraries.api.LibraryItemFilter
 import app.campfire.libraries.api.LibraryRepository
 import app.campfire.libraries.api.screen.LibraryScreen
 import app.campfire.settings.api.CampfireSettings

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.libraries.api.LibraryRepository
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.libraries.api.screen.LibraryScreen
 import app.campfire.settings.api.CampfireSettings
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryPresenter.kt
@@ -9,12 +9,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.screens.LibraryItemScreen
-import app.campfire.common.screens.LibraryScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.libraries.api.LibraryItemFilter
 import app.campfire.libraries.api.LibraryRepository
+import app.campfire.libraries.api.screen.LibraryScreen
 import app.campfire.settings.api.CampfireSettings
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
@@ -31,6 +31,7 @@ import me.tatarka.inject.annotations.Inject
 @CircuitInject(LibraryScreen::class, UserScope::class)
 @Inject
 class LibraryPresenter(
+  @Assisted private val screen: LibraryScreen,
   @Assisted private val navigator: Navigator,
   private val repository: LibraryRepository,
   private val offlineDownloadManager: OfflineDownloadManager,
@@ -41,9 +42,7 @@ class LibraryPresenter(
   override fun present(): LibraryUiState {
     // TODO: We should store this in user preferences so it persists
     //  between UI and process changes
-    var itemFilter by remember {
-      mutableStateOf<LibraryItemFilter?>(null)
-    }
+    var itemFilter by remember { mutableStateOf(screen.filter) }
 
     val sortMode by remember {
       settings.observeSortMode()

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/list/LibraryUi.kt
@@ -41,7 +41,6 @@ import app.campfire.common.compose.widgets.LibraryItemCard
 import app.campfire.common.compose.widgets.LibraryListItem
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.OfflineStatusIndicator
-import app.campfire.common.screens.LibraryScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.fluentIf
@@ -52,6 +51,7 @@ import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SortDirection
 import app.campfire.core.settings.SortMode
 import app.campfire.libraries.api.LibraryItemFilter
+import app.campfire.libraries.api.screen.LibraryScreen
 import app.campfire.libraries.ui.list.sheets.filters.LibraryItemFilterResult
 import app.campfire.libraries.ui.list.sheets.filters.showItemFilterOverlay
 import app.campfire.libraries.ui.list.sheets.sort.SortModeResult

--- a/features/search/ui/src/commonMain/kotlin/app/campfire/search/ui/SearchPresenter.kt
+++ b/features/search/ui/src/commonMain/kotlin/app/campfire/search/ui/SearchPresenter.kt
@@ -12,10 +12,13 @@ import app.campfire.common.screens.AuthorDetailScreen
 import app.campfire.common.screens.BaseScreen
 import app.campfire.common.screens.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
+import app.campfire.libraries.api.LibraryItemFilter
+import app.campfire.libraries.api.screen.LibraryScreen
 import app.campfire.search.api.SearchRepository
 import app.campfire.search.api.SearchResult
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.resetRoot
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -80,8 +83,11 @@ class SearchPresenter(
         )
 
         is SearchUiEvent.OnBookClick -> navigateTo(LibraryItemScreen(event.book.id))
-        is SearchUiEvent.OnGenreClick -> TODO("Navigate to LibraryItemScreen with filter information")
-        is SearchUiEvent.OnNarratorClick -> TODO("Navigate to LibraryItemScreen with filter information")
+        is SearchUiEvent.OnGenreClick -> navigateTo(LibraryScreen(LibraryItemFilter.Genres(event.genre.name)), true)
+        is SearchUiEvent.OnNarratorClick -> navigateTo(
+          screen = LibraryScreen(LibraryItemFilter.Narrators(event.narrator.name)),
+          resetRoot = true
+        )
         is SearchUiEvent.OnSeriesClick -> navigateTo(
           SeriesDetailScreen(
             event.series.id,
@@ -89,13 +95,13 @@ class SearchPresenter(
           ),
         )
 
-        is SearchUiEvent.OnTagClick -> TODO("Navigate to LibraryItemScreen with filter information")
+        is SearchUiEvent.OnTagClick -> navigateTo(LibraryScreen(LibraryItemFilter.Tags(event.tag.name)), true)
       }
     }
   }
 
-  private fun navigateTo(screen: BaseScreen) {
-    navigator.goTo(screen)
+  private fun navigateTo(screen: BaseScreen, resetRoot: Boolean = false) {
+    if (resetRoot) navigator.resetRoot(screen) else navigator.goTo(screen)
     requestDismiss()
   }
 }

--- a/features/search/ui/src/commonMain/kotlin/app/campfire/search/ui/SearchPresenter.kt
+++ b/features/search/ui/src/commonMain/kotlin/app/campfire/search/ui/SearchPresenter.kt
@@ -10,9 +10,9 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.screens.AuthorDetailScreen
 import app.campfire.common.screens.BaseScreen
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.libraries.api.LibraryItemFilter
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.libraries.api.screen.LibraryScreen
 import app.campfire.search.api.SearchRepository
 import app.campfire.search.api.SearchResult
@@ -85,7 +85,7 @@ class SearchPresenter(
         is SearchUiEvent.OnGenreClick -> navigateTo(LibraryScreen(LibraryItemFilter.Genres(event.genre.name)), true)
         is SearchUiEvent.OnNarratorClick -> navigateTo(
           screen = LibraryScreen(LibraryItemFilter.Narrators(event.narrator.name)),
-          resetRoot = true
+          resetRoot = true,
         )
         is SearchUiEvent.OnSeriesClick -> navigateTo(
           SeriesDetailScreen(

--- a/features/search/ui/src/commonMain/kotlin/app/campfire/search/ui/SearchPresenter.kt
+++ b/features/search/ui/src/commonMain/kotlin/app/campfire/search/ui/SearchPresenter.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.screens.AuthorDetailScreen
 import app.campfire.common.screens.BaseScreen
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.libraries.api.LibraryItemFilter
 import app.campfire.libraries.api.screen.LibraryScreen
@@ -18,7 +18,6 @@ import app.campfire.search.api.SearchRepository
 import app.campfire.search.api.SearchResult
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
-import com.slack.circuit.runtime.resetRoot
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailPresenter.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailPresenter.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailPresenter.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailPresenter.kt
@@ -6,10 +6,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import app.campfire.audioplayer.offline.OfflineDownloadManager
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.series.api.SeriesRepository
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/ExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/ExpandedPlaybackBar.kt
@@ -84,11 +84,11 @@ import app.campfire.common.compose.layout.isSupportingPaneEnabled
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.widgets.CoverImage
 import app.campfire.common.compose.widgets.CoverImageSize
-import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.extensions.fluentIf
 import app.campfire.core.model.Bookmark
 import app.campfire.core.model.Chapter
 import app.campfire.core.model.Session
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.sessions.ui.composables.ForwardIcon
 import app.campfire.sessions.ui.composables.PlaybackSpeedAction
 import app.campfire.sessions.ui.composables.RewindIcon

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/ExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/ExpandedPlaybackBar.kt
@@ -84,7 +84,7 @@ import app.campfire.common.compose.layout.isSupportingPaneEnabled
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.widgets.CoverImage
 import app.campfire.common.compose.widgets.CoverImageSize
-import app.campfire.common.screens.LibraryItemScreen
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.core.extensions.fluentIf
 import app.campfire.core.model.Bookmark
 import app.campfire.core.model.Chapter

--- a/features/stats/ui/build.gradle.kts
+++ b/features/stats/ui/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
       dependencies {
         api(projects.common.compose)
 
+        implementation(projects.features.libraries.api)
         implementation(projects.features.stats.api)
 
         implementation(compose.components.resources)

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsPresenter.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsPresenter.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import app.campfire.common.screens.AuthorDetailScreen
-import app.campfire.common.screens.LibraryItemScreen
 import app.campfire.common.screens.StatisticsScreen
 import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.coroutines.LoadState
@@ -13,6 +12,7 @@ import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryStats
 import app.campfire.core.model.ListeningStats
 import app.campfire.core.time.FatherTime
+import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.stats.api.StatsRepository
 import campfire.features.stats.ui.generated.resources.Res
 import campfire.features.stats.ui.generated.resources.user_stats_recent_sessions_header

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -81,5 +81,10 @@ gradlePlugin {
       id = "app.campfire.android.test"
       implementationClass = "app.campfire.convention.AndroidTestConventionPlugin"
     }
+
+    register("parcelize") {
+      id = "app.campfire.parcelize"
+      implementationClass = "app.campfire.convention.ParcelizeConventionPlugin"
+    }
   }
 }

--- a/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/KotlinMultiplatformConventionPlugin.kt
@@ -28,7 +28,10 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
 
     extensions.configure<KotlinMultiplatformExtension> {
       compilerOptions {
-        freeCompilerArgs.add("-opt-in=kotlin.uuid.ExperimentalUuidApi")
+        freeCompilerArgs.addAll(
+          "-opt-in=kotlin.uuid.ExperimentalUuidApi",
+          "-Xexpect-actual-classe"
+        )
       }
 
       applyDefaultHierarchyTemplate()

--- a/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/KotlinMultiplatformConventionPlugin.kt
@@ -30,7 +30,7 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
       compilerOptions {
         freeCompilerArgs.addAll(
           "-opt-in=kotlin.uuid.ExperimentalUuidApi",
-          "-Xexpect-actual-classe"
+          "-Xexpect-actual-classes"
         )
       }
 

--- a/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/KotlinMultiplatformConventionPlugin.kt
@@ -30,7 +30,7 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
       compilerOptions {
         freeCompilerArgs.addAll(
           "-opt-in=kotlin.uuid.ExperimentalUuidApi",
-          "-Xexpect-actual-classes"
+          "-Xexpect-actual-classes",
         )
       }
 

--- a/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/ParcelizeConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/ParcelizeConventionPlugin.kt
@@ -1,0 +1,31 @@
+package app.campfire.convention
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+
+class ParcelizeConventionPlugin : Plugin<Project> {
+  override fun apply(target: Project) = with(target) {
+    pluginManager.apply("org.jetbrains.kotlin.plugin.parcelize")
+
+    extensions.configure<KotlinMultiplatformExtension> {
+      targets.configureEach {
+        val isAndroidTarget = platformType == KotlinPlatformType.androidJvm
+        compilations.configureEach {
+          compileTaskProvider.configure {
+            compilerOptions {
+              if (isAndroidTarget) {
+                freeCompilerArgs.addAll(
+                  "-P",
+                  "plugin:org.jetbrains.kotlin.parcelize:additionalAnnotation=app.campfire.core.parcelize.Parcelize",
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/ParcelizeConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/ParcelizeConventionPlugin.kt
@@ -1,3 +1,6 @@
+// Copyright 2025, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package app.campfire.convention
 
 import org.gradle.api.Plugin

--- a/ui/drawer/build.gradle.kts
+++ b/ui/drawer/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
         api(projects.data.account.api)
         api(projects.data.account.ui)
         api(projects.infra.updates.api)
+        api(projects.features.libraries.api)
 
         implementation(compose.components.resources)
       }

--- a/ui/drawer/src/commonMain/kotlin/app/campfire/ui/drawer/DrawerScreen.kt
+++ b/ui/drawer/src/commonMain/kotlin/app/campfire/ui/drawer/DrawerScreen.kt
@@ -46,12 +46,12 @@ import app.campfire.common.screens.CollectionsScreen
 import app.campfire.common.screens.DebugScreen
 import app.campfire.common.screens.DrawerScreen
 import app.campfire.common.screens.HomeScreen
-import app.campfire.common.screens.LibraryScreen
 import app.campfire.common.screens.SeriesScreen
 import app.campfire.common.screens.SettingsScreen
 import app.campfire.common.screens.StatisticsScreen
 import app.campfire.core.di.UserScope
 import app.campfire.core.isDebug
+import app.campfire.libraries.api.screen.LibraryScreen
 import app.campfire.updates.AppUpdateWidget
 import campfire.ui.drawer.generated.resources.Res
 import campfire.ui.drawer.generated.resources.nav_authors_content_description
@@ -176,7 +176,7 @@ private fun buildDrawerItems(): List<HomeNavigationItem> {
       )
       add(
         HomeNavigationItem(
-          screen = LibraryScreen,
+          screen = LibraryScreen(),
           label = stringResource(Res.string.nav_library_label),
           contentDescription = stringResource(Res.string.nav_library_content_description),
           iconImageVector = Icons.Outlined.Library,


### PR DESCRIPTION
Now that library filtering works, we can now navigate for genres, tags, and narrators to the library screen