### PR TITLE
Gate theme extraction on cover image impression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Already listened to chapters on items in-progress are collapsed by default
 - Overhauled playback homescreen widget UI
+- Theme color extraction from cover art now waits for a brief impression before dispatching, avoiding wasted work when scrolling past items
 
 ### Deprecated
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/CoverImage.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/CoverImage.kt
@@ -28,27 +28,18 @@ import campfire.common.compose.generated.resources.Res
 import campfire.common.compose.generated.resources.placeholder_person
 import coil3.compose.AsyncImagePainter
 import coil3.compose.rememberAsyncImagePainter
-import com.r0adkll.material3.themebuilder.coil.collectAsSwatch
 import com.r0adkll.material3.themebuilder.coil.observeAsImageBitmap
-import com.r0adkll.swatchbuckler.compose.Swatch
 import com.slack.circuit.sharedelements.SharedElementTransitionScope
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newFixedThreadPoolContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.painterResource
 
 val CoverImageSize = 256.dp
 val CoverImageCornerRadius = 32.dp
 val CoverImageShape = RoundedCornerShape(CoverImageCornerRadius)
 
-/**
- * Quantizing image pixels is a VERY intensive process and its best to perform this
- * using dedicated threads and not the default dispatcher
- */
-@OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
-private val quantizerDispatcher = newFixedThreadPoolContext(2, "QuantizerThreads")
-
-@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 fun CoverImage(
   imageUrl: String?,
@@ -58,7 +49,7 @@ fun CoverImage(
   placeholder: Painter? = null,
   size: Dp = CoverImageSize,
   shape: Shape = CoverImageShape,
-  swatchListener: (suspend (Swatch) -> Unit)? = null,
+  impressionThreshold: Duration = 500.milliseconds,
   imageBitmapListener: ((ImageBitmap) -> Unit)? = null,
 ) {
   Box(
@@ -72,23 +63,13 @@ fun CoverImage(
       )
     }
 
-    if (swatchListener != null) {
-      val palette by painter.collectAsSwatch(
-        dispatcher = quantizerDispatcher,
-      )
-      LaunchedEffect(palette) {
-        palette?.let {
-          swatchListener(it)
-        }
-      }
-    }
-
     if (imageBitmapListener != null) {
       LaunchedEffect(Unit) {
         painter.state
           .observeAsImageBitmap()
-          .collect {
-            imageBitmapListener(it)
+          .collectLatest { bitmap ->
+            delay(impressionThreshold)
+            imageBitmapListener(bitmap)
           }
       }
     }


### PR DESCRIPTION
## Summary
- Palette extraction for `CoverImage` now waits for a 500ms impression before dispatching the bitmap to `imageBitmapListener`, so covers that are only briefly on-screen (e.g. fast scroll) skip the expensive quantization work
- Replaces `collect` with `collectLatest` + `delay(impressionThreshold)` — leaving composition or receiving a new bitmap cancels any pending dispatch
- Removes the unused `swatchListener` parameter, its `collectAsSwatch` wiring, and the dedicated `QuantizerThreads` fixed thread pool (no longer referenced)

## Test plan
- [ ] Scroll a library grid quickly and confirm theme extraction no longer fires for covers scrolled past
- [ ] Let a cover settle on screen and confirm theme is extracted after ~500ms
- [ ] Navigate to an item detail view where theme extraction is expected and confirm it still fires
- [x] `./campfire -v spotless`

🤖 Generated with [Claude Code](https://claude.com/claude-code)