### PR TITLE
fix: prevent finished audiobooks from skipping to end on replay

### DIFF
--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
@@ -48,6 +48,12 @@ class DefaultSessionsRepository(
     val progress = mediaProgressRepository.getProgress(libraryItemId)
     val offlineDownload = offlineDownloadManager.getForItem(libraryItem)
 
+    // If the book is finished, delete any existing session so we start completely fresh.
+    // This prevents the data layer from reusing an old session stuck at the end position.
+    if (progress?.isFinished == true) {
+      dataSource.deleteSession(libraryItemId)
+    }
+
     return dataSource.createOrStartSession(
       libraryItemId = libraryItemId,
       playMethod = if (offlineDownload.isCompleted) {

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SqlDelightSessionDataSource.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SqlDelightSessionDataSource.kt
@@ -130,10 +130,12 @@ class SqlDelightSessionDataSource(
       }
     }
 
-    // If we DID have an old session, we'll want to re-use its time stamps instead of the passed, media progress,
-    // timestamps.
-    val newStartTime = existingSession?.currentTime ?: currentTime
-    val newCurrentTime = existingSession?.currentTime ?: currentTime
+    // If we DID have an old session and we're NOT forcing a new one, re-use its timestamps
+    // instead of the passed media progress timestamps. When forceNew is true (e.g. replaying
+    // a finished book), we must use the passed currentTime to avoid inheriting the old
+    // session's position (which could be at the end of the book).
+    val newStartTime = if (forceNew) currentTime else existingSession?.currentTime ?: currentTime
+    val newCurrentTime = if (forceNew) currentTime else existingSession?.currentTime ?: currentTime
 
     // If there is no existing, or its too old. Create a new session.
     bark { "Creating new session for library item" }


### PR DESCRIPTION
## Summary

- Fixes a bug where replaying a previously finished audiobook would immediately skip to the end and mark it as complete again
- The root cause was dual: stale finished sessions in the local DB had `currentTime = duration`, and `createOrStartSession()` unconditionally preferred the existing session's position over the reset value from `MediaProgress`

## Root Cause

When a book finishes, `markFinished()` sets `currentTime = duration` in the local session row. This session is only deleted after a successful remote sync. If the user replays before sync completes (or sync fails), `createOrStartSession()` finds the old session and — on lines 135-136 — picks up `existingSession.currentTime` (which equals the full book duration) instead of the passed `currentTime = 0.seconds` parameter. The new session is immediately `isFinished`, and the player skips to the end.

## Fix (two-layer defense)

1. **`DefaultSessionsRepository.createSession()`** — Delete any existing session when the book is finished, so the data layer can't reuse an old session stuck at the end position
2. **`SqlDelightSessionDataSource.createOrStartSession()`** — When `forceNew = true`, use the passed `currentTime` parameter instead of blindly preferring `existingSession?.currentTime`

## Files Changed

- `features/sessions/impl/.../DefaultSessionsRepository.kt` — Delete stale finished session before creating new one
- `features/sessions/impl/.../db/SqlDelightSessionDataSource.kt` — Respect `forceNew` flag in timestamp selection

## Future Architectural Improvement

The underlying issue is a dual source of truth: both the local `session` table and `MediaProgress` hold playback position, and they can diverge. The current fix patches the finished-book case, but a cleaner long-term architecture would:

- Treat `MediaProgress` as the **sole source of truth** for resume position
- Treat local `session` as a **write-ahead log** purely for sync/analytics — it should never influence where playback starts
- This aligns with how other Audiobookshelf clients (e.g. [Lissen](https://github.com/GrakovNe/lissen-android)) handle it: sessions are in-memory only, `MediaProgress` (reconciled via `lastUpdate` timestamp) determines resume position

This would be a separate refactor PR.

## Test Plan

- [ ] Play a book to completion, then immediately replay — should start from the beginning
- [ ] Play a book to completion, wait for remote sync, then replay — should start from the beginning
- [ ] Partially play a book, close app, reopen and resume — should resume from the correct position
- [ ] Verify the "young session" reuse path still works for recently-paused books on the same day