### PR TITLE
Revert "fix(deps): update compose.multiplatform to v1.9.2"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ clikt = "5.0.3"
 core-ktx = "1.17.0"
 coroutines = "1.10.2"
 # TODO: 1.9.1+ breaks Wavy Slider - TODO: Update to support M3 Expressive
-compose-multiplatform = "1.9.2"
+compose-multiplatform = "1.9.0"
 connectivity = "2.3.0"
 coil = "3.3.0"
 circuit = "0.31.0"


### PR DESCRIPTION
Reverts r0adkll/Campfire#369

This breaks wavy-slider until we can get that library updated