### PR TITLE
refactor: make MediaProgress the single source of truth for resume position

### DIFF
--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
@@ -63,14 +63,14 @@ class DefaultSessionsRepository(
       },
       mediaPlayer = "campfire",
       duration = libraryItem.media.durationInMillis.milliseconds,
+      // MediaProgress is the single source of truth for resume position.
+      // Finished books restart from the beginning.
       currentTime = if (progress?.isFinished == true) {
-        // Reset to beginning for finished audiobooks so playback can restart
         0.seconds
       } else {
         progress?.currentTime?.seconds ?: 0.seconds
       },
       startedAt = startedAt,
-      forceNew = progress?.isFinished == true,
     )
   }
 

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SessionDataSource.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SessionDataSource.kt
@@ -25,7 +25,6 @@ interface SessionDataSource {
     duration: Duration,
     currentTime: Duration,
     startedAt: LocalDateTime,
-    forceNew: Boolean = false,
   ): Session
 
   suspend fun updateCurrentTime(


### PR DESCRIPTION
## Summary

- Eliminates the dual source of truth between the local `session` table and `MediaProgress` for playback resume position
- The `session` table is now a **write-ahead log** for sync/analytics only — it never influences where playback starts
- `MediaProgress` (from the server, cached locally) is the **sole authority** for resume position

Builds on #629 which fixed the immediate symptom (finished books skipping to end on replay).

## Problem

The local `session` table and `MediaProgress` both stored `currentTime`, and the code used them inconsistently:

| Operation | Source used |
|-----------|-----------|
| Creating a new session | `MediaProgress` (via passed `currentTime`) |
| Reusing a "young" session | **Local session** (`existingSession.currentTime`) |
| Creating after a finished book | `MediaProgress` (with `forceNew` workaround) |

This meant the resume position depended on *which code path* was taken, and divergence between the two sources caused the skip-to-end bug. The `forceNew` parameter was a bandaid for one specific case.

## Changes

**`SessionDataSource` / `SqlDelightSessionDataSource`:**
- Removed `forceNew` parameter entirely
- `createOrStartSession()` now **always** uses the passed `currentTime` (sourced from `MediaProgress`)
- "Young session" reuse path: keeps session identity (ID, `timeListening`) for server-side continuity, but updates `currentTime` from `MediaProgress` in the same DB transaction
- New session path: uses passed `currentTime` directly — no fallback to `existingSession?.currentTime`

**`DefaultSessionsRepository`:**
- Removed `forceNew` usage
- Kept session deletion for finished books as cleanup (prevents stale rows)
- Clear comment marking `MediaProgress` as the single source of truth

## Architecture (before → after)

**Before:** Session table was both a sync log AND a position authority
```
MediaProgress ──→ createSession() ──→ createOrStartSession()
                                         ├── young session? → use session.currentTime  ← WRONG
                                         ├── forceNew?      → use passed currentTime   ← BANDAID
                                         └── new session    → use session.currentTime  ← WRONG
```

**After:** Session table is a sync log only; MediaProgress is always the authority
```
MediaProgress ──→ createSession() ──→ createOrStartSession()
                                         ├── young session? → reuse ID, update currentTime from MediaProgress
                                         └── new session    → use currentTime from MediaProgress
```

This aligns with how other Audiobookshelf clients (e.g. [Lissen](https://github.com/GrakovNe/lissen-android)) handle it — sessions are ephemeral transport for the sync protocol, progress determines resume position.

## Files Changed

- `features/sessions/impl/.../db/SessionDataSource.kt` — Remove `forceNew` from interface
- `features/sessions/impl/.../db/SqlDelightSessionDataSource.kt` — Always use passed `currentTime`, update young sessions from MediaProgress
- `features/sessions/impl/.../DefaultSessionsRepository.kt` — Remove `forceNew`, clarify MediaProgress as authority

## Test Plan

- [ ] Play a book to completion → replay → should start from the beginning
- [ ] Partially play a book → pause → resume within same day → should resume correctly (young session reuse)
- [ ] Partially play → close app → reopen next day → should resume from MediaProgress position (new session)
- [ ] Play offline (no server sync) → pause → resume → should use locally-cached MediaProgress
- [ ] Verify server session sync still works (session IDs maintained for young sessions)
- [ ] Verify `timeListening` accumulation still correct across young session reuse