### PR TITLE
Adjust time remaining on playback speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Already listened to chapters on items in-progress are collapsed by default
 - Overhauled playback homescreen widget UI
 - Theme color extraction from cover art now waits for a brief impression before dispatching, avoiding wasted work when scrolling past items
+- Time remaining on collapsed bar + item detail now reflect the current playback speed of a session
 
 ### Deprecated
 

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
@@ -177,6 +177,18 @@ class LibraryItemPresenter(
         .distinctUntilChanged()
     }.collectAsState(false)
 
+    val playbackSpeed by remember {
+      audioPlayerHolder.currentPlayer
+        .flatMapLatest {
+          if (it?.preparedSession?.libraryItem?.id == screen.libraryItemId) {
+            it.playbackSpeed
+          } else {
+            flowOf(1f)
+          }
+        }
+        .distinctUntilChanged()
+    }.collectAsState(1f)
+
     val isQueued by remember {
       sessionQueue.observeContains(screen.libraryItemId)
     }.collectAsState(false)
@@ -218,6 +230,7 @@ class LibraryItemPresenter(
         libraryItemValidation = itemValidation,
         sharedTransitionKey = screen.sharedTransitionKey,
         isPlaying = isPlaying,
+        playbackSpeed = playbackSpeed,
         mediaProgressState = mediaProgressState,
         offlineDownloadState = offlineDownloadState,
         seriesContentState = seriesContentState,
@@ -405,6 +418,7 @@ private fun buildSlots(
   libraryItemValidation: LibraryItemValidation,
   sharedTransitionKey: String,
   isPlaying: Boolean,
+  playbackSpeed: Float,
   mediaProgressState: LoadState<out MediaProgress?>,
   offlineDownloadState: OfflineDownload?,
   seriesContentState: LoadState<out List<LibraryItem>>,
@@ -431,7 +445,7 @@ private fun buildSlots(
     mediaProgressState.onLoaded { mediaProgress ->
       if (mediaProgress != null && mediaProgress.progress > 0f) {
         this += SpacerSlot.xlarge("progress_spacer_before")
-        this += ProgressSlot(isPlaying, mediaProgress, libraryItem)
+        this += ProgressSlot(isPlaying, playbackSpeed, mediaProgress, libraryItem)
         this += SpacerSlot.small("progress_spacer_after")
       }
     }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
@@ -326,7 +326,7 @@ fun LibraryItemPreview() = PreviewSharedElementTransitionLayout {
             CoverImageSlot("", "", ""),
             TitleAndAuthorSlot(libraryItem, ""),
             SpacerSlot.medium("progress_spacer"),
-            ProgressSlot(false, mediaProgress, libraryItem),
+            ProgressSlot(false, 1f, mediaProgress, libraryItem),
             SpacerSlot.medium("control_spacer"),
             ExpressiveControlSlot(
               libraryItem = libraryItem,

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/MediaProgressBar.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/MediaProgressBar.kt
@@ -1,5 +1,6 @@
 package app.campfire.libraries.ui.detail.composables
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.KeyboardDoubleArrowRight
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearWavyProgressIndicator
@@ -22,12 +24,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import app.campfire.common.compose.extensions.readoutFormat
 import app.campfire.common.compose.util.withDensity
 import app.campfire.core.extensions.asDate
 import app.campfire.core.extensions.asSeconds
+import app.campfire.core.extensions.fluentIf
 import app.campfire.core.extensions.readableFormat
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.MediaProgress
@@ -43,6 +48,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 internal fun MediaProgressBar(
   isPlaying: Boolean,
+  playbackSpeed: Float,
   libraryItem: LibraryItem,
   progress: MediaProgress,
   modifier: Modifier = Modifier,
@@ -101,16 +107,37 @@ internal fun MediaProgressBar(
         )
         else -> {
           val duration = progress.duration ?: libraryItem.media.durationInMillis.milliseconds.asSeconds()
-          val remainingDurationMillis = (duration - (duration * progress.actualProgress)) * 1000f
+          val remainingDurationMillis = (duration - (duration * progress.actualProgress)).div(playbackSpeed) * 1000f
           val remainingDuration = remainingDurationMillis.roundToLong().milliseconds.readoutFormat()
           stringResource(Res.string.remaining_duration_format, remainingDuration)
         }
       }
-      Text(
-        text = remainingText,
-        style = MaterialTheme.typography.labelSmall,
-        fontWeight = FontWeight.SemiBold,
-      )
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        val isAccelerated = playbackSpeed != 1f && !progress.isFinished
+        AnimatedVisibility(
+          visible = isAccelerated,
+        ) {
+          Icon(
+            Icons.Rounded.KeyboardDoubleArrowRight,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.secondary,
+          )
+        }
+        Text(
+          text = remainingText,
+          style = MaterialTheme.typography.labelSmall.fluentIf(isAccelerated) {
+            copy(
+              fontWeight = FontWeight.Bold,
+              fontStyle = FontStyle.Italic,
+              fontSize = 12.sp,
+            )
+          },
+          fontWeight = FontWeight.SemiBold,
+        )
+      }
 
       Spacer(Modifier.weight(1f))
 

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/MediaProgressBar.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/MediaProgressBar.kt
@@ -122,8 +122,9 @@ internal fun MediaProgressBar(
           Icon(
             Icons.Rounded.KeyboardDoubleArrowRight,
             contentDescription = null,
-            modifier = Modifier.size(16.dp),
             tint = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.size(16.dp)
+              .testTag("accelerated_icon"),
           )
         }
         Text(

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/ProgressSlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/ProgressSlot.kt
@@ -12,6 +12,7 @@ import app.campfire.libraries.ui.detail.composables.MediaProgressBar
 
 class ProgressSlot(
   val isPlaying: Boolean,
+  val playbackSpeed: Float,
   @get:VisibleForTesting val mediaProgress: MediaProgress,
   val libraryItem: LibraryItem,
 ) : ContentSlot {
@@ -22,6 +23,7 @@ class ProgressSlot(
   override fun Content(modifier: Modifier, eventSink: (LibraryItemUiEvent) -> Unit) {
     MediaProgressBar(
       isPlaying = isPlaying,
+      playbackSpeed = playbackSpeed,
       progress = mediaProgress,
       libraryItem = libraryItem,
       modifier = modifier

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/composables/slots/ProgressSlotTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/composables/slots/ProgressSlotTest.kt
@@ -23,7 +23,7 @@ class ProgressSlotTest {
       currentTime = 20f,
       duration = 100f,
     )
-    val slot = ProgressSlot(false, mediaProgress, libraryItem)
+    val slot = ProgressSlot(false, 1f, mediaProgress, libraryItem)
 
     setContent {
       PreviewSharedElementTransitionLayout {
@@ -38,6 +38,29 @@ class ProgressSlotTest {
   }
 
   @Test
+  fun isAcceleratedTest() = runComposeUiTest {
+    val libraryItem = libraryItem()
+    val mediaProgress = mediaProgress(
+      libraryItemId = TestLibraryItemId,
+      currentTime = 20f,
+      duration = 100f,
+    )
+    val slot = ProgressSlot(false, 2f, mediaProgress, libraryItem)
+
+    setContent {
+      PreviewSharedElementTransitionLayout {
+        slot.Content(Modifier) {}
+      }
+    }
+
+    onNodeWithTag("progress_indicator").assertExists()
+    onNodeWithTag("icon_finished_check").assertDoesNotExist()
+    onNodeWithTag("accelerated_icon").assertExists()
+    onNodeWithText("40s left").assertExists()
+    onNodeWithText("20%").assertExists()
+  }
+
+  @Test
   fun isFinishedTest() = runComposeUiTest {
     val libraryItem = libraryItem()
     val mediaProgress = mediaProgress(
@@ -47,7 +70,7 @@ class ProgressSlotTest {
       isFinished = true,
       finishedAt = 0L,
     )
-    val slot = ProgressSlot(false, mediaProgress, libraryItem)
+    val slot = ProgressSlot(false, 1f, mediaProgress, libraryItem)
 
     setContent {
       PreviewSharedElementTransitionLayout {

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/collapsed/CollapsedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/collapsed/CollapsedPlaybackBar.kt
@@ -233,7 +233,7 @@ private fun CollapsedPlaybackBarContent(
         dragState = dragState,
       )
 
-      Spacer(Modifier.width(16.dp))
+      Spacer(Modifier.width(12.dp))
 
       Column(
         modifier = Modifier.weight(1f),
@@ -281,11 +281,10 @@ private fun CollapsedPlaybackBarContent(
               copy(
                 fontWeight = FontWeight.Bold,
                 fontStyle = FontStyle.Italic,
-                color = MaterialTheme.colorScheme.secondary,
                 fontSize = 12.sp,
               )
             },
-            modifier = Modifier.alpha(0.7f),
+            modifier = Modifier.alpha(0.75f),
           )
         }
       }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/collapsed/CollapsedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/collapsed/CollapsedPlaybackBar.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.KeyboardDoubleArrowRight
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.CircularProgressIndicator
@@ -56,12 +57,14 @@ import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastRoundToInt
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.model.RunningTimer
@@ -71,6 +74,7 @@ import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Sync
 import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
+import app.campfire.core.extensions.fluentIf
 import app.campfire.core.extensions.progressOver
 import app.campfire.core.model.Session
 import app.campfire.sessions.ui.composables.RewindIcon
@@ -159,7 +163,9 @@ internal fun <T> T.CollapsedPlaybackBar(
     val title = playerState.metadata.title ?: session?.title ?: Session.TITLE_PLACEHOLDER
     val thumbnailUrl = playerState.metadata.artworkUri ?: session?.libraryItem?.media?.coverImageUrl
     val thumbnailContentDescription = session?.libraryItem?.media?.metadata?.title
-    val timeRemaining = session?.timeRemaining?.readoutFormat() ?: "--"
+    val timeRemaining = session?.timeRemaining
+      ?.div(playerState.speed.toDouble())
+      ?.readoutFormat() ?: "--"
 
     CollapsedPlaybackBarContent(
       dragState = dragState,
@@ -171,6 +177,7 @@ internal fun <T> T.CollapsedPlaybackBar(
         playerState.time progressOver playerState.duration
       },
       timeRemaining = timeRemaining,
+      isAccelerated = playerState.speed != 1f,
       runningTimer = playerState.timer,
       availableSync = syncState.availableSync,
       onSync = {
@@ -198,6 +205,7 @@ private fun CollapsedPlaybackBarContent(
   state: AudioPlayer.State,
   progress: () -> Float,
   timeRemaining: String,
+  isAccelerated: Boolean,
   runningTimer: RunningTimer?,
   availableSync: AvailableSync?,
   onSync: () -> Unit,
@@ -251,11 +259,35 @@ private fun CollapsedPlaybackBarContent(
           else -> stringResource(Res.string.time_remaining, timeRemaining)
         }
 
-        Text(
-          text = subtitle,
-          style = MaterialTheme.typography.labelSmall,
-          modifier = Modifier.alpha(0.7f),
-        )
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          AnimatedVisibility(
+            visible = isAccelerated &&
+              dragState.actionState != Dispose &&
+              availableSync == null,
+          ) {
+            Icon(
+              Icons.Rounded.KeyboardDoubleArrowRight,
+              contentDescription = null,
+              modifier = Modifier.size(16.dp),
+              tint = MaterialTheme.colorScheme.secondary,
+            )
+          }
+
+          Text(
+            text = subtitle,
+            style = MaterialTheme.typography.labelSmall.fluentIf(isAccelerated) {
+              copy(
+                fontWeight = FontWeight.Bold,
+                fontStyle = FontStyle.Italic,
+                color = MaterialTheme.colorScheme.secondary,
+                fontSize = 12.sp,
+              )
+            },
+            modifier = Modifier.alpha(0.7f),
+          )
+        }
       }
 
       Spacer(Modifier.width(16.dp))


### PR DESCRIPTION
It appears the collapsed bar + item detail were not showing the adjusted time remaining by the current playback speed like the expanded player view was. 

Resolves #734