### PR TITLE
feat: add setting for remote control next/prev behavior

### DIFF
--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/PlaybackSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/PlaybackSettings.kt
@@ -20,4 +20,11 @@ interface PlaybackSettings {
   fun observePlaybackRates(): StateFlow<List<Float>>
 
   var playbackSpeed: Float
+
+  /**
+   * When true, remote control next/previous buttons skip to next/previous chapter.
+   * When false, they seek forward/backward by the configured time.
+   */
+  var remoteNextPrevSkipsChapters: Boolean
+  fun observeRemoteNextPrevSkipsChapters(): StateFlow<Boolean>
 }

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/PlaybackSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/PlaybackSettingsImpl.kt
@@ -73,6 +73,16 @@ class PlaybackSettingsImpl(
 
   override var playbackSpeed: Float by floatSetting(PREF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED)
 
+  override var remoteNextPrevSkipsChapters: Boolean by booleanSetting(
+    PREF_REMOTE_NEXT_PREV_SKIPS_CHAPTERS,
+    DEFAULT_REMOTE_NEXT_PREV_SKIPS_CHAPTERS,
+  )
+
+  override fun observeRemoteNextPrevSkipsChapters(): StateFlow<Boolean> {
+    return flowSettings.getBooleanFlow(PREF_REMOTE_NEXT_PREV_SKIPS_CHAPTERS, DEFAULT_REMOTE_NEXT_PREV_SKIPS_CHAPTERS)
+      .stateIn(settingsScope, SharingStarted.Lazily, remoteNextPrevSkipsChapters)
+  }
+
   private fun String.asFloatList(): List<Float> = split(PLAYBACK_RATES_SEPARATOR).mapNotNull { it.toFloatOrNull() }
 }
 
@@ -90,3 +100,5 @@ internal const val DEFAULT_BACKWARD_TIME_MS = 10L * 1000L // 15s
 internal const val DEFAULT_TRACK_RESET_THRESHOLD_SECONDS = 5.0 // 5s
 internal val DEFAULT_PLAYBACK_RATES = listOf(0.5f, 0.75f, 1f, 1.5f, 2f)
 internal const val DEFAULT_PLAYBACK_SPEED = 1f
+internal const val PREF_REMOTE_NEXT_PREV_SKIPS_CHAPTERS = "pref_playback_remote_next_prev_skips_chapters"
+internal const val DEFAULT_REMOTE_NEXT_PREV_SKIPS_CHAPTERS = true

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -57,6 +57,8 @@
   <string name="setting_playback_mp3seeking_subtitle">Improve the accuracy of seeking in variable bitrate MP3s</string>
   <string name="setting_playback_track_reset_title">Track reset threshold</string>
   <string name="setting_playback_track_reset_subtitle">How far into a track that skip previous will just restart it</string>
+  <string name="setting_playback_remote_skip_title">Remote next/prev skips chapters</string>
+  <string name="setting_playback_remote_skip_subtitle">When enabled, remote control next/previous buttons skip to next/previous chapter. When disabled, they seek forward/backward by the configured time.</string>
   <string name="header_shake_to_reset">Reset</string>
   <string name="setting_playback_sleep_shake_to_reset_title">Shake-to-reset</string>
   <string name="setting_playback_sleep_shake_to_reset_subtitle">Enable shaking to reset the current or previous timer</string>

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -47,6 +47,7 @@ import app.campfire.ui.settings.SettingsUiEvent.DownloadsSettingEvent.ShowDownlo
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.BackwardTime
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ForwardTime
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.Mp3IndexSeeking
+import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.RemoteNextPrevSkipsChapters
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.TrackResetThreshold
 import app.campfire.ui.settings.SettingsUiEvent.SleepSettingEvent.AutoSleepRewindAmount
 import app.campfire.ui.settings.SettingsUiEvent.SleepSettingEvent.AutoSleepRewindEnabled
@@ -118,6 +119,9 @@ class SettingsPresenter(
     val backwardTime by remember { playbackSettings.observeBackwardTimeMs() }.collectAsState()
     val trackResetThreshold by remember { playbackSettings.observeTrackResetThreshold() }.collectAsState()
     val mp3IndexSeeking by remember { playbackSettings.observeMp3IndexSeeking() }.collectAsState()
+    val remoteNextPrevSkipsChapters by remember {
+      playbackSettings.observeRemoteNextPrevSkipsChapters()
+    }.collectAsState()
 
     // Downloads Settings
     val showDownloadConfirmation by remember { settings.observeShowConfirmDownload() }
@@ -184,6 +188,7 @@ class SettingsPresenter(
         backwardTime = backwardTime.milliseconds,
         trackResetThreshold = trackResetThreshold,
         mp3IndexSeeking = mp3IndexSeeking,
+        remoteNextPrevSkipsChapters = remoteNextPrevSkipsChapters,
       ),
       sleepSettings = SleepSettingsInfo(
         shakeToReset = shakeToResetEnabled,
@@ -249,6 +254,8 @@ class SettingsPresenter(
           is BackwardTime -> playbackSettings.backwardTimeMs = event.backwardTime.inWholeMilliseconds
           is TrackResetThreshold -> playbackSettings.trackResetThreshold = event.trackResetThreshold
           is Mp3IndexSeeking -> playbackSettings.enableMp3IndexSeeking = event.mp3IndexSeeking
+          is RemoteNextPrevSkipsChapters ->
+            playbackSettings.remoteNextPrevSkipsChapters = event.enabled
         }
 
         is SettingsUiEvent.SleepSettingEvent -> when (event) {

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -54,6 +54,7 @@ data class PlaybackSettingsInfo(
   val backwardTime: Duration,
   val trackResetThreshold: Duration,
   val mp3IndexSeeking: Boolean,
+  val remoteNextPrevSkipsChapters: Boolean,
 )
 
 @Immutable
@@ -141,6 +142,7 @@ sealed interface SettingsUiEvent : CircuitUiEvent {
     data class BackwardTime(val backwardTime: Duration) : PlaybackSettingEvent
     data class TrackResetThreshold(val trackResetThreshold: Duration) : PlaybackSettingEvent
     data class Mp3IndexSeeking(val mp3IndexSeeking: Boolean) : PlaybackSettingEvent
+    data class RemoteNextPrevSkipsChapters(val enabled: Boolean) : PlaybackSettingEvent
   }
 
   // Sleep Setting Events

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/PlaybackPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/PlaybackPane.kt
@@ -15,6 +15,8 @@ import campfire.features.settings.ui.generated.resources.setting_playback_forwar
 import campfire.features.settings.ui.generated.resources.setting_playback_forward_title
 import campfire.features.settings.ui.generated.resources.setting_playback_mp3seeking_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_mp3seeking_title
+import campfire.features.settings.ui.generated.resources.setting_playback_remote_skip_subtitle
+import campfire.features.settings.ui.generated.resources.setting_playback_remote_skip_title
 import campfire.features.settings.ui.generated.resources.setting_playback_title
 import campfire.features.settings.ui.generated.resources.setting_playback_track_reset_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_track_reset_title
@@ -70,6 +72,15 @@ internal fun PlaybackPane(
       },
       headlineContent = { Text(stringResource(Res.string.setting_playback_mp3seeking_title)) },
       supportingContent = { Text(stringResource(Res.string.setting_playback_mp3seeking_subtitle)) },
+    )
+
+    SwitchSetting(
+      value = state.playbackSettings.remoteNextPrevSkipsChapters,
+      onValueChange = {
+        state.eventSink(PlaybackSettingEvent.RemoteNextPrevSkipsChapters(it))
+      },
+      headlineContent = { Text(stringResource(Res.string.setting_playback_remote_skip_title)) },
+      supportingContent = { Text(stringResource(Res.string.setting_playback_remote_skip_subtitle)) },
     )
   }
 }

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -128,8 +128,14 @@ class ExoPlayerAudioPlayer(
    * A proxy accessor for the correct player client. All listener and access goes through the
    * [castPlayer] which configures the [exoPlayer] as the local player to use when a MediaRoute
    * is not directed at remote playback.
+   *
+   * Wrapped with [RemoteControlForwardingPlayer] to intercept next/previous commands
+   * based on user settings.
    */
-  internal val player: Player = (castPlayer ?: exoPlayer).apply {
+  internal val player: Player = RemoteControlForwardingPlayer(
+    player = castPlayer ?: exoPlayer,
+    settings = settings,
+  ).apply {
     addListener(this@ExoPlayerAudioPlayer)
   }
 

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/RemoteControlForwardingPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/RemoteControlForwardingPlayer.kt
@@ -1,0 +1,53 @@
+package app.campfire.audioplayer.impl
+
+import androidx.annotation.OptIn
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import app.campfire.settings.api.PlaybackSettings
+
+/**
+ * A [ForwardingPlayer] that intercepts next/previous media item commands and
+ * redirects them based on the [PlaybackSettings.remoteNextPrevSkipsChapters] setting.
+ *
+ * When [remoteNextPrevSkipsChapters] is true (default), next/prev commands skip chapters.
+ * When false, they seek forward/backward by the configured time instead.
+ */
+@OptIn(UnstableApi::class)
+class RemoteControlForwardingPlayer(
+  player: Player,
+  private val settings: PlaybackSettings,
+) : ForwardingPlayer(player) {
+
+  override fun seekToNextMediaItem() {
+    if (settings.remoteNextPrevSkipsChapters) {
+      super.seekToNextMediaItem()
+    } else {
+      seekForward()
+    }
+  }
+
+  override fun seekToPreviousMediaItem() {
+    if (settings.remoteNextPrevSkipsChapters) {
+      super.seekToPreviousMediaItem()
+    } else {
+      seekBack()
+    }
+  }
+
+  override fun seekToNext() {
+    if (settings.remoteNextPrevSkipsChapters) {
+      super.seekToNext()
+    } else {
+      seekForward()
+    }
+  }
+
+  override fun seekToPrevious() {
+    if (settings.remoteNextPrevSkipsChapters) {
+      super.seekToPrevious()
+    } else {
+      seekBack()
+    }
+  }
+}

--- a/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/IosAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/IosAudioPlayer.kt
@@ -380,12 +380,20 @@ class IosAudioPlayer(
     )
 
     commandCenter.nextTrackCommand.enable {
-      skipToNext()
+      if (settings.remoteNextPrevSkipsChapters) {
+        skipToNext()
+      } else {
+        seekForward()
+      }
       MPRemoteCommandHandlerStatusSuccess
     }
 
     commandCenter.previousTrackCommand.enable {
-      skipToPrevious()
+      if (settings.remoteNextPrevSkipsChapters) {
+        skipToPrevious()
+      } else {
+        seekBackward()
+      }
       MPRemoteCommandHandlerStatusSuccess
     }
 


### PR DESCRIPTION
Adds a new setting "Remote next/prev skips chapters" that allows users to choose between two behaviors for remote control next/previous buttons:

- When enabled (default): next/prev buttons skip to next/previous chapter
- When disabled: next/prev buttons seek forward/backward by configured time

This addresses user feedback that some users prefer using remote controls for time-based seeking rather than chapter navigation.

Implementation:
- PlaybackSettings: Added remoteNextPrevSkipsChapters property
- PlaybackSettingsImpl: Implementation with persistence
- SettingsPresenter/UiState: UI state and event handling
- PlaybackPane: Switch toggle in settings UI
- IosAudioPlayer: Uses setting in remote transport controls setup
- Android: RemoteControlForwardingPlayer wraps ExoPlayer to intercept next/prev commands from MediaSession and redirect based on setting