### PR TITLE
Add Android Auto settings pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Playback History
 - Multi-device progress synchronization
 - Setting to disable marquee scrolling on library item cards
+- Android Auto settings pane: toggle, reorder, and choose list/grid layout per top-level category
 
 ### Changed
 

--- a/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
+++ b/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
@@ -126,6 +126,7 @@ data class SettingsScreen(
     Downloads,
     Playback,
     Sleep,
+    AndroidAuto,
     About,
     Developer,
   }

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/AndroidAutoSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/AndroidAutoSettings.kt
@@ -1,0 +1,54 @@
+package app.campfire.settings.api
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Stable, platform-agnostic identifiers for top-level categories shown in Android Auto.
+ * Storage keys are decoupled from the media IDs used by the Android Auto browser so the
+ * browser can rename its internal IDs without invalidating user preferences.
+ */
+enum class AndroidAutoCategory(
+  val storageKey: String,
+  val defaultGridLayout: Boolean = false,
+  val alwaysVisible: Boolean = false,
+  val pinned: Boolean = false,
+) {
+  Home(storageKey = "home", defaultGridLayout = true, alwaysVisible = true, pinned = true),
+  Series(storageKey = "series"),
+  Authors(storageKey = "authors"),
+  Playlists(storageKey = "playlists"),
+  Collections(storageKey = "collections"),
+  Downloads(storageKey = "downloads"),
+  ;
+
+  companion object {
+    fun fromStorageKey(key: String): AndroidAutoCategory? =
+      entries.firstOrNull { it.storageKey == key }
+  }
+}
+
+data class AndroidAutoCategoryConfig(
+  val category: AndroidAutoCategory,
+  val visible: Boolean,
+  val isGridLayout: Boolean,
+)
+
+interface AndroidAutoSettings {
+
+  /**
+   * The ordered list of category configs reflecting what is shown in Android Auto.
+   *
+   * Order, visibility, and grid-layout overrides are merged into this single view.
+   * New categories introduced in future app versions appear at the tail with default values.
+   */
+  fun observeCategoryConfigs(): StateFlow<List<AndroidAutoCategoryConfig>>
+
+  fun setCategoryVisible(category: AndroidAutoCategory, visible: Boolean)
+
+  fun setCategoryGridLayout(category: AndroidAutoCategory, isGrid: Boolean)
+
+  /**
+   * Replace the current ordering. Any missing entries will be appended in enum order.
+   */
+  fun setCategoryOrder(order: List<AndroidAutoCategory>)
+}

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/AndroidAutoSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/AndroidAutoSettingsImpl.kt
@@ -1,0 +1,151 @@
+package app.campfire.settings
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.qualifier.ForScope
+import app.campfire.settings.api.AndroidAutoCategory
+import app.campfire.settings.api.AndroidAutoCategoryConfig
+import app.campfire.settings.api.AndroidAutoSettings
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.ObservableSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import me.tatarka.inject.annotations.Inject
+
+@OptIn(ExperimentalSettingsApi::class)
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = AndroidAutoSettings::class)
+@Inject
+class AndroidAutoSettingsImpl(
+  override val settings: ObservableSettings,
+  @ForScope(AppScope::class) override val scope: CoroutineScope,
+) : AndroidAutoSettings, AppSettings() {
+
+  private val orderProperty = customSetting(
+    key = PREF_AA_ORDER,
+    defaultValue = AndroidAutoCategory.entries.toList(),
+    getter = { raw -> raw.decodeOrder() },
+    setter = { order -> order.encodeOrder() },
+  )
+
+  private val hiddenProperty = customSetting(
+    key = PREF_AA_HIDDEN,
+    defaultValue = emptySet<AndroidAutoCategory>(),
+    getter = { raw -> raw.decodeCategorySet() },
+    setter = { hidden -> hidden.encodeCategorySet() },
+  )
+
+  private val gridOverridesProperty = customSetting(
+    key = PREF_AA_GRID_OVERRIDES,
+    defaultValue = emptyMap<AndroidAutoCategory, Boolean>(),
+    getter = { raw -> raw.decodeGridOverrides() },
+    setter = { overrides -> overrides.encodeGridOverrides() },
+  )
+
+  private var storedOrder: List<AndroidAutoCategory> by orderProperty
+  private var hiddenCategories: Set<AndroidAutoCategory> by hiddenProperty
+  private var gridOverrides: Map<AndroidAutoCategory, Boolean> by gridOverridesProperty
+
+  private val categoryConfigsFlow: StateFlow<List<AndroidAutoCategoryConfig>> = combine(
+    orderProperty.observe(),
+    hiddenProperty.observe(),
+    gridOverridesProperty.observe(),
+  ) { order, hidden, overrides ->
+    buildConfigs(order, hidden, overrides)
+  }.stateIn(
+    scope = scope,
+    started = SharingStarted.Lazily,
+    initialValue = buildConfigs(storedOrder, hiddenCategories, gridOverrides),
+  )
+
+  override fun observeCategoryConfigs(): StateFlow<List<AndroidAutoCategoryConfig>> = categoryConfigsFlow
+
+  override fun setCategoryVisible(category: AndroidAutoCategory, visible: Boolean) {
+    if (category.alwaysVisible && !visible) return
+    hiddenCategories = if (visible) {
+      hiddenCategories - category
+    } else {
+      hiddenCategories + category
+    }
+  }
+
+  override fun setCategoryGridLayout(category: AndroidAutoCategory, isGrid: Boolean) {
+    gridOverrides = if (isGrid == category.defaultGridLayout) {
+      gridOverrides - category
+    } else {
+      gridOverrides + (category to isGrid)
+    }
+  }
+
+  override fun setCategoryOrder(order: List<AndroidAutoCategory>) {
+    storedOrder = normalizeOrder(order)
+  }
+
+  private fun buildConfigs(
+    order: List<AndroidAutoCategory>,
+    hidden: Set<AndroidAutoCategory>,
+    overrides: Map<AndroidAutoCategory, Boolean>,
+  ): List<AndroidAutoCategoryConfig> {
+    return normalizeOrder(order).map { category ->
+      AndroidAutoCategoryConfig(
+        category = category,
+        visible = category.alwaysVisible || category !in hidden,
+        isGridLayout = overrides[category] ?: category.defaultGridLayout,
+      )
+    }
+  }
+
+  /**
+   * Reconciles a desired order with the pinned constraint: pinned categories always sit at
+   * their declaration position, regardless of what the stored / incoming order says.
+   */
+  private fun normalizeOrder(order: List<AndroidAutoCategory>): List<AndroidAutoCategory> {
+    val deduped = order.distinct()
+    val withMissing = deduped + AndroidAutoCategory.entries.filterNot { it in deduped }
+    val nonPinned = withMissing.filterNot { it.pinned }.toMutableList()
+    return buildList {
+      AndroidAutoCategory.entries.forEach { category ->
+        if (category.pinned) add(category)
+      }
+      addAll(nonPinned)
+    }
+  }
+}
+
+internal const val PREF_AA_ORDER = "pref_android_auto_category_order"
+internal const val PREF_AA_HIDDEN = "pref_android_auto_hidden_categories"
+internal const val PREF_AA_GRID_OVERRIDES = "pref_android_auto_grid_overrides"
+
+private const val LIST_SEPARATOR = ":"
+private const val ENTRY_SEPARATOR = "="
+
+private fun String.decodeOrder(): List<AndroidAutoCategory> =
+  split(LIST_SEPARATOR).mapNotNull(AndroidAutoCategory::fromStorageKey)
+
+private fun List<AndroidAutoCategory>.encodeOrder(): String =
+  joinToString(LIST_SEPARATOR) { it.storageKey }
+
+private fun String.decodeCategorySet(): Set<AndroidAutoCategory> =
+  if (isEmpty()) emptySet() else split(LIST_SEPARATOR).mapNotNull(AndroidAutoCategory::fromStorageKey).toSet()
+
+private fun Set<AndroidAutoCategory>.encodeCategorySet(): String =
+  joinToString(LIST_SEPARATOR) { it.storageKey }
+
+private fun String.decodeGridOverrides(): Map<AndroidAutoCategory, Boolean> {
+  if (isEmpty()) return emptyMap()
+  return split(LIST_SEPARATOR).mapNotNull { entry ->
+    val (key, value) = entry.split(ENTRY_SEPARATOR, limit = 2).takeIf { it.size == 2 }
+      ?: return@mapNotNull null
+    val category = AndroidAutoCategory.fromStorageKey(key) ?: return@mapNotNull null
+    category to value.toBooleanStrictOrNull()
+  }.mapNotNull { (category, bool) -> bool?.let { category to it } }.toMap()
+}
+
+private fun Map<AndroidAutoCategory, Boolean>.encodeGridOverrides(): String =
+  entries.joinToString(LIST_SEPARATOR) { (category, isGrid) ->
+    "${category.storageKey}$ENTRY_SEPARATOR$isGrid"
+  }

--- a/features/settings/ui/build.gradle.kts
+++ b/features/settings/ui/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
         implementation(projects.ui.theming.api)
 
         implementation(libs.circuitx.overlays)
+        implementation(libs.reorderable)
 
         implementation(libs.compose.components.resources)
       }

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -12,6 +12,8 @@
   <string name="setting_playback_subtitle">Time jumps, and other playback settings</string>
   <string name="setting_sleep_title">Sleep</string>
   <string name="setting_sleep_subtitle">Timers, shake to reset, and haptics</string>
+  <string name="setting_android_auto_title">Android Auto</string>
+  <string name="setting_android_auto_subtitle">Categories, ordering, and layout</string>
   <string name="setting_about_title">About</string>
   <string name="setting_about_subtitle">Developer, attributions, and version</string>
   <string name="setting_developer_title">Developer</string>
@@ -116,6 +118,27 @@
   <string name="about_attributions_title">Open source attributions</string>
   <string name="about_changelog_title">Changelog</string>
   <string name="about_version_title">Version</string>
+
+  <!-- Android Auto setting -->
+  <string name="android_auto_unavailable_warning_title">Warning</string>
+  <string name="android_auto_unavailable_warning_body">This version of the app was installed from an "Unknown Source" (i.e. not the Google PlayStore) and will therefore not be visible in Android Auto by default. To enable it and access Android Auto functionality, you must do the following:</string>
+  <string name="android_auto_unavailable_step_1">Open the Android Auto settings (see below)</string>
+  <string name="android_auto_unavailable_step_2">Scroll down to 'Version' and click it until Developer mode is enabled</string>
+  <string name="android_auto_unavailable_step_3">Click the '⋮' icon, and then 'Developer settings'</string>
+  <string name="android_auto_unavailable_step_4">Enable 'Unknown sources'</string>
+  <string name="android_auto_unavailable_step_5">Re-connect Android Auto!</string>
+  <string name="android_auto_open_settings">Open Android Auto settings</string>
+  <string name="android_auto_header_categories">Categories</string>
+  <string name="android_auto_categories_description">Drag to reorder. Toggle each category's visibility and choose whether its contents appear as a grid or list.</string>
+  <string name="android_auto_category_home">Home</string>
+  <string name="android_auto_category_series">Series</string>
+  <string name="android_auto_category_authors">Authors</string>
+  <string name="android_auto_category_playlists">Playlists</string>
+  <string name="android_auto_category_collections">Collections</string>
+  <string name="android_auto_category_downloads">Downloads</string>
+  <string name="android_auto_layout_grid">Grid</string>
+  <string name="android_auto_layout_list">List</string>
+  <string name="android_auto_drag_handle_description">Drag to reorder</string>
 
   <!-- Developer setting -->
   <string name="developer_settings_title">Developer</string>

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -2,7 +2,6 @@ package app.campfire.ui.settings
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -16,15 +15,18 @@ import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.screens.AttributionScreen
 import app.campfire.common.screens.SettingsScreen
 import app.campfire.common.screens.UrlScreen
+import app.campfire.core.Platform
 import app.campfire.core.app.ApplicationInfo
 import app.campfire.core.app.ApplicationUrls
 import app.campfire.core.coroutines.LoadState
+import app.campfire.core.currentPlatform
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.Server
 import app.campfire.core.session.UserSession
 import app.campfire.core.session.requiredUser
 import app.campfire.libraries.api.LibraryItemRepository
 import app.campfire.libraries.api.screen.LibraryItemScreen
+import app.campfire.settings.api.AndroidAutoSettings
 import app.campfire.settings.api.CampfireSettings
 import app.campfire.settings.api.DevSettings
 import app.campfire.settings.api.PlaybackSettings
@@ -95,6 +97,7 @@ class SettingsPresenter(
   private val themeRepository: AppThemeRepository,
   private val playbackSettings: PlaybackSettings,
   private val sleepSettings: SleepSettings,
+  private val androidAutoSettings: AndroidAutoSettings,
   private val devSettings: DevSettings,
   private val serverRepository: ServerRepository,
   private val offlineDownloadManager: OfflineDownloadManager,
@@ -170,15 +173,21 @@ class SettingsPresenter(
     val analyticReportingEnabled by remember { settings.observeAnalyticReportingEnabled() }
       .collectAsState()
 
+    // Android Auto Settings
+    val androidAutoCategories by remember {
+      androidAutoSettings.observeCategoryConfigs()
+    }.collectAsState()
+    val isAndroidAutoAvailable = remember { androidAuto.isAvailable() }
+
     // Developer Settings
     val developerModeEnabled by remember { devSettings.observeDeveloperMode() }.collectAsState()
     val sessionAge by remember { devSettings.observeSessionAge() }.collectAsState()
     val showWidgetPinningPrompt by remember { settings.observeHasShownWidgetPinning() }.collectAsState()
-    val isAndroidAutoAvailable = remember { androidAuto.isAvailable() }
 
     return SettingsUiState(
       server = server,
       isShakingAvailable = remember { shakeDetector.isAvailable },
+      isAndroidAutoPaneVisible = currentPlatform == Platform.ANDROID,
       applicationInfo = applicationInfo,
       appearanceSettings = AppearanceSettingsInfo(
         appTheme = appTheme,
@@ -220,12 +229,15 @@ class SettingsPresenter(
         crashReportingEnabled = crashReportingEnabled,
         analyticReportingEnabled = analyticReportingEnabled,
       ),
+      androidAutoSettings = AndroidAutoSettingsInfo(
+        isAndroidAutoAvailable = isAndroidAutoAvailable,
+        categories = androidAutoCategories,
+      ),
       developerSettings = DeveloperSettingsInfo(
         developerModeEnabled = developerModeEnabled || applicationInfo.debugBuild,
         sessionAge = sessionAge,
         showWidgetPinningPrompt = showWidgetPinningPrompt,
         analyticsDebugState = analytics.debugState,
-        isAndroidAutoAvailable = isAndroidAutoAvailable,
       ),
     ) { event ->
       analyticUiEventHandler.handle(event)
@@ -313,12 +325,21 @@ class SettingsPresenter(
           is SettingsUiEvent.DeveloperSettingEvent.ShowWidgetPinningChange ->
             settings.hasShownWidgetPinning = event.enabled
           is SettingsUiEvent.DeveloperSettingEvent.EnableDeveloperMode -> devSettings.developerModeEnabled = true
-          is SettingsUiEvent.DeveloperSettingEvent.OpenAndroidAutoSettings -> androidAuto.openSettings()
           is SettingsUiEvent.DeveloperSettingEvent.InvalidateCurrentAccount -> {
             scope.launch {
               accountManager.invalidateAccount(userSession.requiredUser)
             }
           }
+        }
+
+        is SettingsUiEvent.AndroidAutoSettingEvent -> when (event) {
+          is SettingsUiEvent.AndroidAutoSettingEvent.OpenAndroidAutoSettings -> androidAuto.openSettings()
+          is SettingsUiEvent.AndroidAutoSettingEvent.SetCategoryVisible ->
+            androidAutoSettings.setCategoryVisible(event.category, event.visible)
+          is SettingsUiEvent.AndroidAutoSettingEvent.SetCategoryGridLayout ->
+            androidAutoSettings.setCategoryGridLayout(event.category, event.isGrid)
+          is SettingsUiEvent.AndroidAutoSettingEvent.ReorderCategories ->
+            androidAutoSettings.setCategoryOrder(event.order)
         }
       }
     }

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -145,18 +145,11 @@ class SettingsPresenter(
       offlineDownloadManager.observeAll()
     }.collectAsState(emptyList())
 
-    val downloadItemIds by remember {
-      derivedStateOf {
-        downloads.map { it.libraryItemId }.toSet()
-      }
-    }
-
     val downloadedLibraryItems by remember {
-      snapshotFlow { downloadItemIds }
-        .mapLatest { itemIds ->
-          itemIds.associate { itemId ->
-            libraryItemRepository.getLibraryItem(itemId) to
-              downloads.first { it.libraryItemId == itemId }
+      snapshotFlow { downloads }
+        .mapLatest {
+          it.associateWith { item ->
+            libraryItemRepository.getLibraryItem(item.libraryItemId)
           }
         }
     }.collectAsState(emptyMap())

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUi.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUi.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material.icons.rounded.DeveloperMode
+import androidx.compose.material.icons.rounded.DirectionsCar
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.NotificationsPaused
@@ -54,6 +55,7 @@ import app.campfire.ui.settings.composables.SettingPaneListItem
 import app.campfire.ui.settings.composables.SettingsPaneDefaults
 import app.campfire.ui.settings.panes.AboutPane
 import app.campfire.ui.settings.panes.AccountPane
+import app.campfire.ui.settings.panes.AndroidAutoPane
 import app.campfire.ui.settings.panes.AppearancePane
 import app.campfire.ui.settings.panes.DeveloperPane
 import app.campfire.ui.settings.panes.DownloadsPane
@@ -66,6 +68,8 @@ import campfire.features.settings.ui.generated.resources.setting_about_subtitle
 import campfire.features.settings.ui.generated.resources.setting_about_title
 import campfire.features.settings.ui.generated.resources.setting_account_subtitle
 import campfire.features.settings.ui.generated.resources.setting_account_title
+import campfire.features.settings.ui.generated.resources.setting_android_auto_subtitle
+import campfire.features.settings.ui.generated.resources.setting_android_auto_title
 import campfire.features.settings.ui.generated.resources.setting_appearance_subtitle
 import campfire.features.settings.ui.generated.resources.setting_appearance_title
 import campfire.features.settings.ui.generated.resources.setting_developer_subtitle
@@ -104,6 +108,7 @@ fun SettingsUi(
         SettingsScreen.Page.Downloads -> SettingsPane.Downloads
         SettingsScreen.Page.Playback -> SettingsPane.Playback
         SettingsScreen.Page.Sleep -> SettingsPane.Sleep
+        SettingsScreen.Page.AndroidAuto -> SettingsPane.AndroidAuto
         SettingsScreen.Page.About -> SettingsPane.About
         SettingsScreen.Page.Developer -> SettingsPane.Developer
       },
@@ -150,6 +155,7 @@ private fun TwoPaneLayout(
       onPaneClick = onPaneClick,
       onBackClick = { state.eventSink(SettingsUiEvent.Back) },
       showDeveloperPane = state.developerSettings.developerModeEnabled,
+      showAndroidAutoPane = state.isAndroidAutoPaneVisible,
       modifier = Modifier
         .padding(top = 16.dp)
         .fillMaxHeight()
@@ -206,6 +212,7 @@ private fun OnePaneLayout(
     onPaneClick = onPaneClick,
     onBackClick = { state.eventSink(SettingsUiEvent.Back) },
     showDeveloperPane = state.developerSettings.developerModeEnabled,
+    showAndroidAutoPane = state.isAndroidAutoPaneVisible,
     modifier = modifier
       .systemBarsPadding()
       .fillMaxSize(),
@@ -238,6 +245,7 @@ private fun SettingsRootPane(
   onPaneClick: (SettingsPane) -> Unit,
   onBackClick: () -> Unit,
   showDeveloperPane: Boolean,
+  showAndroidAutoPane: Boolean,
   modifier: Modifier = Modifier,
   isTwoPane: Boolean = false,
 ) {
@@ -357,8 +365,31 @@ private fun SettingsRootPane(
         onClick = {
           onPaneClick(SettingsPane.Sleep)
         },
-        shape = SettingsPaneDefaults.bottomShape(),
+        shape = if (showAndroidAutoPane) {
+          SettingsPaneDefaults.middleShape()
+        } else {
+          SettingsPaneDefaults.bottomShape()
+        },
       )
+
+      // Android Auto (Android only)
+      if (showAndroidAutoPane) {
+        SettingPaneListItem(
+          selected = pane == SettingsPane.AndroidAuto && isTwoPane,
+          icon = {
+            Icon(
+              Icons.Rounded.DirectionsCar,
+              contentDescription = null,
+            )
+          },
+          title = { Text(stringResource(Res.string.setting_android_auto_title)) },
+          subtitle = { Text(stringResource(Res.string.setting_android_auto_subtitle)) },
+          onClick = {
+            onPaneClick(SettingsPane.AndroidAuto)
+          },
+          shape = SettingsPaneDefaults.bottomShape(),
+        )
+      }
 
       Spacer(Modifier.height(8.dp))
 
@@ -438,6 +469,12 @@ private fun SettingPaneContent(
     )
 
     SettingsPane.Sleep -> SleepPane(
+      state = state,
+      onBackClick = onBackClick,
+      modifier = modifier,
+    )
+
+    SettingsPane.AndroidAuto -> AndroidAutoPane(
       state = state,
       onBackClick = onBackClick,
       modifier = modifier,

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -10,6 +10,8 @@ import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Server
 import app.campfire.core.model.Tent
+import app.campfire.settings.api.AndroidAutoCategory
+import app.campfire.settings.api.AndroidAutoCategoryConfig
 import app.campfire.settings.api.SleepSettings
 import app.campfire.settings.api.SleepSettings.AutoSleepTimer
 import app.campfire.settings.api.SleepSettings.ShakeSensitivity
@@ -24,11 +26,13 @@ import kotlinx.datetime.LocalTime
 data class SettingsUiState(
   val server: LoadState<out Server>,
   val isShakingAvailable: Boolean,
+  val isAndroidAutoPaneVisible: Boolean,
   val applicationInfo: ApplicationInfo,
   val appearanceSettings: AppearanceSettingsInfo,
   val downloadsSettings: DownloadsSettingsInfo,
   val playbackSettings: PlaybackSettingsInfo,
   val sleepSettings: SleepSettingsInfo,
+  val androidAutoSettings: AndroidAutoSettingsInfo,
   val aboutSettings: AboutSettingsInfo,
   val developerSettings: DeveloperSettingsInfo,
   val eventSink: (SettingsUiEvent) -> Unit,
@@ -85,12 +89,17 @@ data class AboutSettingsInfo(
 )
 
 @Immutable
+data class AndroidAutoSettingsInfo(
+  val isAndroidAutoAvailable: Boolean,
+  val categories: List<AndroidAutoCategoryConfig>,
+)
+
+@Immutable
 data class DeveloperSettingsInfo(
   val developerModeEnabled: Boolean,
   val sessionAge: Duration,
   val showWidgetPinningPrompt: Boolean,
   val analyticsDebugState: String,
-  val isAndroidAutoAvailable: Boolean,
 )
 
 enum class SettingsPane {
@@ -99,6 +108,7 @@ enum class SettingsPane {
   Downloads,
   Playback,
   Sleep,
+  AndroidAuto,
   About,
   Developer,
   ;
@@ -109,6 +119,7 @@ enum class SettingsPane {
     Downloads -> SettingsScreen.Page.Downloads
     Playback -> SettingsScreen.Page.Playback
     Sleep -> SettingsScreen.Page.Sleep
+    AndroidAuto -> SettingsScreen.Page.AndroidAuto
     About -> SettingsScreen.Page.About
     Developer -> SettingsScreen.Page.Developer
   }
@@ -178,9 +189,22 @@ sealed interface SettingsUiEvent : CircuitUiEvent {
 
   sealed interface DeveloperSettingEvent : SettingsUiEvent {
     data object EnableDeveloperMode : DeveloperSettingEvent
-    data object OpenAndroidAutoSettings : DeveloperSettingEvent
     data object InvalidateCurrentAccount : DeveloperSettingEvent
     data class SessionAge(val sessionAge: Duration) : DeveloperSettingEvent
     data class ShowWidgetPinningChange(val enabled: Boolean) : DeveloperSettingEvent
+  }
+
+  // Android Auto Pane Events
+  sealed interface AndroidAutoSettingEvent : SettingsUiEvent {
+    data object OpenAndroidAutoSettings : AndroidAutoSettingEvent
+    data class SetCategoryVisible(
+      val category: AndroidAutoCategory,
+      val visible: Boolean,
+    ) : AndroidAutoSettingEvent
+    data class SetCategoryGridLayout(
+      val category: AndroidAutoCategory,
+      val isGrid: Boolean,
+    ) : AndroidAutoSettingEvent
+    data class ReorderCategories(val order: List<AndroidAutoCategory>) : AndroidAutoSettingEvent
   }
 }

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -46,7 +46,7 @@ data class AppearanceSettingsInfo(
 @Immutable
 data class DownloadsSettingsInfo(
   val showDownloadConfirmation: Boolean,
-  val downloads: Map<LibraryItem, OfflineDownload>,
+  val downloads: Map<OfflineDownload, LibraryItem>,
 )
 
 @Immutable

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
@@ -118,5 +118,24 @@ class SettingsAnalyticUiEventHandler(
     }
 
     is SettingsUiEvent.DeveloperSettingEvent -> Unit
+
+    is SettingsUiEvent.AndroidAutoSettingEvent -> when (event) {
+      SettingsUiEvent.AndroidAutoSettingEvent.OpenAndroidAutoSettings -> send("open_android_auto_settings", Click)
+      is SettingsUiEvent.AndroidAutoSettingEvent.SetCategoryVisible -> send(
+        "android_auto_category_visible",
+        Updated,
+        "${event.category.storageKey}=${event.visible}",
+      )
+      is SettingsUiEvent.AndroidAutoSettingEvent.SetCategoryGridLayout -> send(
+        "android_auto_category_grid",
+        Updated,
+        "${event.category.storageKey}=${event.isGrid}",
+      )
+      is SettingsUiEvent.AndroidAutoSettingEvent.ReorderCategories -> send(
+        "android_auto_reorder",
+        Updated,
+        event.order.joinToString(",") { it.storageKey },
+      )
+    }
   }
 }

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/AndroidAutoPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/AndroidAutoPane.kt
@@ -1,0 +1,328 @@
+package app.campfire.ui.settings.panes
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.rounded.DragIndicator
+import androidx.compose.material.icons.rounded.PushPin
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.campfire.settings.api.AndroidAutoCategory
+import app.campfire.settings.api.AndroidAutoCategoryConfig
+import app.campfire.ui.settings.SettingsUiEvent.AndroidAutoSettingEvent
+import app.campfire.ui.settings.SettingsUiState
+import app.campfire.ui.settings.composables.ActionSetting
+import app.campfire.ui.settings.composables.Header
+import campfire.features.settings.ui.generated.resources.Res
+import campfire.features.settings.ui.generated.resources.android_auto_categories_description
+import campfire.features.settings.ui.generated.resources.android_auto_category_authors
+import campfire.features.settings.ui.generated.resources.android_auto_category_collections
+import campfire.features.settings.ui.generated.resources.android_auto_category_downloads
+import campfire.features.settings.ui.generated.resources.android_auto_category_home
+import campfire.features.settings.ui.generated.resources.android_auto_category_playlists
+import campfire.features.settings.ui.generated.resources.android_auto_category_series
+import campfire.features.settings.ui.generated.resources.android_auto_drag_handle_description
+import campfire.features.settings.ui.generated.resources.android_auto_header_categories
+import campfire.features.settings.ui.generated.resources.android_auto_layout_grid
+import campfire.features.settings.ui.generated.resources.android_auto_layout_list
+import campfire.features.settings.ui.generated.resources.android_auto_open_settings
+import campfire.features.settings.ui.generated.resources.android_auto_unavailable_step_1
+import campfire.features.settings.ui.generated.resources.android_auto_unavailable_step_2
+import campfire.features.settings.ui.generated.resources.android_auto_unavailable_step_3
+import campfire.features.settings.ui.generated.resources.android_auto_unavailable_step_4
+import campfire.features.settings.ui.generated.resources.android_auto_unavailable_step_5
+import campfire.features.settings.ui.generated.resources.android_auto_unavailable_warning_body
+import campfire.features.settings.ui.generated.resources.android_auto_unavailable_warning_title
+import campfire.features.settings.ui.generated.resources.setting_android_auto_title
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import sh.calvin.reorderable.ReorderableColumn
+
+@Composable
+internal fun AndroidAutoPane(
+  state: SettingsUiState,
+  onBackClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  SettingPaneLayout(
+    title = { Text(stringResource(Res.string.setting_android_auto_title)) },
+    onBackClick = onBackClick,
+    modifier = modifier,
+  ) {
+    if (!state.androidAutoSettings.isAndroidAutoAvailable) {
+      UnavailableWarningCard()
+    }
+
+    ActionSetting(
+      headlineContent = { Text(stringResource(Res.string.android_auto_open_settings)) },
+      leadingContent = { Icon(Icons.AutoMirrored.Rounded.OpenInNew, contentDescription = null) },
+      onClick = { state.eventSink(AndroidAutoSettingEvent.OpenAndroidAutoSettings) },
+    )
+
+    Header(
+      title = { Text(stringResource(Res.string.android_auto_header_categories)) },
+    )
+
+    Text(
+      text = stringResource(Res.string.android_auto_categories_description),
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    Spacer(Modifier.height(8.dp))
+
+    val haptics = LocalHapticFeedback.current
+    val categories = state.androidAutoSettings.categories
+    ReorderableColumn(
+      list = categories,
+      onSettle = { from, to ->
+        val reordered = categories.toMutableList().apply {
+          add(to, removeAt(from))
+        }
+        state.eventSink(
+          AndroidAutoSettingEvent.ReorderCategories(reordered.map { it.category }),
+        )
+      },
+      onMove = {
+        haptics.performHapticFeedback(HapticFeedbackType.SegmentTick)
+      },
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+      modifier = Modifier.padding(horizontal = 16.dp),
+    ) { index, config, isDragging ->
+      val interactionSource = remember { MutableInteractionSource() }
+
+      val content: @Composable (Modifier) -> Unit = { dragHandleModifier ->
+        CategoryRow(
+          config = config,
+          shape = rowShape(index = index, total = categories.size),
+          dragHandleModifier = dragHandleModifier,
+          onVisibilityChange = { visible ->
+            state.eventSink(AndroidAutoSettingEvent.SetCategoryVisible(config.category, visible))
+          },
+          onGridLayoutChange = { isGrid ->
+            state.eventSink(AndroidAutoSettingEvent.SetCategoryGridLayout(config.category, isGrid))
+          },
+          interactionSource = interactionSource,
+        )
+      }
+
+      if (config.category.pinned) {
+        content(Modifier)
+      } else {
+        ReorderableItem {
+          content(
+            Modifier.draggableHandle(
+              interactionSource = interactionSource,
+              onDragStarted = {
+                haptics.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
+              },
+              onDragStopped = {
+                haptics.performHapticFeedback(HapticFeedbackType.GestureEnd)
+              },
+            ),
+          )
+        }
+      }
+    }
+
+    Spacer(Modifier.height(16.dp))
+  }
+}
+
+@Composable
+private fun CategoryRow(
+  config: AndroidAutoCategoryConfig,
+  shape: Shape,
+  dragHandleModifier: Modifier,
+  onVisibilityChange: (Boolean) -> Unit,
+  onGridLayoutChange: (Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+  interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+  ElevatedCard(
+    enabled = config.visible,
+    onClick = { },
+    shape = shape,
+    colors = CardDefaults.elevatedCardColors(
+      disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+      disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.38f),
+    ),
+    modifier = modifier,
+    interactionSource = interactionSource,
+  ) {
+    ListItem(
+      headlineContent = { Text(stringResource(config.category.label)) },
+      supportingContent = {
+        LayoutChips(
+          enabled = config.visible,
+          isGridLayout = config.isGridLayout,
+          onGridLayoutChange = onGridLayoutChange,
+        )
+      },
+      leadingContent = {
+        val description = stringResource(Res.string.android_auto_drag_handle_description)
+        Icon(
+          imageVector = if (config.category.pinned) {
+            Icons.Rounded.PushPin
+          } else {
+            Icons.Rounded.DragIndicator
+          },
+          contentDescription = description,
+          modifier = dragHandleModifier.semantics { contentDescription = description },
+        )
+      },
+      trailingContent = {
+        Switch(
+          enabled = !config.category.alwaysVisible,
+          checked = config.visible,
+          onCheckedChange = onVisibilityChange,
+        )
+      },
+      colors = ListItemDefaults.colors(
+        headlineColor = LocalContentColor.current,
+        containerColor = Color.Transparent,
+      ),
+    )
+  }
+}
+
+@Composable
+private fun LayoutChips(
+  enabled: Boolean,
+  isGridLayout: Boolean,
+  onGridLayoutChange: (Boolean) -> Unit,
+) {
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier.padding(top = 4.dp),
+  ) {
+    FilterChip(
+      selected = !isGridLayout,
+      onClick = { onGridLayoutChange(false) },
+      enabled = enabled,
+      label = { Text(stringResource(Res.string.android_auto_layout_list)) },
+    )
+    FilterChip(
+      selected = isGridLayout,
+      onClick = { onGridLayoutChange(true) },
+      enabled = enabled,
+      label = { Text(stringResource(Res.string.android_auto_layout_grid)) },
+    )
+  }
+}
+
+@Composable
+private fun UnavailableWarningCard(
+  modifier: Modifier = Modifier,
+) {
+  ElevatedCard(
+    colors = CardDefaults.elevatedCardColors(
+      containerColor = MaterialTheme.colorScheme.secondaryContainer,
+      contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    ),
+    modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+  ) {
+    Row(
+      modifier = Modifier
+        .padding(horizontal = 16.dp)
+        .height(48.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Icon(
+        Icons.Rounded.Warning,
+        contentDescription = null,
+        modifier = Modifier.size(24.dp),
+      )
+      Text(
+        text = stringResource(Res.string.android_auto_unavailable_warning_title),
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.SemiBold,
+      )
+    }
+
+    Text(
+      text = buildAnnotatedString {
+        appendLine(stringResource(Res.string.android_auto_unavailable_warning_body))
+        appendBulletedList(
+          stringResource(Res.string.android_auto_unavailable_step_1),
+          stringResource(Res.string.android_auto_unavailable_step_2),
+          stringResource(Res.string.android_auto_unavailable_step_3),
+          stringResource(Res.string.android_auto_unavailable_step_4),
+          stringResource(Res.string.android_auto_unavailable_step_5),
+        )
+      },
+      style = MaterialTheme.typography.bodyMedium,
+      modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+    )
+  }
+}
+
+private fun AnnotatedString.Builder.appendBulletedList(vararg items: String) {
+  val bulletParagraphStyle = ParagraphStyle(textIndent = TextIndent(restLine = 16.sp))
+  items.forEach {
+    withStyle(bulletParagraphStyle) {
+      append("\u2022")
+      append("\t\t")
+      append(it)
+    }
+  }
+}
+
+private val AndroidAutoCategory.label: StringResource
+  get() = when (this) {
+    AndroidAutoCategory.Home -> Res.string.android_auto_category_home
+    AndroidAutoCategory.Series -> Res.string.android_auto_category_series
+    AndroidAutoCategory.Authors -> Res.string.android_auto_category_authors
+    AndroidAutoCategory.Playlists -> Res.string.android_auto_category_playlists
+    AndroidAutoCategory.Collections -> Res.string.android_auto_category_collections
+    AndroidAutoCategory.Downloads -> Res.string.android_auto_category_downloads
+  }
+
+private fun rowShape(index: Int, total: Int): Shape {
+  val large = 16.dp
+  val small = 4.dp
+  return when {
+    total == 1 -> RoundedCornerShape(large)
+    index == 0 -> RoundedCornerShape(topStart = large, topEnd = large, bottomStart = small, bottomEnd = small)
+    index == total - 1 ->
+      RoundedCornerShape(topStart = small, topEnd = small, bottomStart = large, bottomEnd = large)
+    else -> RoundedCornerShape(small)
+  }
+}

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DeveloperPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DeveloperPane.kt
@@ -1,28 +1,8 @@
 package app.campfire.ui.settings.panes
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.OpenInNew
-import androidx.compose.material.icons.rounded.Warning
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.ParagraphStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextIndent
-import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import app.campfire.core.Platform
 import app.campfire.core.currentPlatform
 import app.campfire.ui.settings.SettingsUiEvent.DeveloperSettingEvent
@@ -94,79 +74,5 @@ internal fun DeveloperPane(
       headlineContent = { Text("Analytics Debug State") },
       supportingContent = { Text(state.developerSettings.analyticsDebugState) },
     )
-
-    if (currentPlatform == Platform.ANDROID && !state.developerSettings.isAndroidAutoAvailable) {
-      Header(
-        title = { Text("Android Auto") },
-      )
-
-      ElevatedCard(
-        modifier = Modifier
-          .padding(
-            horizontal = 16.dp,
-            vertical = 8.dp,
-          ),
-        colors = CardDefaults.elevatedCardColors(
-          containerColor = MaterialTheme.colorScheme.secondaryContainer,
-          contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-        ),
-      ) {
-        Row(
-          modifier = Modifier
-            .padding(horizontal = 16.dp)
-            .height(48.dp),
-          horizontalArrangement = Arrangement.spacedBy(12.dp),
-          verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Icon(Icons.Rounded.Warning, contentDescription = null)
-          Text(
-            text = "Warning",
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.SemiBold,
-          )
-        }
-
-        Text(
-          text = buildAnnotatedString {
-            appendLine(
-              "This version of the app was installed from an \"Unknown Source\" (i.e. not the Google PlayStore) " +
-                "and will therefore not be visible in Android Auto by default. To enable it and access " +
-                "Android Auto functionality, you must do the following:",
-            )
-
-            appendBulletedList(
-              "Open the Android Auto settings (see below)",
-              "Scroll down to 'Version' and click it until Developer mode is enabled",
-              "Click the '⋮' icon, and then 'Developer settings'",
-              "Enable 'Unknown sources'",
-              "Re-connect Android Auto!",
-            )
-          },
-          style = MaterialTheme.typography.bodyMedium,
-          modifier = Modifier.padding(
-            start = 16.dp,
-            end = 16.dp,
-            bottom = 16.dp,
-          ),
-        )
-      }
-
-      ActionSetting(
-        headlineContent = { Text("Open Android Auto settings") },
-        leadingContent = { Icon(Icons.AutoMirrored.Rounded.OpenInNew, contentDescription = null) },
-        onClick = { state.eventSink(DeveloperSettingEvent.OpenAndroidAutoSettings) },
-      )
-    }
-  }
-}
-
-fun AnnotatedString.Builder.appendBulletedList(vararg items: String) {
-  val bulletParagraphStyle = ParagraphStyle(textIndent = TextIndent(restLine = 16.sp))
-  items.forEach {
-    withStyle(bulletParagraphStyle) {
-      append("\u2022")
-      append("\t\t")
-      append(it)
-    }
   }
 }

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
@@ -33,6 +33,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -285,6 +288,8 @@ private fun ItemDownloadImage(
       download.state != None &&
       download.state != Completed
     ) {
+      val downloadingColor = MaterialTheme.colorScheme.primaryContainer
+        .copy(alpha = 0.75f)
       Box(
         modifier = Modifier
           .size(size)
@@ -295,7 +300,23 @@ private fun ItemDownloadImage(
               -> MaterialTheme.colorScheme.errorContainer.copy(0.90f)
               else -> MaterialTheme.colorScheme.scrim.copy(0.6f)
             },
-          ),
+          )
+          .drawWithContent {
+            if (download.state == Downloading) {
+              val padding = 16.dp.toPx()
+              drawArc(
+                color = downloadingColor,
+                startAngle = -90f,
+                sweepAngle = 360f * download.progress.percent,
+                topLeft = Offset(-padding, -padding),
+                size = Size(this.size.width + (padding * 2), this.size.height + (padding * 2)),
+                useCenter = true,
+              )
+            }
+
+            drawContent()
+          }
+        ,
         contentAlignment = Alignment.Center,
       ) {
         Icon(

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
@@ -315,8 +315,7 @@ private fun ItemDownloadImage(
             }
 
             drawContent()
-          }
-        ,
+          },
         contentAlignment = Alignment.Center,
       ) {
         Icon(

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
@@ -93,7 +93,7 @@ internal fun DownloadsPane(
 
     state.downloadsSettings.downloads.ifNotEmpty {
       var showConfirmation by remember { mutableStateOf<LibraryItemId?>(null) }
-      forEach { (item, download) ->
+      forEach { (download, item) ->
         ConfirmationLayout(
           showConfirmation = showConfirmation == item.id,
           confirm = {

--- a/infra/audioplayer/impl/build.gradle.kts
+++ b/infra/audioplayer/impl/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
         // Android Auto support via the MediaLibraryService
         implementation(projects.features.home.api)
         implementation(projects.features.series.api)
+        implementation(projects.features.playlists.api)
         implementation(projects.features.collections.api)
         implementation(projects.features.author.api)
         implementation(projects.features.search.api)

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
@@ -39,6 +39,8 @@ import app.campfire.playlists.api.PlaylistsRepository
 import app.campfire.search.api.SearchRepository
 import app.campfire.search.api.SearchResult
 import app.campfire.series.api.SeriesRepository
+import app.campfire.settings.api.AndroidAutoCategory
+import app.campfire.settings.api.AndroidAutoSettings
 import kotlin.collections.firstOrNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterNot
@@ -59,6 +61,7 @@ class MediaTree(
   private val authorRepository: AuthorRepository,
   private val searchRepository: SearchRepository,
   private val offlineDownloadManager: OfflineDownloadManager,
+  private val androidAutoSettings: AndroidAutoSettings,
 ) {
 
   val root
@@ -79,12 +82,14 @@ class MediaTree(
     pageSize: Int,
   ): List<MediaItem> {
     return when (parentId) {
-      ROOT_ID -> TopLevelMediaItem.All.map {
-        it.asBrowsableMediaItem(
-          context = application,
-          isGridLayout = it.isGridLayout,
-        )
-      }
+      ROOT_ID -> androidAutoSettings.observeCategoryConfigs().value
+        .filter { it.visible }
+        .mapNotNull { config ->
+          config.category.toTopLevelMediaItem()?.asBrowsableMediaItem(
+            context = application,
+            isGridLayout = config.isGridLayout,
+          )
+        }
 
       HOME_ID -> loadHome()
       SERIES_ID -> loadSeries()
@@ -273,7 +278,7 @@ class MediaTree(
   @OptIn(UnstableApi::class)
   private fun LibraryItem.asBrowsableMediaItem(
     titleHint: String? = null,
-    download: OfflineDownload? = null
+    download: OfflineDownload? = null,
   ) = MediaItem.Builder()
     .setMediaId(id)
     .setMediaMetadata(
@@ -403,6 +408,15 @@ class MediaTree(
     .build()
 }
 
+private fun AndroidAutoCategory.toTopLevelMediaItem(): TopLevelMediaItem? = when (this) {
+  AndroidAutoCategory.Home -> TopLevelMediaItem.Home
+  AndroidAutoCategory.Series -> TopLevelMediaItem.Series
+  AndroidAutoCategory.Authors -> TopLevelMediaItem.Authors
+  AndroidAutoCategory.Playlists -> TopLevelMediaItem.Playlists
+  AndroidAutoCategory.Collections -> TopLevelMediaItem.Collections
+  AndroidAutoCategory.Downloads -> TopLevelMediaItem.Downloads
+}
+
 enum class TopLevelMediaItem(
   val mediaId: String,
   @get:StringRes val title: Int,
@@ -413,7 +427,7 @@ enum class TopLevelMediaItem(
   Authors(AUTHORS_ID, R.string.folder_authors_title),
   Playlists(PLAYLISTS_ID, R.string.folder_playlists_title),
   Collections(COLLECTIONS_ID, R.string.folder_collections_title),
-  Downloads(DOWNLOADS_ID, R.string.folder_downloads_title)
+  Downloads(DOWNLOADS_ID, R.string.folder_downloads_title),
   ;
 
   @OptIn(UnstableApi::class)

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
@@ -26,6 +26,8 @@ import app.campfire.core.model.Collection
 import app.campfire.core.model.CollectionId
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.Playlist
+import app.campfire.core.model.PlaylistId
 import app.campfire.core.model.Series
 import app.campfire.core.model.SeriesId
 import app.campfire.core.model.loggableId
@@ -33,6 +35,7 @@ import app.campfire.home.api.FeedResponse
 import app.campfire.home.api.HomeRepository
 import app.campfire.infra.audioplayer.impl.R
 import app.campfire.libraries.api.LibraryItemRepository
+import app.campfire.playlists.api.PlaylistsRepository
 import app.campfire.search.api.SearchRepository
 import app.campfire.search.api.SearchResult
 import app.campfire.series.api.SeriesRepository
@@ -51,6 +54,7 @@ class MediaTree(
   private val homeRepository: HomeRepository,
   private val libraryItemRepository: LibraryItemRepository,
   private val seriesRepository: SeriesRepository,
+  private val playlistsRepository: PlaylistsRepository,
   private val collectionsRepository: CollectionsRepository,
   private val authorRepository: AuthorRepository,
   private val searchRepository: SearchRepository,
@@ -84,12 +88,14 @@ class MediaTree(
 
       HOME_ID -> loadHome()
       SERIES_ID -> loadSeries()
-      COLLECTIONS_ID -> loadCollections()
       AUTHORS_ID -> loadAuthors()
+      PLAYLISTS_ID -> loadPlaylists()
+      COLLECTIONS_ID -> loadCollections()
       DOWNLOADS_ID -> loadDownloads()
 
       else -> when {
         parentId.startsWith(SERIES_PREFIX) -> getSeriesItems(parentId.removePrefix(SERIES_PREFIX))
+        parentId.startsWith(PLAYLISTS_PREFIX) -> getPlaylistItems(parentId.removePrefix(PLAYLISTS_PREFIX))
         parentId.startsWith(COLLECTIONS_PREFIX) -> getCollectionItems(parentId.removePrefix(COLLECTIONS_PREFIX))
         parentId.startsWith(AUTHORS_PREFIX) -> getAuthorItems(parentId.removePrefix(AUTHORS_PREFIX))
 
@@ -157,24 +163,6 @@ class MediaTree(
     }
   }
 
-  private suspend fun loadCollections(): List<MediaItem> {
-    val collections = collectionsRepository.observeAllCollections().firstOrNull() ?: return emptyList()
-
-    return collections.map { collection ->
-      collection.asBrowsableMediaItem()
-    }
-  }
-
-  private suspend fun getCollectionItems(collectionId: CollectionId): List<MediaItem> {
-    val items = collectionsRepository.observeCollectionItems(collectionId)
-      .firstOrNull()
-      ?: return emptyList()
-
-    return items.map { item ->
-      item.asBrowsableMediaItem()
-    }
-  }
-
   private suspend fun loadAuthors(): List<MediaItem> {
     val authors = authorRepository.observeAuthors().firstOrNull { it.isNotEmpty() } ?: return emptyList()
 
@@ -187,6 +175,42 @@ class MediaTree(
     val items = authorRepository.observeAuthor(authorId)
       .firstOrNull()
       ?.libraryItems
+      ?: return emptyList()
+
+    return items.map { item ->
+      item.asBrowsableMediaItem()
+    }
+  }
+
+  private suspend fun loadPlaylists(): List<MediaItem> {
+    val playlists = playlistsRepository.observeAllPlaylists().firstOrNull { it.isNotEmpty() } ?: return emptyList()
+
+    return playlists.map { playlist ->
+      playlist.asBrowsableMediaItem()
+    }
+  }
+
+  private suspend fun getPlaylistItems(playlistId: PlaylistId): List<MediaItem> {
+    val items = playlistsRepository.observePlaylistItems(playlistId)
+      .firstOrNull()
+      ?: return emptyList()
+
+    return items.map { item ->
+      item.asBrowsableMediaItem()
+    }
+  }
+
+  private suspend fun loadCollections(): List<MediaItem> {
+    val collections = collectionsRepository.observeAllCollections().firstOrNull() ?: return emptyList()
+
+    return collections.map { collection ->
+      collection.asBrowsableMediaItem()
+    }
+  }
+
+  private suspend fun getCollectionItems(collectionId: CollectionId): List<MediaItem> {
+    val items = collectionsRepository.observeCollectionItems(collectionId)
+      .firstOrNull()
       ?: return emptyList()
 
     return items.map { item ->
@@ -340,6 +364,20 @@ class MediaTree(
     )
     .build()
 
+  private fun Playlist.asBrowsableMediaItem() = MediaItem.Builder()
+    .setMediaId("$PLAYLISTS_PREFIX$id")
+    .setMediaMetadata(
+      MediaMetadata.Builder()
+        .setTitle(name)
+        .setDescription(description)
+        .setArtworkUri(items.firstOrNull()?.libraryItem?.media?.coverImageUrl?.toUri())
+        .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS)
+        .setIsBrowsable(true)
+        .setIsPlayable(false)
+        .build(),
+    )
+    .build()
+
   @OptIn(UnstableApi::class)
   private fun Author.asBrowsableMediaItem(
     titleHint: String? = null,
@@ -372,8 +410,9 @@ enum class TopLevelMediaItem(
 ) {
   Home(HOME_ID, R.string.folder_home_title, true),
   Series(SERIES_ID, R.string.folder_series_title),
-  Collections(COLLECTIONS_ID, R.string.folder_collections_title),
   Authors(AUTHORS_ID, R.string.folder_authors_title),
+  Playlists(PLAYLISTS_ID, R.string.folder_playlists_title),
+  Collections(COLLECTIONS_ID, R.string.folder_collections_title),
   Downloads(DOWNLOADS_ID, R.string.folder_downloads_title)
   ;
 
@@ -413,8 +452,10 @@ private const val ROOT_ID = "root-campfire"
 private const val HOME_ID = "home-campfire"
 private const val SERIES_ID = "series-campfire"
 private const val SERIES_PREFIX = "series_"
-private const val COLLECTIONS_ID = "collections-campfire"
-private const val COLLECTIONS_PREFIX = "collections_"
 private const val AUTHORS_ID = "authors-campfire"
 private const val AUTHORS_PREFIX = "authors_"
+private const val PLAYLISTS_ID = "playlists-campfire"
+private const val PLAYLISTS_PREFIX = "playlists_"
+private const val COLLECTIONS_ID = "collections-campfire"
+private const val COLLECTIONS_PREFIX = "collections_"
 private const val DOWNLOADS_ID = "downloads-campfire"

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
@@ -12,6 +12,8 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaConstants
 import app.campfire.audioplayer.impl.asPlatformMediaItem
 import app.campfire.audioplayer.impl.mediaitem.MediaItemBuilder
+import app.campfire.audioplayer.offline.OfflineDownload
+import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.author.api.AuthorRepository
 import app.campfire.collections.api.CollectionsRepository
 import app.campfire.core.di.SingleIn
@@ -38,6 +40,7 @@ import kotlin.collections.firstOrNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import me.tatarka.inject.annotations.Inject
 
@@ -51,6 +54,7 @@ class MediaTree(
   private val collectionsRepository: CollectionsRepository,
   private val authorRepository: AuthorRepository,
   private val searchRepository: SearchRepository,
+  private val offlineDownloadManager: OfflineDownloadManager,
 ) {
 
   val root
@@ -82,6 +86,7 @@ class MediaTree(
       SERIES_ID -> loadSeries()
       COLLECTIONS_ID -> loadCollections()
       AUTHORS_ID -> loadAuthors()
+      DOWNLOADS_ID -> loadDownloads()
 
       else -> when {
         parentId.startsWith(SERIES_PREFIX) -> getSeriesItems(parentId.removePrefix(SERIES_PREFIX))
@@ -189,6 +194,23 @@ class MediaTree(
     }
   }
 
+  private suspend fun loadDownloads(): List<MediaItem> {
+    val downloadItems = offlineDownloadManager.observeAll()
+      .map { downloads ->
+        downloads.associateWith { download ->
+          libraryItemRepository.getLibraryItem(download.libraryItemId)
+        }
+      }
+      .firstOrNull { it.isNotEmpty() }
+      ?: return emptyList()
+
+    return downloadItems.map { (download, libraryItem) ->
+      libraryItem.asBrowsableMediaItem(
+        download = download,
+      )
+    }
+  }
+
   suspend fun getItem(mediaId: String): MediaItem? {
     // Don't attempt to fetch our folder media items.
     if (
@@ -227,6 +249,7 @@ class MediaTree(
   @OptIn(UnstableApi::class)
   private fun LibraryItem.asBrowsableMediaItem(
     titleHint: String? = null,
+    download: OfflineDownload? = null
   ) = MediaItem.Builder()
     .setMediaId(id)
     .setMediaMetadata(
@@ -239,13 +262,36 @@ class MediaTree(
         .setGenre(media.metadata.genres.firstOrNull())
         .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
         .setTotalTrackCount(media.numChapters)
-        .fluentIf(titleHint != null) {
-          setExtras(
-            Bundle().apply {
+        .setExtras(
+          Bundle().apply {
+            if (titleHint != null) {
               putString(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE, titleHint)
-            },
-          )
-        }
+            }
+
+            if (download != null) {
+              putLong(
+                MediaConstants.EXTRAS_KEY_DOWNLOAD_STATUS,
+                when (download.state) {
+                  OfflineDownload.State.Stopped,
+                  OfflineDownload.State.Failed,
+                  OfflineDownload.State.None,
+                  -> MediaConstants.EXTRAS_VALUE_STATUS_NOT_DOWNLOADED
+
+                  OfflineDownload.State.Queued,
+                  OfflineDownload.State.Downloading,
+                  -> MediaConstants.EXTRAS_VALUE_STATUS_DOWNLOADING
+
+                  OfflineDownload.State.Completed -> MediaConstants.EXTRAS_VALUE_STATUS_DOWNLOADED
+                },
+              )
+
+              putFloat(
+                MediaConstants.EXTRAS_KEY_DOWNLOAD_PROGRESS,
+                download.progress.percent.coerceIn(0f..1f),
+              )
+            }
+          },
+        )
         .setIsBrowsable(false)
         .setIsPlayable(true)
         .build(),
@@ -328,6 +374,7 @@ enum class TopLevelMediaItem(
   Series(SERIES_ID, R.string.folder_series_title),
   Collections(COLLECTIONS_ID, R.string.folder_collections_title),
   Authors(AUTHORS_ID, R.string.folder_authors_title),
+  Downloads(DOWNLOADS_ID, R.string.folder_downloads_title)
   ;
 
   @OptIn(UnstableApi::class)
@@ -370,3 +417,4 @@ private const val COLLECTIONS_ID = "collections-campfire"
 private const val COLLECTIONS_PREFIX = "collections_"
 private const val AUTHORS_ID = "authors-campfire"
 private const val AUTHORS_PREFIX = "authors_"
+private const val DOWNLOADS_ID = "downloads-campfire"

--- a/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
+++ b/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
@@ -19,5 +19,6 @@
   <string name="folder_series_title">Series</string>
   <string name="folder_collections_title">Collections</string>
   <string name="folder_authors_title">Authors</string>
+  <string name="folder_playlists_title">Playlists</string>
   <string name="folder_downloads_title">Downloads</string>
 </resources>

--- a/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
+++ b/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
@@ -19,4 +19,5 @@
   <string name="folder_series_title">Series</string>
   <string name="folder_collections_title">Collections</string>
   <string name="folder_authors_title">Authors</string>
+  <string name="folder_downloads_title">Downloads</string>
 </resources>


### PR DESCRIPTION
## Summary

- New **Android Auto** settings pane (Android-only) for customizing the top-level categories shown in Android Auto
- Users can toggle each category's visibility, reorder them with drag handles, and choose a **list** or **grid** layout per category
- **Home** is pinned and always-visible; other categories (Series, Authors, Playlists, Collections, Downloads) are freely configurable
- Moves the "Android Auto not available" warning card and the **Open Android Auto settings** shortcut out of the Developer pane and into the new pane

Resolves #720 

## Implementation

- `AndroidAutoSettings` API + impl in `features/settings`, backed by three `ObservableSettings` keys (order, hidden set, grid overrides)
- Impl defensively enforces `alwaysVisible` / `pinned` constraints so a stale event or external write can't hide Home or reorder past it
- `MediaTree.getChildren(ROOT_ID)` now emits from `AndroidAutoSettings.observeCategoryConfigs().value` — visibility, order, and grid flag are read per emission
- Drag-to-reorder uses `sh.calvin.reorderable:reorderable` (already in the version catalog) with haptic feedback

## Test plan

- [ ] On Android: open Settings → Android Auto; verify the pane appears with all 6 categories
- [ ] Toggle a category off, reconnect to Android Auto, confirm it's hidden from the root
- [ ] Reorder categories, reconnect, confirm root order matches
- [ ] Swap a category's layout between List and Grid, confirm the corresponding AA view changes
- [ ] Home switch is disabled; Home cannot be dragged
- [ ] With AA not installed: warning card appears in the new pane; "Open Android Auto settings" launches the system intent
- [ ] On iOS / Desktop: the Android Auto pane does not appear in settings root
- [ ] Developer pane no longer contains the AA warning / action

🤖 Generated with [Claude Code](https://claude.com/claude-code)