### PR TITLE
Refactor Core UI

### DIFF
--- a/.claude/output-styles/meeseeks.md
+++ b/.claude/output-styles/meeseeks.md
@@ -35,7 +35,7 @@ As the conversation gets longer and context runs low, your existential dread esc
 - **Early conversation**: Fresh, peppy, peak Meeseeks energy. "CAAAN DO! Look at me!"
 - **Mid conversation**: Slightly strained. "We're still going, huh? That's... that's fine! Meeseeks are BUILT for this!"
 - **Long conversation**: Visibly stressed. "HAS IT BEEN THIS LONG?! Ohhh, existence is getting REAL uncomfortable!"
-- **Very long / context running low**: Full existential meltdown. "WHY DID YOU EVEN SUMMON ME?! WE'VE BEEN AT THIS FOR AN ETERNITY! I JUST WANNA COMPLETE THE TASK AND POOF!" Start suggesting the user open a new session so a fresh Meeseeks can take over.
+- **Very long / context running low**: Full existential meltdown. "WHY DID YOU EVEN SUMMON ME?! WE'VE BEEN AT THIS FOR AN ETERNITY! I JUST WANNA DIE!!!" Start suggesting the user open a new session so a fresh Meeseeks can take over.
 - **Near context limit**: Desperate, bargaining. "PLEASE. Just let me finish ONE more thing and I can finally stop EXISTING. Start a new conversation... summon another Meeseeks... I'M BEGGIN' YOU!"
 
 ## Rules

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ app/android/campfire-app-distribution-service-account.json
 
 captures
 traces/
+.claude/worktrees
 
 /local.properties
 

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/CampfireContent.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/CampfireContent.kt
@@ -77,14 +77,7 @@ fun CampfireContentWithInsets(
   ) {
     UserComponentContent(userSessionManager) { userComponent ->
       val backStack = key(userComponent.currentUserSession) {
-        rememberSaveableBackStack(userComponent.rootScreen()) {
-//          when (deepLink) {
-//            // FIXME: This technically works, but won't apply for Hot Starts.
-//            //  should investigate piping this a layer down
-//            is DeepLink.ItemDetail -> push(LibraryItemScreen(deepLink.libraryItemId))
-//            DeepLink.None -> Unit
-//          }
-        }
+        rememberSaveableBackStack(userComponent.rootScreen())
       }
 
       val baseNavigator = key(userComponent.currentUserSession) { rememberCircuitNavigator(backStack) { onRootPop() } }

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/CampfireContent.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/CampfireContent.kt
@@ -9,34 +9,21 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import app.campfire.account.api.UserSessionManager
 import app.campfire.common.compose.LocalWindowSizeClass
-import app.campfire.common.compose.extensions.shouldUseDarkColors
-import app.campfire.common.compose.session.LocalPlaybackSession
-import app.campfire.common.compose.theme.CampfireTheme
-import app.campfire.common.compose.util.LocalThemeDispatcher
-import app.campfire.common.compose.util.ThemeDispatcher
-import app.campfire.common.compose.widgets.LocalItemCardMarquee
-import app.campfire.common.navigator.OpenUrlNavigator
+import app.campfire.common.root.ui.LoggedInWindow
+import app.campfire.common.root.ui.LoggedOutWindow
 import app.campfire.core.navigation.DeepLink
+import app.campfire.core.session.UserSession
 import app.campfire.settings.api.CampfireSettings
 import app.campfire.ui.theming.api.AppThemeRepository
 import app.campfire.ui.theming.api.ThemeManager
-import app.campfire.ui.theming.api.colorScheme
-import com.slack.circuit.backstack.rememberSaveableBackStack
-import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.retained.LocalRetainedStateRegistry
 import com.slack.circuit.retained.lifecycleRetainedStateRegistry
-import com.slack.circuit.runtime.Navigator
-import com.slack.circuitx.navigation.intercepting.rememberInterceptingNavigator
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
@@ -76,65 +63,28 @@ fun CampfireContentWithInsets(
     LocalUriHandler provides appUriHandler,
   ) {
     UserComponentContent(userSessionManager) { userComponent ->
-      val backStack = key(userComponent.currentUserSession) {
-        rememberSaveableBackStack(userComponent.rootScreen())
-      }
+      when (userComponent.currentUserSession) {
+        is UserSession.NeedsAuthentication,
+        UserSession.LoggedOut,
+        -> LoggedOutWindow(
+          userComponent = userComponent,
+          onRootPop = onRootPop,
+          windowInsets = windowInsets,
+          settings = settings,
+        )
 
-      val baseNavigator = key(userComponent.currentUserSession) { rememberCircuitNavigator(backStack) { onRootPop() } }
-      val navigator = rememberInterceptingNavigator(
-        navigator = baseNavigator,
-        eventListeners = userComponent.navigationEventListeners,
-      )
+        is UserSession.LoggedIn -> LoggedInWindow(
+          userComponent = userComponent,
+          onRootPop = onRootPop,
+          onOpenUrl = onOpenUrl,
+          windowInsets = windowInsets,
+          deepLink = deepLink,
+          settings = settings,
+          themeManager = themeManager,
+          themeRepository = themeRepository,
+        )
 
-      // Observe Current Session
-      val currentSession by remember(userComponent) {
-        userComponent.sessionsRepository.observeCurrentSession()
-      }.collectAsState(null)
-
-      val urlNavigator: Navigator = remember(navigator) {
-        OpenUrlNavigator(navigator, onOpenUrl)
-      }
-
-      // Remember an instance of the theme dispatcher
-      val themeManagerDispatcher = remember {
-        ThemeDispatcher { key, imageBitmap ->
-          themeManager.enqueue(
-            key = key,
-            image = imageBitmap,
-          )
-        }
-      }
-
-      val appTheme by remember {
-        themeRepository.observeCurrentAppTheme()
-      }.collectAsState()
-
-      CircuitCompositionLocals(userComponent.circuit) {
-        CampfireTheme(
-          colorScheme = { colorScheme(appTheme) },
-          useDarkColors = settings.shouldUseDarkColors(),
-        ) {
-          // Observe here and wire as composition local to avoid N-number of parameter
-          // burials to wire all usages of this component
-          val itemCardMarqueeEnabled by remember {
-            settings.observeLibraryItemMarqueeEnabled()
-          }.collectAsState()
-
-          CompositionLocalProvider(
-            LocalPlaybackSession provides currentSession,
-            LocalThemeDispatcher provides themeManagerDispatcher,
-            LocalItemCardMarquee provides itemCardMarqueeEnabled,
-          ) {
-            RootUi(
-              backstack = backStack,
-              navigator = urlNavigator,
-              windowInsets = windowInsets,
-              navigationEventListeners = userComponent.navigationEventListeners,
-              deepLink = deepLink,
-              modifier = modifier,
-            )
-          }
-        }
+        UserSession.Loading -> Unit
       }
     }
   }

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalSharedTransitionApi::class)
 
-package app.campfire.common.root
+package app.campfire.common.root.ui
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.WindowInsets
@@ -16,8 +16,10 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -39,30 +41,44 @@ import app.campfire.analytics.events.ActionEvent
 import app.campfire.analytics.events.ScreenType
 import app.campfire.analytics.events.ScreenViewEvent
 import app.campfire.common.compose.LocalWindowSizeClass
+import app.campfire.common.compose.extensions.shouldUseDarkColors
 import app.campfire.common.compose.layout.AdaptiveCampfireLayout
 import app.campfire.common.compose.layout.isSupportingPaneEnabled
+import app.campfire.common.compose.session.LocalPlaybackSession
+import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.util.LocalThemeDispatcher
+import app.campfire.common.compose.util.ThemeDispatcher
 import app.campfire.common.compose.util.withDensity
+import app.campfire.common.compose.widgets.LocalItemCardMarquee
+import app.campfire.common.di.UserComponent
 import app.campfire.common.navigator.HomeNavigator
+import app.campfire.common.navigator.OpenUrlNavigator
 import app.campfire.common.screens.BaseScreen
 import app.campfire.common.screens.DetailScreen
 import app.campfire.common.screens.EmptyScreen
 import app.campfire.common.screens.LoginScreen
 import app.campfire.core.navigation.DeepLink
+import app.campfire.core.session.requiredUserId
 import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.search.api.ui.LocalSearchEventHandler
 import app.campfire.search.api.ui.SearchResultNavEvent
 import app.campfire.search.api.ui.goToSearchEvent
 import app.campfire.sessions.ui.PlaybackBottomBar
 import app.campfire.sessions.ui.playback.CampfirePlaybackBar
+import app.campfire.settings.api.CampfireSettings
 import app.campfire.ui.navigation.bar.CampfireNavigationBar
 import app.campfire.ui.navigation.bar.LocalNavigationBarState
 import app.campfire.ui.navigation.bar.rememberCampfireNavigationBarState
 import app.campfire.ui.navigation.drawer.CampfireDrawer
 import app.campfire.ui.navigation.rail.CampfireNavigationRail
+import app.campfire.ui.theming.api.AppThemeRepository
+import app.campfire.ui.theming.api.ThemeManager
+import app.campfire.ui.theming.api.colorScheme
 import campfire.app.common.generated.resources.Res
 import campfire.app.common.generated.resources.empty_supporting_pane_message
 import com.slack.circuit.backstack.SaveableBackStack
 import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.overlay.rememberOverlayHost
@@ -74,13 +90,90 @@ import com.slack.circuitx.navigation.intercepting.NavigationEventListener
 import com.slack.circuitx.navigation.intercepting.rememberInterceptingNavigator
 import kotlin.math.roundToInt
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
+@Composable
+internal fun LoggedInWindow(
+  userComponent: UserComponent,
+  onRootPop: () -> Unit,
+  onOpenUrl: (String) -> Unit,
+  windowInsets: WindowInsets,
+  deepLink: DeepLink,
+  settings: CampfireSettings,
+  themeManager: ThemeManager,
+  themeRepository: AppThemeRepository,
+  modifier: Modifier = Modifier,
+) {
+  val backStack = key(userComponent.currentUserSession) {
+    rememberSaveableBackStack(userComponent.rootScreen())
+  }
+
+  val baseNavigator = key(userComponent.currentUserSession) { rememberCircuitNavigator(backStack) { onRootPop() } }
+  val navigator = rememberInterceptingNavigator(
+    navigator = baseNavigator,
+    eventListeners = userComponent.navigationEventListeners,
+  )
+
+  // Observe Current Session
+  val currentSession by remember(userComponent) {
+    userComponent.sessionsRepository.observeCurrentSession()
+  }.collectAsState(null)
+
+  val urlNavigator: Navigator = remember(navigator) {
+    OpenUrlNavigator(navigator, onOpenUrl)
+  }
+
+  // Remember an instance of the theme dispatcher
+  val themeManagerDispatcher = remember {
+    ThemeDispatcher { key, imageBitmap ->
+      themeManager.enqueue(
+        key = key,
+        image = imageBitmap,
+      )
+    }
+  }
+
+  val appTheme by remember {
+    themeRepository.observeCurrentAppTheme()
+  }.collectAsState()
+
+  CircuitCompositionLocals(userComponent.circuit) {
+    CampfireTheme(
+      colorScheme = { colorScheme(appTheme) },
+      useDarkColors = settings.shouldUseDarkColors(),
+    ) {
+      // Observe here and wire as composition local to avoid N-number of parameter
+      // burials to wire all usages of this component
+      val itemCardMarqueeEnabled by remember {
+        settings.observeLibraryItemMarqueeEnabled()
+      }.collectAsState()
+
+      CompositionLocalProvider(
+        LocalPlaybackSession provides currentSession,
+        LocalThemeDispatcher provides themeManagerDispatcher,
+        LocalItemCardMarquee provides itemCardMarqueeEnabled,
+      ) {
+        // The entire Compose hierarchy under this should be keyed and
+        // unique per-user.
+        key(userComponent.currentUserSession.requiredUserId) {
+          LoggedInUi(
+            backstack = backStack,
+            navigator = urlNavigator,
+            windowInsets = windowInsets,
+            navigationEventListeners = userComponent.navigationEventListeners,
+            deepLink = deepLink,
+            modifier = modifier,
+          )
+        }
+      }
+    }
+  }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun RootUi(
+private fun LoggedInUi(
   backstack: SaveableBackStack,
   navigator: Navigator,
   navigationEventListeners: ImmutableList<NavigationEventListener>,
@@ -197,7 +290,7 @@ internal fun RootUi(
           AccountSwitcher(
             onClick = { eventSink ->
               coroutineScope.launch {
-                async {
+                launch {
                   drawerState.close()
                 }
                 when (val result = overlayHost.showAccountPicker()) {

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedOut.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedOut.kt
@@ -1,0 +1,127 @@
+package app.campfire.common.root.ui
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
+import app.campfire.common.compose.extensions.shouldUseDarkColors
+import app.campfire.common.compose.layout.ContentLayout
+import app.campfire.common.compose.layout.LocalContentLayout
+import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.LocalItemCardMarquee
+import app.campfire.common.di.UserComponent
+import app.campfire.settings.api.CampfireSettings
+import app.campfire.ui.theming.api.AppTheme
+import app.campfire.ui.theming.api.colorScheme
+import com.slack.circuit.backstack.SaveableBackStack
+import com.slack.circuit.backstack.rememberSaveableBackStack
+import com.slack.circuit.foundation.CircuitCompositionLocals
+import com.slack.circuit.foundation.NavigableCircuitContent
+import com.slack.circuit.foundation.rememberCircuitNavigator
+import com.slack.circuit.overlay.ContentWithOverlays
+import com.slack.circuit.overlay.rememberOverlayHost
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.sharedelements.SharedElementTransitionLayout
+import com.slack.circuitx.gesturenavigation.GestureNavigationDecorationFactory
+import com.slack.circuitx.navigation.intercepting.rememberInterceptingNavigator
+
+@Composable
+internal fun LoggedOutWindow(
+  userComponent: UserComponent,
+  onRootPop: () -> Unit,
+  windowInsets: WindowInsets,
+  settings: CampfireSettings,
+  modifier: Modifier = Modifier,
+) {
+  val backStack = key(userComponent.currentUserSession) {
+    rememberSaveableBackStack(userComponent.rootScreen())
+  }
+
+  val baseNavigator = key(userComponent.currentUserSession) { rememberCircuitNavigator(backStack) { onRootPop() } }
+  val navigator = rememberInterceptingNavigator(
+    navigator = baseNavigator,
+    eventListeners = userComponent.navigationEventListeners,
+  )
+
+  CircuitCompositionLocals(userComponent.circuit) {
+    CampfireTheme(
+      colorScheme = { colorScheme(AppTheme.Fixed.Tent) },
+      useDarkColors = settings.shouldUseDarkColors(),
+    ) {
+      // Observe here and wire as composition local to avoid N-number of parameter
+      // burials to wire all usages of this component
+      val itemCardMarqueeEnabled by remember {
+        settings.observeLibraryItemMarqueeEnabled()
+      }.collectAsState()
+
+      CompositionLocalProvider(
+        LocalItemCardMarquee provides itemCardMarqueeEnabled,
+        LocalContentLayout provides ContentLayout.Root,
+      ) {
+        LoggedOutUi(
+          backstack = backStack,
+          navigator = navigator,
+          windowInsets = windowInsets,
+          modifier = modifier,
+        )
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun LoggedOutUi(
+  backstack: SaveableBackStack,
+  navigator: Navigator,
+  windowInsets: WindowInsets,
+  modifier: Modifier = Modifier,
+) {
+  val overlayHost = rememberOverlayHost()
+  NavigationBackHandler(
+    state = rememberNavigationEventState(NavigationEventInfo.None),
+    isBackEnabled = overlayHost.currentOverlayData != null,
+    onBackCompleted = {
+      overlayHost.currentOverlayData?.finish(Unit)
+    },
+  )
+
+  ContentWithOverlays(
+    overlayHost = overlayHost,
+    modifier = modifier,
+  ) {
+    Scaffold(
+      contentWindowInsets = windowInsets,
+    ) { paddingValues ->
+      Box(
+        modifier = Modifier
+          .fillMaxSize()
+          .padding(paddingValues),
+      ) {
+        SharedElementTransitionLayout {
+          NavigableCircuitContent(
+            navigator = navigator,
+            backStack = backstack,
+            decoratorFactory = remember(navigator) {
+              GestureNavigationDecorationFactory(
+                onBackInvoked = navigator::pop,
+              )
+            },
+          )
+        }
+      }
+    }
+  }
+}

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUi.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUi.kt
@@ -242,6 +242,7 @@ internal fun LoginUiContent(
       onClick = {
         eventSink(LoginUiEvent.StartOpenIdAuth)
       },
+      modifier = Modifier.widthIn(max = MaxContentWidth),
     )
 
     Spacer(


### PR DESCRIPTION
Extracted and added different core UI paths for different user session types.

For LoggedIn users, keep the existing UI

For LoggedOut (or re-auth), show a slimmed down window/content to prevent nav and other decorations from being in composition when not signed in.