### PR TITLE
Add 37 new theme icons + grid icon picker

### DIFF
--- a/.claude/skills/add-theme-icons/SKILL.md
+++ b/.claude/skills/add-theme-icons/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: add-theme-icons
+description: Add new `AppTheme.Icon` entries by pulling Icons8 icons (Arcade style by default) and converting them to Compose ImageVectors via the Valkyrie CLI.
+argument-hint: [concept terms or icon ids...]
+---
+
+## When to use
+
+Invoke when the user wants to expand the set of icons available in `AppTheme.Icon` (used by OOTB `AppTheme.Fixed` themes and user-built `AppTheme.Fixed.Custom` themes). Icons should match the app's **camping / nature / travel** theme.
+
+## Prerequisites
+
+- **Valkyrie CLI** installed (`brew install ComposeGears/repo/valkyrie`, check with `command -v valkyrie`). Required — do not hand-translate SVG paths.
+- **Icons8 MCP** tools available: `mcp__icons8mcp__search_icons`, `mcp__icons8mcp__get_icon_svg`.
+
+## Conventions (project-specific — follow exactly)
+
+| Concern | Value |
+|---|---|
+| Icon style (platform) | `arcade` (colored; unless user specifies otherwise) |
+| Iconpack object | `CampfireIcons` (defined at `common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/CampfireIcons.kt`) |
+| Nested pack | `Theme` |
+| ImageVector package | `app.campfire.common.compose.icons.theme` |
+| ImageVector files dir | `common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/` |
+| Lazy thread-safety | `LazyThreadSafetyMode.PUBLICATION` (Valkyrie emits `NONE` — **you must replace it**) |
+| Indent | 2 spaces (ktlint) |
+| Enum location | `ui/theming/api/src/commonMain/kotlin/app/campfire/ui/theming/api/AppTheme.kt` → `AppTheme.Icon` |
+
+## Workflow
+
+1. **Search candidates.** First read `AppTheme.kt` and list the existing `Icon` enum entries so you can exclude them. Then use `mcp__icons8mcp__search_icons` with `platform=arcade` and camping/nature/travel query terms (examples: campfire, compass, binoculars, lantern, map, axe, sleeping bag, evergreen, suitcase, log cabin, canoe, fishing, hammock, trail, camper, waterfall, flashlight). Note: some searches return zero (`kayak`, `hammock`, `thermos`) — try synonyms (`dinghy`, `picnic`). Fire multiple searches in parallel.
+
+2. **Fetch SVGs in parallel** via `mcp__icons8mcp__get_icon_svg` for each chosen icon id.
+
+3. **Stage SVGs.** Write each to `/tmp/campfire-icons-svg/<PascalCaseName>.svg`. The filename becomes the generated Kotlin property name (`CampfireIcons.Theme.<PascalCaseName>`) — avoid names that collide with existing Kotlin types (e.g. prefer `PaperMap` over `Map`).
+
+4. **Run Valkyrie.** Output to a scratch dir first (Valkyrie creates a `theme/` subfolder):
+   ```bash
+   valkyrie svgxml2imagevector \
+     --input-path=/tmp/campfire-icons-svg \
+     --output-path=/tmp/campfire-icons-out \
+     --package-name=app.campfire.common.compose.icons \
+     --iconpack-name=CampfireIcons \
+     --nested-pack-name=Theme \
+     --output-format=lazy-property \
+     --indent-size=2 \
+     --trailing-comma=true
+   ```
+   Key flags: `--package-name` is the **root** package (Valkyrie appends `.theme` from `--nested-pack-name`); do **not** pass the full `...icons.theme` package or you'll get a doubled path. `--trailing-comma=true` is required — without it ktlint flags every multi-arg `path(...)` call.
+
+5. **Post-process** — replace Valkyrie's default lazy mode to match project convention:
+   ```bash
+   bash -c 'for f in /tmp/campfire-icons-out/theme/*.kt; do sed -i "" "s/LazyThreadSafetyMode.NONE/LazyThreadSafetyMode.PUBLICATION/g" "$f"; done'
+   ```
+
+6. **Move into the source tree.**
+   ```bash
+   cp /tmp/campfire-icons-out/theme/*.kt \
+      /Users/r0adkll/StudioProjects/Campfire/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/
+   ```
+
+7. **Wire into `AppTheme.Icon`.** In `ui/theming/api/src/commonMain/kotlin/app/campfire/ui/theming/api/AppTheme.kt`:
+   - Add `import app.campfire.common.compose.icons.theme.<Name>` (keep alphabetical ordering).
+   - Add `<Name>(icon = { CampfireIcons.Theme.<Name> }),` to the `Icon` enum.
+
+8. **Verify.** Run `--format` first (it auto-fixes the alphabetical import reordering that adding new imports can break), then compile:
+   ```bash
+   ./scripts/ktlint --format
+   ./gradlew :common:compose:compileKotlinIosSimulatorArm64 :ui:theming:api:compileKotlinIosSimulatorArm64 --console=plain
+   ```
+   Pre-existing warnings (`ExperimentalMaterial3Api` opt-in, `dayOfMonth` deprecation, `SynchronizedObject` under `compileCommonMainKotlinMetadata`) are unrelated — ignore.
+
+9. **Clean up** `/tmp/campfire-icons-svg` and `/tmp/campfire-icons-out`.
+
+## Notes
+
+- Icons are rendered by `AppThemeImage` via `Image(...)` (not `Icon(... tint)`), so the original Arcade colors come through — do **not** convert to single-color vectors.
+- Custom themes built by users pick from this same enum (see `AppTheme.Fixed.Custom.icon`), so every added entry is immediately user-selectable.
+- If the user names a different Icons8 platform (e.g. `color`, `plumpy`), pass that as the `platform` filter in step 1 — the rest of the workflow is identical.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-device progress synchronization
 - Setting to disable marquee scrolling on library item cards
 - Android Auto settings pane: toggle, reorder, and choose list/grid layout per top-level category
+- 37 new theme icons (camping/nature/travel) selectable when building a custom theme
 
 ### Changed
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Theme color extraction from cover art now waits for a brief impression before dispatching, avoiding wasted work when scrolling past items
 - Time remaining on collapsed bar + item detail now reflect the current playback speed of a session
 - Improved home feed scrolling with mixed scrolling orientations
+- Theme builder icon picker is now a grid popup instead of a tall scrolling list
 
 ### Deprecated
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Airplane.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Airplane.kt
@@ -1,0 +1,168 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Airplane: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Airplane",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(9.525f, 61f)
+      arcToRelative(23f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 46f, 0f)
+      arcToRelative(23f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -46f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(23f, 32f)
+      horizontalLineTo(2.662f)
+      curveTo(1.192f, 32f, 0f, 33.192f, 0f, 34.662f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, 1.337f, 0.992f, 2.467f, 2.318f, 2.64f)
+      lineTo(23f, 40f)
+      verticalLineTo(32f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(41f, 32f)
+      horizontalLineToRelative(20.338f)
+      curveTo(62.808f, 32f, 64f, 33.192f, 64f, 34.662f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, 1.337f, -0.992f, 2.467f, -2.318f, 2.64f)
+      lineTo(41f, 40f)
+      verticalLineTo(32f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(28f, 25f)
+      lineToRelative(1.696f, -11.023f)
+      curveTo(29.871f, 12.839f, 30.849f, 12f, 32f, 12f)
+      horizontalLineToRelative(0f)
+      curveToRelative(1.151f, 0f, 2.129f, 0.839f, 2.304f, 1.977f)
+      lineTo(36f, 25f)
+      horizontalLineTo(28f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(42.5f, 22f)
+      horizontalLineToRelative(-21f)
+      curveToRelative(-0.828f, 0f, -1.5f, -0.671f, -1.5f, -1.5f)
+      reflectiveCurveToRelative(0.672f, -1.5f, 1.5f, -1.5f)
+      horizontalLineToRelative(21f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.671f, 1.5f, 1.5f)
+      reflectiveCurveTo(43.328f, 22f, 42.5f, 22f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(22.06f, 31.761f)
+      lineToRelative(-0.871f, 3.485f)
+      curveToRelative(-0.737f, 2.949f, 0.127f, 6.069f, 2.277f, 8.219f)
+      lineToRelative(0f, 0f)
+      curveTo(25.088f, 45.088f, 27.29f, 46f, 29.585f, 46f)
+      horizontalLineToRelative(4.83f)
+      curveToRelative(2.295f, 0f, 4.497f, -0.912f, 6.12f, -2.535f)
+      lineToRelative(0f, 0f)
+      curveToRelative(2.15f, -2.15f, 3.014f, -5.27f, 2.277f, -8.219f)
+      lineToRelative(-0.871f, -3.485f)
+      curveTo(40.8f, 27.2f, 36.702f, 24f, 32f, 24f)
+      horizontalLineToRelative(0f)
+      curveTo(27.298f, 24f, 23.2f, 27.2f, 22.06f, 31.761f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(11f, 37f)
+      horizontalLineToRelative(11f)
+      curveToRelative(2.295f, 0f, 4.296f, -1.563f, 4.852f, -3.79f)
+      lineToRelative(0.059f, -0.235f)
+      curveToRelative(0.188f, -0.75f, 0.527f, -1.433f, 1.011f, -2.029f)
+      curveToRelative(1.472f, -1.818f, 1.445f, -4.347f, 0.102f, -6.137f)
+      curveToRelative(-2.902f, 1.224f, -5.163f, 3.75f, -5.964f, 6.952f)
+      lineTo(22f, 32f)
+      horizontalLineTo(6f)
+      curveTo(6f, 34.761f, 8.238f, 37f, 11f, 37f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(11f, 41f)
+      moveToRelative(-5f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 10f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -10f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(53f, 41f)
+      moveToRelative(-5f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 10f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -10f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(35.967f, 36f)
+      horizontalLineToRelative(-7.934f)
+      curveToRelative(-1.436f, 0f, -2.404f, -1.468f, -1.838f, -2.788f)
+      lineToRelative(1.026f, -2.394f)
+      curveTo(27.693f, 29.715f, 28.778f, 29f, 29.978f, 29f)
+      horizontalLineToRelative(4.044f)
+      curveToRelative(1.2f, 0f, 2.285f, 0.715f, 2.757f, 1.818f)
+      lineToRelative(1.026f, 2.394f)
+      curveTo(38.371f, 34.532f, 37.403f, 36f, 35.967f, 36f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(11f, 41f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(53f, 41f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(42.601f, 34.749f)
+      lineToRelative(-0.532f, 0.069f)
+      curveToRelative(-1.967f, 0.256f, -3.596f, 1.65f, -4.153f, 3.553f)
+      curveToRelative(-0.174f, 0.594f, -0.49f, 1.133f, -0.915f, 1.558f)
+      curveTo(36.31f, 40.62f, 35.392f, 41f, 34.415f, 41f)
+      curveToRelative(-2.759f, 0f, -4.995f, 2.234f, -4.999f, 4.992f)
+      curveTo(29.472f, 45.993f, 29.528f, 46f, 29.585f, 46f)
+      horizontalLineToRelative(4.83f)
+      curveToRelative(2.295f, 0f, 4.497f, -0.912f, 6.12f, -2.535f)
+      curveToRelative(1.044f, -1.044f, 1.777f, -2.318f, 2.179f, -3.689f)
+      lineToRelative(5.49f, -0.716f)
+      curveTo(47.847f, 36.323f, 45.342f, 34.388f, 42.601f, 34.749f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(25.499f, 34f)
+      curveToRelative(-0.226f, 0f, -0.454f, -0.051f, -0.67f, -0.159f)
+      curveToRelative(-0.741f, -0.371f, -1.041f, -1.271f, -0.671f, -2.013f)
+      lineToRelative(1f, -2f)
+      curveToRelative(0.371f, -0.741f, 1.272f, -1.04f, 2.013f, -0.671f)
+      curveToRelative(0.741f, 0.371f, 1.041f, 1.271f, 0.671f, 2.013f)
+      lineToRelative(-1f, 2f)
+      curveTo(26.579f, 33.696f, 26.049f, 34f, 25.499f, 34f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Axe.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Axe.kt
@@ -1,0 +1,115 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Axe: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Axe",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFDA7200))) {
+      moveTo(16.966f, 53.878f)
+      curveToRelative(-0.253f, 0.061f, -0.515f, 0.098f, -0.785f, 0.11f)
+      curveToRelative(-2.207f, 0.09f, -4.069f, -1.627f, -4.159f, -3.835f)
+      curveToRelative(-0.198f, -4.875f, 2.074f, -10.455f, 4.266f, -14.051f)
+      curveToRelative(2.013f, -3.302f, 4.317f, -5.573f, 6.544f, -7.77f)
+      curveToRelative(3.349f, -3.302f, 6.512f, -6.421f, 8.837f, -13.423f)
+      curveToRelative(0.696f, -2.096f, 2.96f, -3.233f, 5.057f, -2.535f)
+      curveToRelative(2.096f, 0.696f, 3.232f, 2.96f, 2.535f, 5.057f)
+      curveToRelative(-2.931f, 8.826f, -7.119f, 12.955f, -10.813f, 16.597f)
+      curveToRelative(-2.054f, 2.026f, -3.829f, 3.776f, -5.33f, 6.237f)
+      curveToRelative(-1.896f, 3.111f, -3.201f, 7.134f, -3.103f, 9.563f)
+      curveTo(20.094f, 51.767f, 18.781f, 53.438f, 16.966f, 53.878f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA7B3C7))) {
+      moveTo(41.938f, 29.96f)
+      curveToRelative(-2.587f, -6.374f, -8.518f, -10.774f, -12.54f, -13.294f)
+      curveToRelative(-1.39f, -0.871f, -1.811f, -2.696f, -0.958f, -4.096f)
+      lineToRelative(3.154f, -5.173f)
+      curveToRelative(0.829f, -1.36f, 2.571f, -1.836f, 3.975f, -1.084f)
+      curveToRelative(4.347f, 2.328f, 11.788f, 5.627f, 17.966f, 4.643f)
+      curveToRelative(1.134f, -0.181f, 2.166f, 0.661f, 2.16f, 1.81f)
+      curveTo(55.664f, 19.46f, 51.61f, 27.08f, 44.447f, 30.854f)
+      curveTo(43.518f, 31.342f, 42.333f, 30.932f, 41.938f, 29.96f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(54.777f, 18.363f)
+      curveToRelative(-2.284f, -1.021f, -5.016f, -0.218f, -6.328f, 1.984f)
+      curveToRelative(-0.531f, 0.892f, -1.136f, 1.725f, -1.805f, 2.489f)
+      curveToRelative(-0.848f, 0.969f, -2.371f, 0.845f, -3.127f, -0.196f)
+      curveToRelative(-0.811f, -1.117f, -1.724f, -2.207f, -2.737f, -3.265f)
+      curveToRelative(-0.775f, -0.811f, -1.791f, -1.394f, -2.9f, -1.564f)
+      curveToRelative(-2.236f, -0.342f, -4.328f, 0.812f, -5.273f, 2.728f)
+      curveToRelative(-2.277f, 4.613f, -5.019f, 7.316f, -7.673f, 9.933f)
+      curveToRelative(-2.193f, 2.163f, -4.265f, 4.206f, -6.086f, 7.192f)
+      curveToRelative(-2.021f, 3.317f, -3.989f, 8.427f, -3.829f, 12.368f)
+      curveToRelative(0.064f, 1.58f, 0.866f, 2.944f, 2.047f, 3.813f)
+      curveToRelative(1.761f, -0.478f, 3.026f, -2.115f, 2.949f, -4.015f)
+      curveToRelative(-0.098f, -2.43f, 1.207f, -6.452f, 3.103f, -9.563f)
+      curveToRelative(1.501f, -2.461f, 3.276f, -4.211f, 5.33f, -6.237f)
+      curveToRelative(2.856f, -2.816f, 6.005f, -5.933f, 8.642f, -11.277f)
+      curveToRelative(1.938f, 2.012f, 3.681f, 4.381f, 4.809f, 7.116f)
+      curveToRelative(0.415f, 1.006f, 1.585f, 1.492f, 2.547f, 0.985f)
+      curveTo(49.653f, 28.111f, 53.206f, 23.336f, 54.777f, 18.363f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(29.398f, 16.666f)
+      curveToRelative(0.275f, 0.172f, 0.571f, 0.368f, 0.863f, 0.559f)
+      curveToRelative(0.985f, -0.384f, 1.856f, -1.081f, 2.448f, -2.053f)
+      lineToRelative(1.711f, -2.808f)
+      curveToRelative(0.268f, -0.439f, 0.826f, -0.596f, 1.29f, -0.374f)
+      curveToRelative(2.664f, 1.278f, 5.247f, 2.273f, 7.708f, 2.968f)
+      curveToRelative(2.795f, 0.789f, 5.703f, -0.959f, 6.27f, -3.868f)
+      curveToRelative(-0.008f, -0.011f, -0.012f, -0.016f, -0.02f, -0.027f)
+      curveToRelative(-5.196f, -0.426f, -10.634f, -2.896f, -14.102f, -4.753f)
+      curveToRelative(-1.403f, -0.752f, -3.143f, -0.273f, -3.972f, 1.086f)
+      lineTo(28.44f, 12.57f)
+      curveTo(27.587f, 13.97f, 28.009f, 15.796f, 29.398f, 16.666f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(32.333f, 14.393f)
+      curveToRelative(-0.375f, 0f, -0.757f, -0.141f, -1.063f, -0.441f)
+      curveToRelative(-0.505f, -0.495f, -0.545f, -1.304f, -0.175f, -1.907f)
+      lineToRelative(1.474f, -2.407f)
+      curveToRelative(0.684f, -1.117f, 2.108f, -1.52f, 3.272f, -0.919f)
+      curveToRelative(0.558f, 0.288f, 1.145f, 0.58f, 1.756f, 0.87f)
+      curveToRelative(0.677f, 0.32f, 1.094f, 1.075f, 0.889f, 1.795f)
+      curveToRelative(-0.261f, 0.917f, -1.261f, 1.346f, -2.087f, 0.957f)
+      curveToRelative(-0.239f, -0.113f, -0.475f, -0.226f, -0.708f, -0.34f)
+      curveToRelative(-0.461f, -0.225f, -1.017f, -0.059f, -1.285f, 0.379f)
+      lineToRelative(-0.793f, 1.296f)
+      curveTo(33.331f, 14.139f, 32.838f, 14.393f, 32.333f, 14.393f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/BeachUmbrella.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/BeachUmbrella.kt
@@ -1,0 +1,152 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.BeachUmbrella: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.BeachUmbrella",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFDA7200))) {
+      moveTo(36f, 12f)
+      verticalLineToRelative(39f)
+      curveToRelative(0f, 2.21f, -1.79f, 4f, -4f, 4f)
+      curveToRelative(-0.3f, 0f, -0.59f, -0.03f, -0.87f, -0.1f)
+      curveTo(29.34f, 54.5f, 28f, 52.91f, 28f, 51f)
+      verticalLineTo(12f)
+      curveToRelative(0f, -2.21f, 1.79f, -4f, 4f, -4f)
+      curveToRelative(1.1f, 0f, 2.1f, 0.45f, 2.83f, 1.17f)
+      curveToRelative(0.52f, 0.53f, 0.9f, 1.21f, 1.07f, 1.96f)
+      curveTo(35.97f, 11.41f, 36f, 11.7f, 36f, 12f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(36f, 16.75f)
+      verticalLineToRelative(20.5f)
+      curveTo(34.76f, 37.73f, 33.41f, 38f, 32f, 38f)
+      reflectiveCurveToRelative(-2.76f, -0.27f, -4f, -0.75f)
+      verticalLineToRelative(-20.5f)
+      curveToRelative(1.24f, -0.48f, 2.59f, -0.75f, 4f, -0.75f)
+      reflectiveCurveTo(34.76f, 16.27f, 36f, 16.75f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(32f, 27f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(44f, 27f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(20f, 27f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(4f, 27f)
+      curveTo(4f, 17f, 17f, 4f, 32f, 4f)
+      verticalLineToRelative(23f)
+      horizontalLineTo(4f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(60f, 27f)
+      curveTo(60f, 17f, 47f, 4f, 32f, 4f)
+      verticalLineToRelative(23f)
+      horizontalLineTo(60f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(17f, 61f)
+      arcToRelative(15f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 30f, 0f)
+      arcToRelative(15f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -30f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(38f, 27f)
+      curveToRelative(0f, -7f, -3f, -20f, -6f, -23f)
+      curveToRelative(-3f, 3f, -6f, 16f, -6f, 23f)
+      curveToRelative(0f, 3.314f, 2.686f, 6f, 6f, 6f)
+      reflectiveCurveTo(38f, 30.314f, 38f, 27f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(14f, 27f)
+      curveTo(14f, 13f, 25f, 6f, 32f, 4f)
+      curveTo(17f, 4f, 4f, 17f, 4f, 27f)
+      curveToRelative(0f, 2.761f, 2.239f, 5f, 5f, 5f)
+      reflectiveCurveTo(14f, 29.761f, 14f, 27f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(50f, 27f)
+      curveTo(50f, 13f, 39f, 6f, 32f, 4f)
+      curveToRelative(15f, 0f, 28f, 13f, 28f, 23f)
+      curveToRelative(0f, 2.761f, -2.239f, 5f, -5f, 5f)
+      reflectiveCurveTo(50f, 29.761f, 50f, 27f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(36.97f, 4.48f)
+      curveTo(36.73f, 7.02f, 34.6f, 9f, 32f, 9f)
+      curveToRelative(-6.15f, 0f, -12.68f, 2.84f, -17.48f, 7.59f)
+      curveToRelative(-0.98f, 0.96f, -2.25f, 1.44f, -3.52f, 1.44f)
+      curveToRelative(-1.16f, 0f, -2.32f, -0.4f, -3.24f, -1.2f)
+      curveTo(12.68f, 9.91f, 21.88f, 4f, 32f, 4f)
+      curveTo(33.69f, 4f, 35.35f, 4.16f, 36.97f, 4.48f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(59.987f, 26.455f)
+      curveToRelative(0.127f, 2.749f, -1.779f, 5.277f, -4.519f, 5.524f)
+      curveToRelative(-2.044f, 0.185f, -3.855f, -0.854f, -4.798f, -2.479f)
+      curveToRelative(0.609f, -1.05f, 1.581f, -1.855f, 2.743f, -2.243f)
+      curveToRelative(0.983f, -0.328f, 1.584f, -1.29f, 1.349f, -2.299f)
+      curveToRelative(-0.441f, -1.891f, -1.698f, -4.836f, -5.282f, -8.367f)
+      curveToRelative(-1.86f, -1.85f, -1.97f, -4.8f, -0.3f, -6.78f)
+      curveTo(55.495f, 14.353f, 59.727f, 20.827f, 59.987f, 26.455f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(15.501f, 15.333f)
+      curveToRelative(-0.437f, 0f, -0.869f, -0.189f, -1.166f, -0.554f)
+      curveToRelative(-0.522f, -0.643f, -0.424f, -1.588f, 0.219f, -2.11f)
+      curveToRelative(2.427f, -1.971f, 5.091f, -3.509f, 7.918f, -4.572f)
+      curveToRelative(0.774f, -0.29f, 1.64f, 0.101f, 1.932f, 0.876f)
+      curveToRelative(0.292f, 0.775f, -0.101f, 1.64f, -0.876f, 1.932f)
+      curveToRelative(-2.488f, 0.935f, -4.937f, 2.351f, -7.082f, 4.093f)
+      curveTo(16.167f, 15.223f, 15.833f, 15.333f, 15.501f, 15.333f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Bicycle.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Bicycle.kt
@@ -1,0 +1,173 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Bicycle: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Bicycle",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(9f, 61f)
+      arcToRelative(23f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 46f, 0f)
+      arcToRelative(23f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -46f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(12f, 55f)
+      curveTo(5.383f, 55f, 0f, 49.617f, 0f, 43f)
+      reflectiveCurveToRelative(5.383f, -12f, 12f, -12f)
+      reflectiveCurveToRelative(12f, 5.383f, 12f, 12f)
+      reflectiveCurveTo(18.617f, 55f, 12f, 55f)
+      close()
+      moveTo(12f, 36f)
+      curveToRelative(-3.859f, 0f, -7f, 3.141f, -7f, 7f)
+      reflectiveCurveToRelative(3.141f, 7f, 7f, 7f)
+      reflectiveCurveToRelative(7f, -3.141f, 7f, -7f)
+      reflectiveCurveTo(15.859f, 36f, 12f, 36f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(52f, 55f)
+      curveToRelative(-6.617f, 0f, -12f, -5.383f, -12f, -12f)
+      reflectiveCurveToRelative(5.383f, -12f, 12f, -12f)
+      reflectiveCurveToRelative(12f, 5.383f, 12f, 12f)
+      reflectiveCurveTo(58.617f, 55f, 52f, 55f)
+      close()
+      moveTo(52f, 36f)
+      curveToRelative(-3.859f, 0f, -7f, 3.141f, -7f, 7f)
+      reflectiveCurveToRelative(3.141f, 7f, 7f, 7f)
+      reflectiveCurveToRelative(7f, -3.141f, 7f, -7f)
+      reflectiveCurveTo(55.859f, 36f, 52f, 36f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(64f, 43f)
+      curveToRelative(0f, -1.741f, -0.381f, -3.391f, -1.05f, -4.885f)
+      curveTo(60.693f, 38.598f, 59f, 40.599f, 59f, 43f)
+      curveToRelative(0f, 3.859f, -3.141f, 7f, -7f, 7f)
+      curveToRelative(-2.401f, 0f, -4.402f, 1.693f, -4.885f, 3.95f)
+      curveTo(48.609f, 54.619f, 50.259f, 55f, 52f, 55f)
+      curveTo(58.617f, 55f, 64f, 49.617f, 64f, 43f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(52.5f, 16f)
+      horizontalLineTo(51f)
+      curveToRelative(-1.104f, 0f, -2f, 0.896f, -2f, 2f)
+      reflectiveCurveToRelative(0.896f, 2f, 2f, 2f)
+      horizontalLineToRelative(1.5f)
+      curveToRelative(3.032f, 0f, 5.5f, -2.468f, 5.5f, -5.5f)
+      reflectiveCurveTo(55.532f, 9f, 52.5f, 9f)
+      horizontalLineToRelative(-9.305f)
+      curveToRelative(-2.046f, 0f, -3.931f, 1.026f, -5.04f, 2.745f)
+      curveToRelative(-1.11f, 1.719f, -1.271f, 3.859f, -0.414f, 5.756f)
+      lineTo(41.284f, 25f)
+      horizontalLineTo(23.385f)
+      lineToRelative(-3.677f, -6.04f)
+      curveToRelative(-0.574f, -0.943f, -1.805f, -1.245f, -2.748f, -0.668f)
+      curveToRelative(-0.943f, 0.574f, -1.242f, 1.805f, -0.668f, 2.748f)
+      lineToRelative(3.49f, 5.734f)
+      lineTo(14.304f, 41.94f)
+      curveToRelative(-0.385f, 0.616f, -0.405f, 1.394f, -0.053f, 2.029f)
+      reflectiveCurveTo(15.273f, 45f, 16f, 45f)
+      horizontalLineToRelative(15.977f)
+      curveToRelative(0.008f, 0f, 0.015f, 0f, 0.021f, 0f)
+      curveToRelative(0.058f, 0f, 0.113f, -0.002f, 0.17f, -0.007f)
+      curveToRelative(0.001f, 0f, 0.002f, 0f, 0.002f, 0f)
+      curveToRelative(0.101f, -0.009f, 0.199f, -0.025f, 0.295f, -0.048f)
+      curveToRelative(0.407f, -0.098f, 0.786f, -0.322f, 1.071f, -0.665f)
+      curveToRelative(0.024f, -0.029f, 0.048f, -0.059f, 0.071f, -0.09f)
+      lineToRelative(10.272f, -13.697f)
+      lineToRelative(6.312f, 13.361f)
+      curveTo(50.533f, 44.577f, 51.252f, 45f, 52.001f, 45f)
+      curveToRelative(0.286f, 0f, 0.577f, -0.062f, 0.854f, -0.191f)
+      curveToRelative(0.999f, -0.472f, 1.426f, -1.664f, 0.954f, -2.663f)
+      lineTo(41.373f, 15.823f)
+      curveToRelative(-0.285f, -0.631f, -0.233f, -1.326f, 0.143f, -1.908f)
+      curveTo(41.891f, 13.333f, 42.503f, 13f, 43.195f, 13f)
+      horizontalLineTo(52.5f)
+      curveToRelative(0.827f, 0f, 1.5f, 0.673f, 1.5f, 1.5f)
+      reflectiveCurveTo(53.327f, 16f, 52.5f, 16f)
+      close()
+      moveTo(19f, 41f)
+      lineToRelative(3.109f, -10.402f)
+      lineTo(28.441f, 41f)
+      horizontalLineTo(19f)
+      close()
+      moveTo(32.173f, 39.437f)
+      lineTo(25.819f, 29f)
+      horizontalLineTo(40f)
+      lineTo(32.173f, 39.437f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF6F7B91))) {
+      moveTo(23.5f, 21f)
+      horizontalLineToRelative(-12f)
+      curveTo(10.119f, 21f, 9f, 19.881f, 9f, 18.5f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, -1.381f, 1.119f, -2.5f, 2.5f, -2.5f)
+      horizontalLineToRelative(12f)
+      curveToRelative(1.381f, 0f, 2.5f, 1.119f, 2.5f, 2.5f)
+      verticalLineToRelative(0f)
+      curveTo(26f, 19.881f, 24.881f, 21f, 23.5f, 21f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF6F7B91))) {
+      moveTo(47f, 16f)
+      horizontalLineToRelative(6f)
+      verticalLineToRelative(4f)
+      horizontalLineToRelative(-6f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(0f)
+      curveTo(45f, 16.895f, 45.895f, 16f, 47f, 16f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(11.642f, 21f)
+      lineToRelative(4.63f, 0f)
+      curveToRelative(0.008f, 0.013f, 0.011f, 0.027f, 0.019f, 0.04f)
+      lineToRelative(0f, 0f)
+      curveToRelative(1.497f, 2.459f, 4.167f, 3.96f, 7.046f, 3.96f)
+      horizontalLineToRelative(0.047f)
+      lineToRelative(-2.435f, -4f)
+      lineToRelative(2.408f, 0f)
+      curveToRelative(1.308f, 0f, 2.499f, -0.941f, 2.629f, -2.242f)
+      curveTo(26.137f, 17.261f, 24.966f, 16f, 23.5f, 16f)
+      horizontalLineToRelative(-12f)
+      curveToRelative(-1.466f, 0f, -2.637f, 1.261f, -2.487f, 2.758f)
+      curveTo(9.143f, 20.059f, 10.335f, 21f, 11.642f, 21f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(19.5f, 20f)
+      horizontalLineToRelative(-5f)
+      curveToRelative(-0.828f, 0f, -1.5f, -0.672f, -1.5f, -1.5f)
+      reflectiveCurveToRelative(0.672f, -1.5f, 1.5f, -1.5f)
+      horizontalLineToRelative(5f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.672f, 1.5f, 1.5f)
+      reflectiveCurveTo(20.328f, 20f, 19.5f, 20f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Binoculars.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Binoculars.kt
@@ -1,0 +1,158 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Binoculars: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Binoculars",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(58f, 39f)
+      horizontalLineTo(6f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, -2.642f, 0.504f, -5.26f, 1.486f, -7.714f)
+      lineToRelative(3.956f, -9.887f)
+      curveToRelative(1.063f, -2.657f, 3.637f, -4.4f, 6.499f, -4.4f)
+      horizontalLineToRelative(28.118f)
+      curveToRelative(2.862f, 0f, 5.436f, 1.742f, 6.499f, 4.4f)
+      lineToRelative(3.956f, 9.887f)
+      curveTo(57.496f, 33.74f, 58f, 36.358f, 58f, 39f)
+      lineTo(58f, 39f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(18f, 39f)
+      moveToRelative(-12f, 0f)
+      arcToRelative(12f, 12f, 0f, isMoreThanHalf = true, isPositiveArc = true, 24f, 0f)
+      arcToRelative(12f, 12f, 0f, isMoreThanHalf = true, isPositiveArc = true, -24f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(18f, 39f)
+      moveToRelative(-7f, 0f)
+      arcToRelative(7f, 7f, 0f, isMoreThanHalf = true, isPositiveArc = true, 14f, 0f)
+      arcToRelative(7f, 7f, 0f, isMoreThanHalf = true, isPositiveArc = true, -14f, 0f)
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(14.5f, 40.5f)
+      curveToRelative(-0.828f, 0f, -1.5f, -0.672f, -1.5f, -1.5f)
+      curveToRelative(0f, -2.757f, 2.243f, -5f, 5f, -5f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.672f, 1.5f, 1.5f)
+      reflectiveCurveTo(18.828f, 37f, 18f, 37f)
+      curveToRelative(-1.103f, 0f, -2f, 0.897f, -2f, 2f)
+      curveTo(16f, 39.828f, 15.328f, 40.5f, 14.5f, 40.5f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(23f, 19f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(41f, 19f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(46f, 39f)
+      moveToRelative(-12f, 0f)
+      arcToRelative(12f, 12f, 0f, isMoreThanHalf = true, isPositiveArc = true, 24f, 0f)
+      arcToRelative(12f, 12f, 0f, isMoreThanHalf = true, isPositiveArc = true, -24f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(46f, 39f)
+      moveToRelative(-7f, 0f)
+      arcToRelative(7f, 7f, 0f, isMoreThanHalf = true, isPositiveArc = true, 14f, 0f)
+      arcToRelative(7f, 7f, 0f, isMoreThanHalf = true, isPositiveArc = true, -14f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(32f, 38.5f)
+      moveToRelative(-5.5f, 0f)
+      arcToRelative(5.5f, 5.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 11f, 0f)
+      arcToRelative(5.5f, 5.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -11f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(52.558f, 21.4f)
+      curveToRelative(-0.654f, -1.635f, -1.889f, -2.903f, -3.404f, -3.647f)
+      curveToRelative(-1.463f, 1.367f, -2.026f, 3.533f, -1.238f, 5.504f)
+      lineToRelative(3.956f, 9.888f)
+      curveTo(52.62f, 35.014f, 53f, 36.983f, 53f, 39f)
+      curveToRelative(0f, 3.859f, -3.141f, 7f, -7f, 7f)
+      curveToRelative(-2.401f, 0f, -4.403f, 1.694f, -4.886f, 3.951f)
+      curveTo(42.607f, 50.62f, 44.257f, 51f, 46f, 51f)
+      curveToRelative(6.627f, 0f, 12f, -5.373f, 12f, -12f)
+      curveToRelative(0f, -2.642f, -0.504f, -5.26f, -1.486f, -7.714f)
+      lineTo(52.558f, 21.4f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(27.526f, 15.095f)
+      curveTo(26.428f, 13.819f, 24.816f, 13f, 23f, 13f)
+      curveToRelative(-2.629f, 0f, -4.857f, 1.693f, -5.668f, 4.046f)
+      curveToRelative(-2.612f, 0.229f, -4.903f, 1.888f, -5.89f, 4.353f)
+      lineToRelative(-3.956f, 9.887f)
+      curveToRelative(-0.62f, 1.551f, -1.027f, 3.171f, -1.259f, 4.817f)
+      curveToRelative(0.419f, 0.109f, 0.839f, 0.184f, 1.258f, 0.184f)
+      curveToRelative(1.984f, 0f, 3.862f, -1.189f, 4.645f, -3.144f)
+      lineToRelative(3.954f, -9.886f)
+      curveToRelative(0.277f, -0.692f, 0.924f, -1.164f, 1.687f, -1.231f)
+      curveToRelative(1.966f, -0.173f, 3.646f, -1.484f, 4.289f, -3.35f)
+      curveTo(22.175f, 18.34f, 22.511f, 18f, 23f, 18f)
+      curveTo(25.011f, 18f, 26.733f, 16.806f, 27.526f, 15.095f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA602))) {
+      moveTo(32f, 38f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(42.5f, 40.5f)
+      curveToRelative(-0.828f, 0f, -1.5f, -0.672f, -1.5f, -1.5f)
+      curveToRelative(0f, -2.757f, 2.243f, -5f, 5f, -5f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.672f, 1.5f, 1.5f)
+      reflectiveCurveTo(46.828f, 37f, 46f, 37f)
+      curveToRelative(-1.103f, 0f, -2f, 0.897f, -2f, 2f)
+      curveTo(44f, 39.828f, 43.328f, 40.5f, 42.5f, 40.5f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+    ) {
+      moveTo(14.921f, 22.303f)
+      lineTo(13.152f, 26.5f)
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Cactus.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Cactus.kt
@@ -1,0 +1,127 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Cactus: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Cactus",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(15f, 61f)
+      arcToRelative(17f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 34f, 0f)
+      arcToRelative(17f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -34f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(32f, 14f)
+      moveToRelative(-10f, 0f)
+      arcToRelative(10f, 10f, 0f, isMoreThanHalf = true, isPositiveArc = true, 20f, 0f)
+      arcToRelative(10f, 10f, 0f, isMoreThanHalf = true, isPositiveArc = true, -20f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(41.981f, 14.613f)
+      lineToRelative(-1.982f, 35.192f)
+      curveTo(39.867f, 52.159f, 37.919f, 54f, 35.562f, 54f)
+      horizontalLineToRelative(-7.124f)
+      curveToRelative(-2.358f, 0f, -4.305f, -1.841f, -4.437f, -4.195f)
+      lineToRelative(-1.982f, -35.192f)
+      horizontalLineTo(41.981f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(14.5f, 23.5f)
+      moveToRelative(-4.5f, 0f)
+      arcToRelative(4.5f, 4.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 9f, 0f)
+      arcToRelative(4.5f, 4.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -9f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(49.5f, 34.5f)
+      moveToRelative(-4.5f, 0f)
+      arcToRelative(4.5f, 4.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 9f, 0f)
+      arcToRelative(4.5f, 4.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -9f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(19f, 23.5f)
+      curveTo(19f, 29f, 20f, 35f, 24f, 35f)
+      curveToRelative(2.25f, 2.25f, 0f, 5f, 0f, 5f)
+      curveToRelative(-8f, 0f, -14f, -8f, -14f, -16.5f)
+      curveTo(14f, 23.5f, 19f, 23.5f, 19f, 23.5f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(45f, 34.5f)
+      curveToRelative(0f, 3.5f, -3f, 5.5f, -6.5f, 5.5f)
+      curveToRelative(-1.5f, 1.5f, 0f, 5f, 0f, 5f)
+      curveTo(47f, 45f, 54f, 41f, 54f, 34.5f)
+      curveTo(50.5f, 34.5f, 45f, 34.5f, 45f, 34.5f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(54f, 34.5f)
+      curveToRelative(0f, 6.04f, -6.05f, 9.92f, -13.73f, 10.44f)
+      lineTo(40f, 49.81f)
+      curveTo(39.87f, 52.16f, 37.92f, 54f, 35.56f, 54f)
+      horizontalLineToRelative(-7.12f)
+      curveToRelative(-0.5f, 0f, -0.98f, -0.08f, -1.43f, -0.24f)
+      curveTo(27.13f, 51.11f, 29.32f, 49f, 32f, 49f)
+      horizontalLineToRelative(3.04f)
+      lineToRelative(0.24f, -4.35f)
+      curveToRelative(0.05f, -0.94f, 0.37f, -1.82f, 0.87f, -2.55f)
+      curveToRelative(-0.42f, -0.8f, -0.63f, -1.71f, -0.58f, -2.63f)
+      lineToRelative(0.44f, -7.75f)
+      curveToRelative(0.15f, -2.76f, 2.51f, -4.87f, 5.27f, -4.71f)
+      lineToRelative(-0.71f, 12.74f)
+      curveTo(43.1f, 39.11f, 45f, 37.28f, 45f, 34.5f)
+      curveToRelative(0f, -2.49f, 2.01f, -4.5f, 4.5f, -4.5f)
+      reflectiveCurveTo(54f, 32.01f, 54f, 34.5f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(36.84f, 5.25f)
+      curveTo(36.29f, 7.41f, 34.33f, 9f, 32f, 9f)
+      curveToRelative(-2.76f, 0f, -5f, 2.24f, -5f, 5f)
+      lineToRelative(0.02f, 0.3f)
+      curveToRelative(0.01f, 0.13f, 0.01f, 0.26f, 0.01f, 0.38f)
+      lineToRelative(0.45f, 8.04f)
+      curveToRelative(0.16f, 2.76f, -1.95f, 5.12f, -4.71f, 5.27f)
+      lineToRelative(-0.75f, -13.38f)
+      horizontalLineToRelative(0.01f)
+      curveTo(22.02f, 14.41f, 22f, 14.21f, 22f, 14f)
+      curveToRelative(0f, -5.52f, 4.48f, -10f, 10f, -10f)
+      curveTo(33.75f, 4f, 35.4f, 4.45f, 36.84f, 5.25f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(25.501f, 15f)
+      curveToRelative(-0.12f, 0f, -0.243f, -0.015f, -0.365f, -0.045f)
+      curveToRelative(-0.804f, -0.201f, -1.292f, -1.016f, -1.091f, -1.819f)
+      curveToRelative(1.28f, -5.12f, 5.386f, -6.664f, 7.091f, -7.091f)
+      curveToRelative(0.806f, -0.202f, 1.618f, 0.289f, 1.819f, 1.091f)
+      curveToRelative(0.201f, 0.804f, -0.288f, 1.618f, -1.091f, 1.819f)
+      curveToRelative(-1.466f, 0.367f, -4.054f, 1.492f, -4.909f, 4.909f)
+      curveTo(26.785f, 14.545f, 26.173f, 15f, 25.501f, 15f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Camera.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Camera.kt
@@ -1,0 +1,130 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Camera: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Camera",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(20f, 20f)
+      horizontalLineToRelative(-7f)
+      verticalLineToRelative(-3f)
+      curveToRelative(0f, -1.105f, 0.895f, -2f, 2f, -2f)
+      horizontalLineToRelative(3f)
+      curveToRelative(1.105f, 0f, 2f, 0.895f, 2f, 2f)
+      verticalLineTo(20f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(51f, 18f)
+      horizontalLineToRelative(-6.141f)
+      curveToRelative(-1.231f, 0f, -2.393f, -0.567f, -3.151f, -1.536f)
+      lineToRelative(-1.507f, -1.927f)
+      curveTo(39.443f, 13.567f, 38.281f, 13f, 37.05f, 13f)
+      horizontalLineToRelative(-10.1f)
+      curveToRelative(-1.231f, 0f, -2.393f, 0.567f, -3.151f, 1.536f)
+      lineToRelative(-1.507f, 1.927f)
+      curveTo(21.534f, 17.433f, 20.372f, 18f, 19.141f, 18f)
+      horizontalLineTo(13f)
+      curveToRelative(-3.314f, 0f, -6f, 2.686f, -6f, 6f)
+      verticalLineToRelative(22f)
+      curveToRelative(0f, 3.314f, 2.686f, 6f, 6f, 6f)
+      horizontalLineToRelative(38f)
+      curveToRelative(3.314f, 0f, 6f, -2.686f, 6f, -6f)
+      verticalLineTo(24f)
+      curveTo(57f, 20.686f, 54.314f, 18f, 51f, 18f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(48.5f, 25.5f)
+      moveToRelative(-2.5f, 0f)
+      arcToRelative(2.5f, 2.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 5f, 0f)
+      arcToRelative(2.5f, 2.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -5f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(57f, 46f)
+      verticalLineTo(29f)
+      curveToRelative(-2.761f, 0f, -5f, 2.238f, -5f, 5f)
+      verticalLineToRelative(12f)
+      curveToRelative(0f, 0.552f, -0.449f, 1f, -1f, 1f)
+      horizontalLineToRelative(-7f)
+      curveToRelative(-2.761f, 0f, -5f, 2.238f, -5f, 5f)
+      horizontalLineToRelative(12f)
+      curveTo(54.314f, 52f, 57f, 49.314f, 57f, 46f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(23.799f, 14.536f)
+      lineToRelative(-1.507f, 1.927f)
+      curveTo(21.534f, 17.433f, 20.372f, 18f, 19.141f, 18f)
+      horizontalLineTo(13f)
+      curveToRelative(-3.314f, 0f, -6f, 2.686f, -6f, 6f)
+      verticalLineToRelative(13.213f)
+      curveToRelative(2.762f, 0f, 5f, -2.239f, 5f, -5f)
+      verticalLineToRelative(-8.958f)
+      curveTo(12f, 23.114f, 12.114f, 23f, 12.255f, 23f)
+      horizontalLineToRelative(6.886f)
+      curveToRelative(2.77f, 0f, 5.386f, -1.275f, 7.091f, -3.458f)
+      lineToRelative(0.605f, -0.774f)
+      curveTo(27.216f, 18.283f, 27.797f, 18f, 28.413f, 18f)
+      horizontalLineToRelative(1.34f)
+      curveToRelative(2.762f, 0f, 5f, -2.239f, 5f, -5f)
+      horizontalLineTo(26.95f)
+      curveTo(25.719f, 13f, 24.557f, 13.567f, 23.799f, 14.536f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(32f, 34.5f)
+      moveToRelative(-12.5f, 0f)
+      arcToRelative(12.5f, 12.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 25f, 0f)
+      arcToRelative(12.5f, 12.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -25f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(32f, 34.5f)
+      moveToRelative(-8.5f, 0f)
+      arcToRelative(8.5f, 8.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 17f, 0f)
+      arcToRelative(8.5f, 8.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -17f, 0f)
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(10.514f, 27.045f)
+      verticalLineToRelative(-3.5f)
+      curveToRelative(0f, -1.103f, 0.897f, -2f, 2f, -2f)
+      horizontalLineToRelative(3.5f)
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Camper.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Camper.kt
@@ -1,0 +1,188 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Camper: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Camper",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF68E5FD))) {
+      moveTo(36f, 46f)
+      horizontalLineTo(10f)
+      curveToRelative(-2.209f, 0f, -4f, -1.791f, -4f, -4f)
+      verticalLineTo(14f)
+      curveToRelative(0f, -2.209f, 1.791f, -4f, 4f, -4f)
+      horizontalLineToRelative(39f)
+      curveToRelative(3.314f, 0f, 6f, 2.686f, 6f, 6f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, 1.657f, -1.343f, 3f, -3f, 3f)
+      lineToRelative(-9f, 0f)
+      curveToRelative(-2.761f, 0f, -5f, 2.239f, -5f, 5f)
+      verticalLineToRelative(20f)
+      curveTo(38f, 45.105f, 37.105f, 46f, 36f, 46f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(36f, 46f)
+      horizontalLineTo(10f)
+      curveToRelative(-2.209f, 0f, -4f, -1.791f, -4f, -4f)
+      verticalLineToRelative(-4f)
+      horizontalLineToRelative(32f)
+      verticalLineToRelative(6f)
+      curveTo(38f, 45.105f, 37.105f, 46f, 36f, 46f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(40f, 46f)
+      horizontalLineToRelative(16f)
+      curveToRelative(1.105f, 0f, 2f, -0.895f, 2f, -2f)
+      verticalLineTo(33.114f)
+      curveToRelative(0f, -0.736f, -0.136f, -1.467f, -0.4f, -2.154f)
+      lineToRelative(-3.86f, -10.037f)
+      curveTo(53.294f, 19.764f, 52.181f, 19f, 50.94f, 19f)
+      horizontalLineTo(40f)
+      curveToRelative(-1.105f, 0f, -2f, 0.895f, -2f, 2f)
+      verticalLineToRelative(23f)
+      curveTo(38f, 45.105f, 38.895f, 46f, 40f, 46f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(18f, 46f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(18f, 46f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(22f, 19f)
+      horizontalLineToRelative(11f)
+      curveToRelative(1.105f, 0f, 2f, 0.895f, 2f, 2f)
+      verticalLineToRelative(7f)
+      curveToRelative(0f, 1.105f, -0.895f, 2f, -2f, 2f)
+      horizontalLineTo(22f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(-7f)
+      curveTo(20f, 19.895f, 20.895f, 19f, 22f, 19f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(13f, 19f)
+      horizontalLineToRelative(2f)
+      curveToRelative(1.105f, 0f, 2f, 0.895f, 2f, 2f)
+      verticalLineToRelative(3f)
+      curveToRelative(0f, 1.105f, -0.895f, 2f, -2f, 2f)
+      horizontalLineToRelative(-2f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(-3f)
+      curveTo(11f, 19.895f, 11.895f, 19f, 13f, 19f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(39.5f, 13f)
+      horizontalLineToRelative(9f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.672f, 1.5f, 1.5f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, 0.828f, -0.672f, 1.5f, -1.5f, 1.5f)
+      lineToRelative(-9f, 0f)
+      curveToRelative(-0.828f, 0f, -1.5f, -0.672f, -1.5f, -1.5f)
+      verticalLineToRelative(0f)
+      curveTo(38f, 13.672f, 38.672f, 13f, 39.5f, 13f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(44f, 32f)
+      horizontalLineToRelative(6.663f)
+      curveToRelative(1.622f, 0f, 2.751f, -1.612f, 2.196f, -3.136f)
+      lineToRelative(-2.381f, -5.548f)
+      curveTo(50.191f, 22.526f, 49.44f, 22f, 48.599f, 22f)
+      horizontalLineTo(44f)
+      curveToRelative(-1.105f, 0f, -2f, 0.895f, -2f, 2f)
+      verticalLineToRelative(6f)
+      curveTo(42f, 31.105f, 42.895f, 32f, 44f, 32f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(58f, 33.11f)
+      verticalLineTo(44f)
+      curveToRelative(0f, 1.1f, -0.9f, 2f, -2f, 2f)
+      horizontalLineTo(43f)
+      curveToRelative(0f, -2.42f, 1.72f, -4.44f, 4f, -4.9f)
+      lineToRelative(5.01f, -0.09f)
+      curveToRelative(0.55f, -0.01f, 0.99f, -0.45f, 0.99f, -1f)
+      verticalLineTo(37f)
+      curveToRelative(0f, -2.73f, 2.19f, -4.95f, 4.9f, -4.99f)
+      curveTo(57.96f, 32.37f, 58f, 32.74f, 58f, 33.11f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(27f, 10f)
+      curveToRelative(0f, 2.76f, -2.24f, 5f, -5f, 5f)
+      horizontalLineTo(11f)
+      verticalLineToRelative(11f)
+      curveToRelative(0f, 2.761f, -2.239f, 5f, -5f, 5f)
+      horizontalLineToRelative(0f)
+      verticalLineTo(14f)
+      curveToRelative(0f, -2.209f, 1.791f, -4f, 4f, -4f)
+      horizontalLineTo(27f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(48f, 46f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(48f, 46f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(9.5f, 20f)
+      curveTo(8.672f, 20f, 8f, 19.329f, 8f, 18.5f)
+      verticalLineToRelative(-3f)
+      curveToRelative(0f, -1.93f, 1.57f, -3.5f, 3.5f, -3.5f)
+      horizontalLineToRelative(3f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.671f, 1.5f, 1.5f)
+      reflectiveCurveTo(15.328f, 15f, 14.5f, 15f)
+      horizontalLineToRelative(-3f)
+      curveToRelative(-0.275f, 0f, -0.5f, 0.224f, -0.5f, 0.5f)
+      verticalLineToRelative(3f)
+      curveTo(11f, 19.329f, 10.328f, 20f, 9.5f, 20f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Campfire.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Campfire.kt
@@ -1,0 +1,127 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Campfire: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Campfire",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(46.841f, 57.003f)
+      curveToRelative(1.815f, 0.067f, 3.505f, -1.117f, 4.003f, -2.946f)
+      curveToRelative(0.581f, -2.131f, -0.676f, -4.331f, -2.807f, -4.912f)
+      lineToRelative(-29.721f, -8.103f)
+      curveToRelative(-2.124f, -0.581f, -4.331f, 0.675f, -4.912f, 2.807f)
+      curveToRelative(-0.581f, 2.131f, 0.676f, 4.331f, 2.807f, 4.912f)
+      lineToRelative(29.721f, 8.103f)
+      curveTo(46.235f, 56.946f, 46.539f, 56.992f, 46.841f, 57.003f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(47f, 53f)
+      moveToRelative(-4f, 0f)
+      arcToRelative(4f, 4f, 0f, isMoreThanHalf = true, isPositiveArc = true, 8f, 0f)
+      arcToRelative(4f, 4f, 0f, isMoreThanHalf = true, isPositiveArc = true, -8f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(15f, 61f)
+      arcToRelative(17f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 34f, 0f)
+      arcToRelative(17f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -34f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFDA7200))) {
+      moveTo(17.104f, 57.003f)
+      curveToRelative(-1.815f, 0.067f, -3.505f, -1.117f, -4.003f, -2.946f)
+      curveToRelative(-0.581f, -2.131f, 0.676f, -4.331f, 2.807f, -4.912f)
+      lineToRelative(29.721f, -8.103f)
+      curveToRelative(2.124f, -0.581f, 4.331f, 0.675f, 4.912f, 2.807f)
+      curveToRelative(0.581f, 2.131f, -0.676f, 4.331f, -2.807f, 4.912f)
+      lineToRelative(-29.721f, 8.103f)
+      curveTo(17.71f, 56.946f, 17.406f, 56.992f, 17.104f, 57.003f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(16.949f, 53f)
+      moveToRelative(-4f, 0f)
+      arcToRelative(4f, 4f, 0f, isMoreThanHalf = true, isPositiveArc = true, 8f, 0f)
+      arcToRelative(4f, 4f, 0f, isMoreThanHalf = true, isPositiveArc = true, -8f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(42.85f, 16.773f)
+      curveToRelative(-0.66f, 1.306f, -1.402f, 2.456f, -2.076f, 3.386f)
+      curveToRelative(-0.46f, 0.634f, -1.467f, 0.236f, -1.364f, -0.54f)
+      curveToRelative(0.449f, -3.378f, 0.16f, -8.975f, -4.992f, -13.813f)
+      curveToRelative(-1.209f, -1.135f, -3.103f, -1.034f, -4.281f, 0.133f)
+      curveToRelative(-6.872f, 6.8f, -17.059f, 12.366f, -16.871f, 23.117f)
+      curveToRelative(0.162f, 9.226f, 7.389f, 17.062f, 16.581f, 17.871f)
+      curveToRelative(10.817f, 0.953f, 19.891f, -7.546f, 19.891f, -18.164f)
+      curveToRelative(0f, -3.923f, -1.847f, -8.226f, -4.623f, -12.15f)
+      curveTo(44.542f, 15.804f, 43.296f, 15.889f, 42.85f, 16.773f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(19.634f, 21.58f)
+      curveToRelative(1.063f, -1.549f, 2.424f, -3.006f, 3.962f, -4.456f)
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(40f, 39f)
+      curveToRelative(0f, 4.971f, -3.582f, 8f, -8f, 8f)
+      reflectiveCurveToRelative(-8f, -3.029f, -8f, -8f)
+      curveToRelative(0f, -4.149f, 3.825f, -8.776f, 6.185f, -11.236f)
+      curveToRelative(1.002f, -1.044f, 2.627f, -1.044f, 3.629f, 0f)
+      curveTo(36.175f, 30.224f, 40f, 34.851f, 40f, 39f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(28.416f, 14.201f)
+      curveToRelative(1.754f, -1.502f, 3.567f, -3.055f, 5.237f, -4.707f)
+      curveToRelative(0.85f, -0.841f, 1.312f, -1.914f, 1.431f, -3.017f)
+      curveToRelative(-0.216f, -0.224f, -0.431f, -0.449f, -0.667f, -0.671f)
+      curveToRelative(-1.209f, -1.135f, -3.103f, -1.034f, -4.281f, 0.133f)
+      curveToRelative(-6.872f, 6.8f, -17.059f, 12.366f, -16.871f, 23.117f)
+      curveToRelative(0.03f, 1.698f, 0.303f, 3.348f, 0.779f, 4.917f)
+      curveToRelative(2.424f, -0.382f, 4.264f, -2.481f, 4.22f, -5.005f)
+      curveTo(18.167f, 23.388f, 22.034f, 19.666f, 28.416f, 14.201f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(48.873f, 23.85f)
+      curveToRelative(-2.348f, 0.411f, -4.136f, 2.447f, -4.136f, 4.913f)
+      curveToRelative(0f, 3.703f, -1.567f, 7.263f, -4.301f, 9.766f)
+      curveToRelative(-2.77f, 2.536f, -6.364f, 3.751f, -10.151f, 3.418f)
+      curveToRelative(-2.503f, -0.222f, -4.73f, 1.462f, -5.287f, 3.849f)
+      curveToRelative(1.529f, 0.591f, 3.154f, 0.982f, 4.848f, 1.132f)
+      curveToRelative(10.817f, 0.953f, 19.891f, -7.546f, 19.891f, -18.164f)
+      curveTo(49.737f, 27.171f, 49.42f, 25.516f, 48.873f, 23.85f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Cloud.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Cloud.kt
@@ -1,0 +1,138 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Cloud: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Cloud",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(35f, 24f)
+      curveToRelative(0f, 4.99f, -3.66f, 9.13f, -8.45f, 9.88f)
+      curveTo(26.05f, 33.96f, 25.53f, 34f, 25f, 34f)
+      curveToRelative(-3.03f, 0f, -5.74f, -1.35f, -7.58f, -3.48f)
+      curveToRelative(-1.08f, -1.26f, -1.86f, -2.79f, -2.22f, -4.49f)
+      curveTo(15.07f, 25.38f, 15f, 24.701f, 15f, 24f)
+      curveToRelative(0f, -5.52f, 4.48f, -10f, 10f, -10f)
+      curveToRelative(1.75f, 0f, 3.4f, 0.45f, 4.84f, 1.25f)
+      curveTo(32.92f, 16.951f, 35f, 20.23f, 35f, 24f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(50.02f, 26.01f)
+      curveToRelative(0f, 0.68f, -0.08f, 1.35f, -0.22f, 1.99f)
+      curveToRelative(-0.08f, 0.35f, -0.18f, 0.69f, -0.3f, 1.03f)
+      curveToRelative(-0.44f, 1.24f, -1.14f, 2.35f, -2.04f, 3.27f)
+      curveToRelative(-1.64f, 1.68f, -3.92f, 2.72f, -6.45f, 2.72f)
+      curveToRelative(-0.19f, 0f, -0.37f, -0.01f, -0.55f, -0.02f)
+      curveToRelative(-3.68f, -0.22f, -6.76f, -2.65f, -7.94f, -5.97f)
+      curveTo(32.18f, 28.09f, 32f, 27.07f, 32f, 26.01f)
+      curveToRelative(0f, -4.98f, 4.03f, -9.01f, 9.01f, -9.01f)
+      curveToRelative(3.93f, 0f, 7.27f, 2.52f, 8.5f, 6.03f)
+      curveTo(49.84f, 23.96f, 50.02f, 24.97f, 50.02f, 26.01f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(27f, 37f)
+      curveToRelative(0f, 6.08f, -4.92f, 11f, -11f, 11f)
+      curveToRelative(-4.33f, 0f, -8.07f, -2.5f, -9.87f, -6.13f)
+      curveTo(5.41f, 40.401f, 5f, 38.75f, 5f, 37f)
+      curveToRelative(0f, -5.81f, 4.5f, -10.56f, 10.2f, -10.97f)
+      curveTo(15.47f, 26.01f, 15.73f, 26f, 16f, 26f)
+      curveToRelative(1.46f, 0f, 2.86f, 0.29f, 4.14f, 0.81f)
+      curveToRelative(3.08f, 1.24f, 5.46f, 3.85f, 6.41f, 7.07f)
+      curveTo(26.84f, 34.871f, 27f, 35.91f, 27f, 37f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(59f, 38f)
+      curveToRelative(0f, 5.51f, -4.46f, 9.98f, -9.96f, 10f)
+      horizontalLineTo(49f)
+      curveToRelative(-3.7f, 0f, -6.93f, -2.01f, -8.66f, -5f)
+      curveTo(39.49f, 41.53f, 39f, 39.82f, 39f, 38f)
+      curveToRelative(0f, -1.05f, 0.16f, -2.05f, 0.46f, -3f)
+      curveToRelative(0.77f, -2.47f, 2.48f, -4.52f, 4.7f, -5.75f)
+      curveToRelative(0.14f, -0.08f, 0.28f, -0.15f, 0.43f, -0.22f)
+      curveToRelative(1.27f, -0.63f, 2.7f, -1f, 4.21f, -1.03f)
+      horizontalLineTo(49f)
+      curveTo(54.52f, 28f, 59f, 32.48f, 59f, 38f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(9f, 61f)
+      arcToRelative(22f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 44f, 0f)
+      arcToRelative(22f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -44f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(16.5f, 29.031f)
+      horizontalLineToRelative(33.54f)
+      verticalLineToRelative(18.97f)
+      horizontalLineToRelative(-33.54f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(59f, 38f)
+      curveToRelative(0f, 5.17f, -3.93f, 9.43f, -8.96f, 9.95f)
+      verticalLineTo(48f)
+      horizontalLineTo(32f)
+      curveToRelative(0f, -2.76f, 2.24f, -5f, 5f, -5f)
+      horizontalLineToRelative(12.31f)
+      curveToRelative(0.07f, -0.01f, 0.14f, -0.02f, 0.22f, -0.03f)
+      curveTo(52.08f, 42.71f, 54f, 40.57f, 54f, 38f)
+      curveToRelative(0f, -2.33f, 1.59f, -4.29f, 3.75f, -4.84f)
+      curveTo(58.54f, 34.59f, 59f, 36.25f, 59f, 38f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(29.84f, 15.25f)
+      curveTo(29.29f, 17.41f, 27.33f, 19f, 25f, 19f)
+      curveToRelative(-2.76f, 0f, -5f, 2.24f, -5f, 5f)
+      curveToRelative(0f, 0.35f, 0.04f, 0.71f, 0.1f, 1.05f)
+      curveToRelative(0.28f, 1.41f, -0.05f, 2.87f, -0.92f, 4.01f)
+      reflectiveCurveToRelative(-2.19f, 1.85f, -3.62f, 1.96f)
+      curveTo(12.44f, 31.24f, 10f, 33.871f, 10f, 37f)
+      curveToRelative(0f, 2.37f, -1.65f, 4.36f, -3.87f, 4.87f)
+      curveTo(5.41f, 40.401f, 5f, 38.75f, 5f, 37f)
+      curveToRelative(0f, -5.81f, 4.5f, -10.56f, 10.2f, -10.97f)
+      curveTo(15.07f, 25.38f, 15f, 24.701f, 15f, 24f)
+      curveToRelative(0f, -5.52f, 4.48f, -10f, 10f, -10f)
+      curveTo(26.75f, 14f, 28.4f, 14.45f, 29.84f, 15.25f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(17.001f, 30.5f)
+      curveToRelative(-0.55f, 0f, -1.08f, -0.304f, -1.343f, -0.829f)
+      curveToRelative(-0.37f, -0.741f, -0.07f, -1.642f, 0.671f, -2.013f)
+      curveToRelative(0.954f, -0.477f, 0.971f, -0.829f, 0.893f, -2.415f)
+      curveToRelative(-0.05f, -1.03f, -0.113f, -2.313f, 0.355f, -3.718f)
+      curveToRelative(0.261f, -0.785f, 1.11f, -1.213f, 1.897f, -0.948f)
+      curveToRelative(0.786f, 0.262f, 1.21f, 1.111f, 0.948f, 1.897f)
+      curveToRelative(-0.29f, 0.87f, -0.248f, 1.722f, -0.204f, 2.622f)
+      curveToRelative(0.08f, 1.636f, 0.189f, 3.876f, -2.548f, 5.245f)
+      curveTo(17.455f, 30.449f, 17.227f, 30.5f, 17.001f, 30.5f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Compass.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Compass.kt
@@ -1,0 +1,130 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Compass: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Compass",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(32f, 32f)
+      moveToRelative(-23f, 0f)
+      arcToRelative(23f, 23f, 0f, isMoreThanHalf = true, isPositiveArc = true, 46f, 0f)
+      arcToRelative(23f, 23f, 0f, isMoreThanHalf = true, isPositiveArc = true, -46f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(32f, 14f)
+      curveToRelative(2.577f, 0f, 4.674f, -1.957f, 4.946f, -4.461f)
+      curveTo(35.352f, 9.19f, 33.699f, 9f, 32f, 9f)
+      curveTo(19.297f, 9f, 9f, 19.297f, 9f, 32f)
+      curveToRelative(0f, 1.699f, 0.19f, 3.352f, 0.539f, 4.946f)
+      curveTo(12.044f, 36.674f, 14f, 34.577f, 14f, 32f)
+      curveTo(14f, 22.075f, 22.075f, 14f, 32f, 14f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(54.461f, 27.054f)
+      curveTo(51.956f, 27.326f, 50f, 29.423f, 50f, 32f)
+      curveToRelative(0f, 9.925f, -8.075f, 18f, -18f, 18f)
+      curveToRelative(-2.577f, 0f, -4.674f, 1.957f, -4.946f, 4.461f)
+      curveTo(28.648f, 54.81f, 30.301f, 55f, 32f, 55f)
+      curveToRelative(12.703f, 0f, 23f, -10.297f, 23f, -23f)
+      curveTo(55f, 30.301f, 54.81f, 28.648f, 54.461f, 27.054f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(32f, 32f)
+      moveToRelative(-18f, 0f)
+      arcToRelative(18f, 18f, 0f, isMoreThanHalf = true, isPositiveArc = true, 36f, 0f)
+      arcToRelative(18f, 18f, 0f, isMoreThanHalf = true, isPositiveArc = true, -36f, 0f)
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(15.047f, 23.427f)
+      curveToRelative(1.878f, -3.699f, 4.932f, -6.705f, 8.666f, -8.522f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(21.136f, 41f)
+      curveToRelative(-0.597f, 1.194f, 0.67f, 2.461f, 1.864f, 1.864f)
+      lineToRelative(7.759f, -3.88f)
+      curveToRelative(1.78f, -0.89f, 3.391f, -2.056f, 4.78f, -3.445f)
+      lineToRelative(-7.078f, -7.078f)
+      curveToRelative(-1.389f, 1.389f, -2.555f, 3f, -3.445f, 4.78f)
+      lineTo(21.136f, 41f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(38.984f, 30.759f)
+      lineTo(42.864f, 23f)
+      curveToRelative(0.597f, -1.194f, -0.67f, -2.461f, -1.864f, -1.864f)
+      lineToRelative(-7.759f, 3.88f)
+      curveToRelative(-1.78f, 0.89f, -3.391f, 2.056f, -4.78f, 3.445f)
+      lineToRelative(7.078f, 7.078f)
+      curveTo(36.928f, 34.15f, 38.095f, 32.539f, 38.984f, 30.759f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(32f, 32f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF0089AD))) {
+      moveTo(32f, 18f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF0089AD))) {
+      moveTo(32f, 46f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF0089AD))) {
+      moveTo(46f, 32f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF0089AD))) {
+      moveTo(18f, 32f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/CrescentMoon.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/CrescentMoon.kt
@@ -1,0 +1,93 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.CrescentMoon: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.CrescentMoon",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(51.137f, 29.807f)
+      curveToRelative(-2.652f, 3.395f, -6.891f, 5.488f, -11.604f, 5.159f)
+      curveToRelative(-6.617f, -0.461f, -12.039f, -5.883f, -12.499f, -12.5f)
+      curveToRelative(-0.328f, -4.712f, 1.765f, -8.951f, 5.159f, -11.603f)
+      curveToRelative(1.632f, -1.275f, 0.637f, -3.927f, -1.431f, -3.818f)
+      curveToRelative(-6.408f, 0.337f, -12.699f, 3.339f, -17.07f, 9.022f)
+      curveToRelative(-6.37f, 8.283f, -6.24f, 20.079f, 0.291f, 28.236f)
+      curveToRelative(8.727f, 10.9f, 24.687f, 11.554f, 34.281f, 1.96f)
+      curveToRelative(4.177f, -4.177f, 6.405f, -9.56f, 6.691f, -15.028f)
+      curveTo(55.063f, 29.169f, 52.411f, 28.175f, 51.137f, 29.807f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(48.263f, 46.263f)
+      curveToRelative(3.346f, -3.346f, 5.419f, -7.469f, 6.268f, -11.785f)
+      curveToRelative(-2.398f, -0.736f, -5.016f, 0.399f, -6.044f, 2.753f)
+      curveToRelative(-0.895f, 2.048f, -2.16f, 3.897f, -3.759f, 5.497f)
+      curveToRelative(-3.598f, 3.599f, -8.575f, 5.507f, -13.671f, 5.247f)
+      curveToRelative(-2.585f, -0.144f, -4.769f, 1.709f, -5.17f, 4.196f)
+      curveTo(33.601f, 54.291f, 42.202f, 52.325f, 48.263f, 46.263f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(17.655f, 19.115f)
+      curveToRelative(1.673f, -2.175f, 3.724f, -3.896f, 6.096f, -5.118f)
+      curveToRelative(2.29f, -1.178f, 3.259f, -3.874f, 2.358f, -6.224f)
+      curveToRelative(-4.716f, 1.24f, -9.115f, 4.001f, -12.417f, 8.294f)
+      curveTo(9.45f, 21.582f, 8.108f, 28.652f, 9.601f, 35.171f)
+      curveToRelative(2.497f, -0.303f, 4.426f, -2.418f, 4.398f, -4.992f)
+      curveTo(13.958f, 26.165f, 15.256f, 22.235f, 17.655f, 19.115f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(15.046f, 22.927f)
+      curveToRelative(-0.229f, 0f, -0.46f, -0.052f, -0.678f, -0.162f)
+      curveToRelative(-0.738f, -0.375f, -1.033f, -1.278f, -0.658f, -2.017f)
+      curveToRelative(1.145f, -2.255f, 2.682f, -4.262f, 4.568f, -5.964f)
+      curveToRelative(0.613f, -0.556f, 1.563f, -0.508f, 2.118f, 0.108f)
+      curveToRelative(0.555f, 0.615f, 0.507f, 1.563f, -0.108f, 2.118f)
+      curveToRelative(-1.612f, 1.455f, -2.925f, 3.17f, -3.903f, 5.095f)
+      curveTo(16.12f, 22.627f, 15.593f, 22.927f, 15.046f, 22.927f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(22.5f, 35.5f)
+      moveToRelative(-3.5f, 0f)
+      arcToRelative(3.5f, 3.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 7f, 0f)
+      arcToRelative(3.5f, 3.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -7f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(33.5f, 39.5f)
+      moveToRelative(-2.5f, 0f)
+      arcToRelative(2.5f, 2.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 5f, 0f)
+      arcToRelative(2.5f, 2.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -5f, 0f)
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Deer.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Deer.kt
@@ -1,0 +1,183 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Deer: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Deer",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(15f, 20f)
+      horizontalLineTo(9f)
+      curveToRelative(-1.105f, 0f, -2f, 0.895f, -2f, 2f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, 3.866f, 3.134f, 7f, 7f, 7f)
+      horizontalLineToRelative(8f)
+      verticalLineToRelative(-2f)
+      curveTo(22f, 23.134f, 18.866f, 20f, 15f, 20f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(49f, 20f)
+      horizontalLineToRelative(6f)
+      curveToRelative(1.105f, 0f, 2f, 0.895f, 2f, 2f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, 3.866f, -3.134f, 7f, -7f, 7f)
+      horizontalLineToRelative(-8f)
+      verticalLineToRelative(-2f)
+      curveTo(42f, 23.134f, 45.134f, 20f, 49f, 20f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA7B3C7))) {
+      moveTo(32f, 22f)
+      curveTo(12.164f, 22f, 8f, 12.212f, 8f, 4f)
+      curveToRelative(0f, -1.657f, 1.343f, -3f, 3f, -3f)
+      reflectiveCurveToRelative(3f, 1.343f, 3f, 3f)
+      curveToRelative(0f, 5.151f, 1.866f, 12f, 18f, 12f)
+      reflectiveCurveTo(50f, 9.151f, 50f, 4f)
+      curveToRelative(0f, -1.657f, 1.343f, -3f, 3f, -3f)
+      reflectiveCurveToRelative(3f, 1.343f, 3f, 3f)
+      curveTo(56f, 12.212f, 51.836f, 22f, 32f, 22f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA7B3C7))) {
+      moveTo(32f, 20f)
+      curveToRelative(-7.72f, 0f, -14f, -6.28f, -14f, -14f)
+      curveToRelative(0f, -1.381f, 1.119f, -2.5f, 2.5f, -2.5f)
+      reflectiveCurveTo(23f, 4.619f, 23f, 6f)
+      curveToRelative(0f, 4.963f, 4.038f, 9f, 9f, 9f)
+      reflectiveCurveToRelative(9f, -4.037f, 9f, -9f)
+      curveToRelative(0f, -1.381f, 1.119f, -2.5f, 2.5f, -2.5f)
+      reflectiveCurveTo(46f, 4.619f, 46f, 6f)
+      curveTo(46f, 13.72f, 39.72f, 20f, 32f, 20f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(47f, 28f)
+      curveToRelative(0f, -9.695f, -8f, -13f, -15f, -12.976f)
+      curveToRelative(-7.941f, 0.028f, -14.252f, 3.061f, -14.933f, 11.351f)
+      curveToRelative(-0.433f, 5.267f, 1.264f, 10.083f, 4.22f, 13.499f)
+      curveToRelative(1.177f, 1.361f, 1.89f, 1.149f, 1.89f, 3.054f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, 1.395f, 0.151f, 2.773f, 0.442f, 4.105f)
+      curveToRelative(0.817f, 3.738f, 4.035f, 7.469f, 7.411f, 7.903f)
+      curveToRelative(3.884f, 0.5f, 7.55f, -2.047f, 8.871f, -6.125f)
+      curveToRelative(0.605f, -1.867f, 0.923f, -3.857f, 0.923f, -5.884f)
+      verticalLineToRelative(-0.003f)
+      curveToRelative(0f, -1.896f, 0.702f, -1.682f, 1.875f, -3.034f)
+      curveTo(45.356f, 36.829f, 47f, 32.636f, 47f, 28f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(42.661f, 39.933f)
+      curveToRelative(-0.466f, -0.193f, -0.958f, -0.34f, -1.488f, -0.384f)
+      curveToRelative(-2.744f, -0.217f, -5.168f, 1.816f, -5.398f, 4.567f)
+      curveToRelative(-0.09f, 1.08f, -2.237f, 2.067f, -2.565f, 3.081f)
+      curveToRelative(-0.171f, 0.526f, -0.516f, 0.995f, -0.814f, 1.388f)
+      curveToRelative(-0.71f, 0.938f, 0.314f, 1.525f, -0.728f, 1.393f)
+      curveToRelative(-2.096f, -0.268f, -4.046f, 0.805f, -5.008f, 2.548f)
+      curveToRelative(1.274f, 1.293f, 2.804f, 2.209f, 4.37f, 2.411f)
+      curveToRelative(3.884f, 0.5f, 7.55f, -2.047f, 8.871f, -6.125f)
+      curveToRelative(0.605f, -1.867f, 0.923f, -3.857f, 0.923f, -5.884f)
+      verticalLineToRelative(-0.003f)
+      curveTo(40.824f, 41.052f, 41.512f, 41.234f, 42.661f, 39.933f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(32f, 15.024f)
+      curveToRelative(-7.941f, 0.022f, -14.252f, 3.061f, -14.933f, 11.351f)
+      curveToRelative(-0.048f, 0.586f, -0.121f, 2.684f, 0.047f, 3.724f)
+      curveTo(18.48f, 27.646f, 20.993f, 27f, 24f, 27f)
+      curveToRelative(2.032f, 0f, 3.887f, 0.758f, 5.298f, 2.006f)
+      curveToRelative(1.556f, 1.377f, 3.848f, 1.377f, 5.404f, 0f)
+      curveTo(36.113f, 27.758f, 37.968f, 27f, 40f, 27f)
+      curveToRelative(3.01f, 0f, 5.518f, 0.699f, 6.884f, 3.156f)
+      curveToRelative(0.005f, -0.002f, -0.005f, -0.025f, 0f, -0.027f)
+      curveTo(48.098f, 18.995f, 40.86f, 15f, 32f, 15.024f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(24.5f, 32.5f)
+      moveToRelative(-2.5f, 0f)
+      arcToRelative(2.5f, 2.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 5f, 0f)
+      arcToRelative(2.5f, 2.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -5f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(39.5f, 32.5f)
+      moveToRelative(-2.5f, 0f)
+      arcToRelative(2.5f, 2.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 5f, 0f)
+      arcToRelative(2.5f, 2.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -5f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(31.961f, 15.024f)
+      curveToRelative(-7.731f, 0.027f, -13.9f, 2.917f, -14.851f, 10.717f)
+      curveToRelative(0.486f, 0.152f, 0.984f, 0.235f, 1.479f, 0.235f)
+      curveToRelative(1.731f, 0f, 3.414f, -0.899f, 4.339f, -2.508f)
+      curveToRelative(1.638f, -2.847f, 5.826f, -3.458f, 9.051f, -3.469f)
+      curveToRelative(2.551f, -0.009f, 4.625f, -1.933f, 4.923f, -4.402f)
+      curveTo(35.275f, 15.203f, 33.592f, 15.019f, 31.961f, 15.024f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(23.26f, 22.461f)
+      curveToRelative(-0.482f, 0f, -0.955f, -0.231f, -1.245f, -0.661f)
+      curveToRelative(-0.463f, -0.687f, -0.283f, -1.619f, 0.404f, -2.082f)
+      curveToRelative(1.55f, -1.046f, 4.25f, -2.355f, 8.316f, -2.654f)
+      curveToRelative(0.831f, -0.058f, 1.545f, 0.562f, 1.606f, 1.386f)
+      curveToRelative(0.061f, 0.826f, -0.56f, 1.546f, -1.386f, 1.606f)
+      curveToRelative(-3.407f, 0.25f, -5.61f, 1.307f, -6.857f, 2.148f)
+      curveTo(23.84f, 22.378f, 23.548f, 22.461f, 23.26f, 22.461f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(33.369f, 47.379f)
+      verticalLineToRelative(-0.25f)
+      curveToRelative(0.168f, -0.07f, 0.333f, -0.15f, 0.494f, -0.247f)
+      lineToRelative(2.567f, -1.54f)
+      curveTo(36.78f, 45.132f, 37f, 44.704f, 37f, 44.236f)
+      lineToRelative(0f, 0f)
+      curveTo(37f, 43.553f, 36.539f, 43f, 35.97f, 43f)
+      horizontalLineToRelative(-7.94f)
+      curveTo(27.461f, 43f, 27f, 43.553f, 27f, 44.236f)
+      lineToRelative(0f, 0f)
+      curveToRelative(0f, 0.468f, 0.22f, 0.896f, 0.569f, 1.105f)
+      lineToRelative(2.567f, 1.54f)
+      curveToRelative(0.076f, 0.046f, 0.155f, 0.08f, 0.233f, 0.12f)
+      verticalLineToRelative(0.377f)
+      lineTo(25.948f, 51.8f)
+      curveToRelative(0.659f, 0.796f, 1.412f, 1.487f, 2.22f, 2.022f)
+      lineToRelative(3.701f, -3.701f)
+      lineToRelative(3.868f, 3.868f)
+      curveToRelative(0.863f, -0.487f, 1.646f, -1.14f, 2.314f, -1.928f)
+      lineTo(33.369f, 47.379f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Dinghy.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Dinghy.kt
@@ -1,0 +1,146 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Dinghy: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Dinghy",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(9f, 61f)
+      arcToRelative(23f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 46f, 0f)
+      arcToRelative(23f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -46f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(30.98f, 35.916f)
+      lineToRelative(-11.244f, -4.193f)
+      lineToRelative(4.542f, -12.181f)
+      curveToRelative(1.158f, -3.105f, 4.613f, -4.683f, 7.718f, -3.525f)
+      lineToRelative(0f, 0f)
+      curveToRelative(3.105f, 1.158f, 4.683f, 4.613f, 3.525f, 7.718f)
+      lineTo(30.98f, 35.916f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFDA7200))) {
+      moveTo(36f, 51f)
+      horizontalLineToRelative(-7f)
+      curveToRelative(-9.941f, 0f, -18f, -8.059f, -18f, -18f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, -1.657f, 1.343f, -3f, 3f, -3f)
+      horizontalLineToRelative(37f)
+      curveToRelative(1.657f, 0f, 3f, 1.343f, 3f, 3f)
+      verticalLineToRelative(0f)
+      curveTo(54f, 42.941f, 45.941f, 51f, 36f, 51f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(24.75f, 18.569f)
+      curveToRelative(-0.182f, 0.306f, -0.343f, 0.628f, -0.471f, 0.973f)
+      lineTo(20.379f, 30f)
+      horizontalLineTo(14f)
+      curveToRelative(-1.657f, 0f, -3f, 1.343f, -3f, 3f)
+      curveToRelative(0f, 1.718f, 0.256f, 3.374f, 0.705f, 4.947f)
+      curveToRelative(1.743f, -0.246f, 3.198f, -1.388f, 3.879f, -2.947f)
+      horizontalLineToRelative(4.795f)
+      curveToRelative(2.088f, 0f, 3.955f, -1.297f, 4.685f, -3.253f)
+      lineToRelative(2.532f, -6.791f)
+      curveTo(28.548f, 22.401f, 27.272f, 19.569f, 24.75f, 18.569f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(35f, 9f)
+      moveToRelative(-5f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 10f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -10f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(33.5f, 51f)
+      curveToRelative(-0.177f, 0f, -0.356f, -0.031f, -0.532f, -0.098f)
+      curveToRelative(-0.774f, -0.294f, -1.164f, -1.16f, -0.87f, -1.935f)
+      lineToRelative(11f, -29f)
+      curveToRelative(0.294f, -0.774f, 1.157f, -1.164f, 1.935f, -0.87f)
+      curveToRelative(0.774f, 0.294f, 1.164f, 1.16f, 0.87f, 1.935f)
+      lineToRelative(-11f, 29f)
+      curveTo(34.675f, 50.632f, 34.104f, 51f, 33.5f, 51f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(44.499f, 26.001f)
+      curveToRelative(-0.298f, 0f, -0.602f, -0.054f, -0.896f, -0.168f)
+      lineToRelative(-13f, -5f)
+      curveToRelative(-1.289f, -0.495f, -1.932f, -1.941f, -1.436f, -3.23f)
+      curveToRelative(0.495f, -1.288f, 1.939f, -1.936f, 3.23f, -1.436f)
+      lineToRelative(13f, 5f)
+      curveToRelative(1.289f, 0.495f, 1.932f, 1.941f, 1.436f, 3.23f)
+      curveTo(46.451f, 25.391f, 45.504f, 26.001f, 44.499f, 26.001f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF68E5FD))) {
+      moveTo(53.361f, 41.154f)
+      curveToRelative(-1.045f, 0.723f, -2.032f, 1.796f, -4.032f, 1.796f)
+      reflectiveCurveToRelative(-2.987f, -0.683f, -4.032f, -1.406f)
+      curveToRelative(-1.133f, -0.784f, -2.304f, -1.594f, -4.639f, -1.594f)
+      curveToRelative(-2.333f, 0f, -3.503f, 0.811f, -4.635f, 1.594f)
+      curveToRelative(-1.044f, 0.723f, -2.03f, 1.406f, -4.029f, 1.406f)
+      reflectiveCurveToRelative(-2.985f, -0.683f, -4.03f, -1.406f)
+      curveToRelative(-1.132f, -0.784f, -2.303f, -1.594f, -4.637f, -1.594f)
+      reflectiveCurveToRelative(-3.504f, 0.811f, -4.635f, 1.594f)
+      curveToRelative(-1.044f, 0.723f, -2.03f, 1.406f, -4.028f, 1.406f)
+      curveToRelative(-1.997f, 0f, -2.983f, -1.074f, -4.027f, -1.798f)
+      curveToRelative(-0.506f, -0.35f, -1.019f, -0.706f, -1.64f, -0.992f)
+      curveTo(7.61f, 39.522f, 6f, 40.486f, 6f, 41.963f)
+      verticalLineToRelative(9.992f)
+      curveToRelative(0f, 1.105f, 0.931f, 2f, 2.08f, 2f)
+      horizontalLineToRelative(47.84f)
+      curveToRelative(1.149f, 0f, 2.08f, -0.895f, 2.08f, -2f)
+      verticalLineToRelative(-9.992f)
+      curveToRelative(0f, -1.477f, -1.609f, -2.44f, -2.995f, -1.803f)
+      curveTo(54.382f, 40.447f, 53.868f, 40.803f, 53.361f, 41.154f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(58f, 52f)
+      verticalLineTo(42f)
+      curveToRelative(-2.762f, 0f, -5f, 2.239f, -5f, 5f)
+      verticalLineToRelative(1f)
+      curveToRelative(0f, 0.552f, -0.448f, 1f, -1f, 1f)
+      horizontalLineToRelative(-8f)
+      curveToRelative(-2.762f, 0f, -5f, 2.239f, -5f, 5f)
+      horizontalLineToRelative(16.76f)
+      curveTo(56.997f, 54f, 58f, 53.105f, 58f, 52f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(20.5f, 35f)
+      horizontalLineToRelative(-5f)
+      curveToRelative(-0.828f, 0f, -1.5f, -0.672f, -1.5f, -1.5f)
+      reflectiveCurveToRelative(0.672f, -1.5f, 1.5f, -1.5f)
+      horizontalLineToRelative(5f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.672f, 1.5f, 1.5f)
+      reflectiveCurveTo(21.328f, 35f, 20.5f, 35f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Evergreen.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Evergreen.kt
@@ -1,0 +1,123 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Evergreen: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Evergreen",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(34f, 54f)
+      horizontalLineToRelative(-4.001f)
+      curveToRelative(-1.657f, 0f, -3f, -1.343f, -3f, -3f)
+      verticalLineTo(29.001f)
+      horizontalLineTo(37f)
+      verticalLineTo(51f)
+      curveTo(37f, 52.657f, 35.657f, 54f, 34f, 54f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(19f, 61f)
+      arcToRelative(13f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 26f, 0f)
+      arcToRelative(13f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -26f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(29.342f, 5.283f)
+      lineTo(18.619f, 18.53f)
+      curveTo(17.167f, 20.324f, 18.443f, 23f, 20.751f, 23f)
+      horizontalLineToRelative(22.497f)
+      curveToRelative(2.308f, 0f, 3.585f, -2.676f, 2.133f, -4.47f)
+      lineTo(34.658f, 5.283f)
+      curveTo(33.289f, 3.593f, 30.711f, 3.593f, 29.342f, 5.283f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(32f, 14f)
+      lineTo(16.038f, 29.237f)
+      curveTo(13.855f, 31.32f, 15.33f, 35f, 18.347f, 35f)
+      horizontalLineToRelative(27.306f)
+      curveToRelative(3.017f, 0f, 4.492f, -3.68f, 2.309f, -5.763f)
+      lineTo(32f, 14f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(32f, 22f)
+      lineTo(13.143f, 39.748f)
+      curveTo(10.757f, 41.993f, 12.347f, 46f, 15.623f, 46f)
+      horizontalLineToRelative(32.754f)
+      curveToRelative(3.276f, 0f, 4.865f, -4.007f, 2.48f, -6.252f)
+      lineTo(32f, 22f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(48.38f, 46f)
+      horizontalLineTo(37f)
+      verticalLineToRelative(5f)
+      curveToRelative(0f, 1.66f, -1.34f, 3f, -3f, 3f)
+      horizontalLineToRelative(-4f)
+      curveToRelative(-0.74f, 0f, -1.42f, -0.27f, -1.94f, -0.72f)
+      curveToRelative(0.29f, -2.09f, 1.89f, -3.77f, 3.94f, -4.18f)
+      verticalLineTo(46f)
+      curveToRelative(0f, -2.76f, 2.24f, -5f, 5f, -5f)
+      horizontalLineToRelative(7.89f)
+      lineToRelative(-2.52f, -2.37f)
+      curveToRelative(-1.46f, -1.38f, -1.96f, -3.5f, -1.25f, -5.39f)
+      curveToRelative(0.39f, -1.07f, 1.13f, -1.94f, 2.07f, -2.51f)
+      curveToRelative(-0.52f, -1.68f, -0.14f, -3.58f, 1.16f, -4.94f)
+      lineToRelative(3.61f, 3.45f)
+      curveToRelative(2.15f, 2.04f, 0.76f, 5.63f, -2.16f, 5.75f)
+      lineToRelative(5.06f, 4.76f)
+      curveTo(53.24f, 41.99f, 51.65f, 46f, 48.38f, 46f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(33.23f, 8.43f)
+      lineToRelative(-8.25f, 10.19f)
+      curveToRelative(0.99f, 0.54f, 1.79f, 1.42f, 2.23f, 2.52f)
+      curveToRelative(0.76f, 1.9f, 0.29f, 4.07f, -1.19f, 5.48f)
+      lineToRelative(-6.53f, 6.23f)
+      curveToRelative(-0.93f, 0.89f, -2.1f, 1.35f, -3.28f, 1.38f)
+      curveToRelative(-1.42f, -1.18f, -1.74f, -3.5f, -0.17f, -4.99f)
+      lineTo(22.57f, 23f)
+      horizontalLineToRelative(-1.82f)
+      curveToRelative(-2.31f, 0f, -3.58f, -2.68f, -2.13f, -4.47f)
+      lineTo(29.34f, 5.28f)
+      curveToRelative(1.26f, -1.56f, 3.56f, -1.68f, 4.98f, -0.36f)
+      curveTo(34.42f, 6.14f, 34.06f, 7.4f, 33.23f, 8.43f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(26.499f, 16f)
+      curveToRelative(-0.328f, 0f, -0.659f, -0.107f, -0.937f, -0.329f)
+      curveToRelative(-0.646f, -0.518f, -0.751f, -1.461f, -0.233f, -2.108f)
+      lineToRelative(4f, -5f)
+      curveToRelative(0.517f, -0.646f, 1.458f, -0.752f, 2.108f, -0.233f)
+      curveToRelative(0.646f, 0.518f, 0.751f, 1.461f, 0.233f, 2.108f)
+      lineToRelative(-4f, 5f)
+      curveTo(27.375f, 15.808f, 26.939f, 16f, 26.499f, 16f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Fishing.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Fishing.kt
@@ -1,0 +1,117 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Fishing: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Fishing",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(32f, 2f)
+      lineTo(32f, 2f)
+      curveToRelative(-2.209f, 0f, -4f, 1.791f, -4f, 4f)
+      verticalLineToRelative(7f)
+      horizontalLineToRelative(8f)
+      verticalLineTo(6f)
+      curveTo(36f, 3.791f, 34.209f, 2f, 32f, 2f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(32f, 55f)
+      lineTo(32f, 55f)
+      curveToRelative(2.209f, 0f, 4f, -1.791f, 4f, -4f)
+      verticalLineToRelative(-7f)
+      horizontalLineToRelative(-8f)
+      verticalLineToRelative(7f)
+      curveTo(28f, 53.209f, 29.791f, 55f, 32f, 55f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(15f, 61f)
+      arcToRelative(17f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 34f, 0f)
+      arcToRelative(17f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -34f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(49f, 26f)
+      curveToRelative(0f, 5.554f, -5.95f, 13.987f, -10.81f, 19.948f)
+      curveToRelative(-3.194f, 3.918f, -9.186f, 3.918f, -12.381f, 0f)
+      curveTo(20.95f, 39.987f, 15f, 31.554f, 15f, 26f)
+      curveToRelative(0f, -9.389f, 7.611f, -17f, 17f, -17f)
+      reflectiveCurveTo(49f, 16.611f, 49f, 26f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(15.513f, 21.921f)
+      curveToRelative(0.137f, 0.107f, 0.261f, 0.225f, 0.412f, 0.319f)
+      curveToRelative(0.824f, 0.515f, 1.74f, 0.761f, 2.646f, 0.761f)
+      curveToRelative(1.667f, 0f, 3.296f, -0.833f, 4.245f, -2.351f)
+      curveToRelative(1.536f, -2.458f, 3.898f, -4.277f, 6.653f, -5.124f)
+      curveToRelative(2.64f, -0.812f, 4.122f, -3.608f, 3.311f, -6.248f)
+      curveToRelative(-0.027f, -0.086f, -0.072f, -0.16f, -0.103f, -0.244f)
+      curveTo(32.45f, 9.025f, 32.228f, 9f, 32f, 9f)
+      curveTo(24.02f, 9f, 17.343f, 14.506f, 15.513f, 21.921f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(15.476f, 29f)
+      curveToRelative(1.491f, 5.304f, 6.284f, 11.981f, 10.333f, 16.948f)
+      curveToRelative(3.194f, 3.918f, 9.186f, 3.918f, 12.38f, 0f)
+      curveTo(42.24f, 40.981f, 47.033f, 34.304f, 48.524f, 29f)
+      horizontalLineTo(15.476f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(47.418f, 32f)
+      curveTo(48.395f, 29.824f, 49f, 27.766f, 49f, 26f)
+      horizontalLineTo(15f)
+      curveToRelative(0f, 1.766f, 0.605f, 3.824f, 1.582f, 6f)
+      horizontalLineTo(47.418f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(22.367f, 20.139f)
+      curveToRelative(-0.305f, 0f, -0.611f, -0.092f, -0.876f, -0.283f)
+      curveToRelative(-0.67f, -0.484f, -0.823f, -1.416f, -0.342f, -2.088f)
+      curveToRelative(0.099f, -0.138f, 2.476f, -3.401f, 6.852f, -4.945f)
+      curveToRelative(0.78f, -0.278f, 1.639f, 0.133f, 1.913f, 0.915f)
+      curveToRelative(0.276f, 0.781f, -0.134f, 1.638f, -0.915f, 1.913f)
+      curveToRelative(-3.455f, 1.22f, -5.396f, 3.844f, -5.415f, 3.87f)
+      curveTo(23.29f, 19.924f, 22.832f, 20.139f, 22.367f, 20.139f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(48.257f, 21.026f)
+      curveTo(48.17f, 21.021f, 48.088f, 21f, 48f, 21f)
+      curveToRelative(-2.762f, 0f, -5f, 2.238f, -5f, 5f)
+      curveToRelative(0f, 2.372f, -2.544f, 8.028f, -9.685f, 16.787f)
+      curveToRelative(-0.779f, 0.956f, -1.785f, 1.099f, -2.315f, 1.099f)
+      curveToRelative(-1.976f, 0f, -3.668f, 1.156f, -4.48f, 2.82f)
+      curveToRelative(3.309f, 3.136f, 8.699f, 2.887f, 11.67f, -0.758f)
+      curveTo(43.05f, 39.987f, 49f, 31.555f, 49f, 26f)
+      curveTo(49f, 24.269f, 48.738f, 22.6f, 48.257f, 21.026f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Flashlight.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Flashlight.kt
@@ -1,0 +1,136 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Flashlight: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Flashlight",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(16.358f, 54.006f)
+      lineToRelative(-6.364f, -6.364f)
+      curveToRelative(-1.562f, -1.562f, -1.562f, -4.095f, 0f, -5.657f)
+      lineToRelative(26.284f, -26.284f)
+      lineToRelative(12.021f, 12.021f)
+      lineTo(22.015f, 54.006f)
+      curveTo(20.453f, 55.568f, 17.92f, 55.568f, 16.358f, 54.006f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(28.854f, 35.146f)
+      lineTo(28.854f, 35.146f)
+      curveToRelative(-5.663f, -5.663f, -5.663f, -14.844f, 0f, -20.506f)
+      lineToRelative(3.889f, -3.889f)
+      lineToRelative(20.506f, 20.506f)
+      lineToRelative(-3.889f, 3.889f)
+      curveTo(43.697f, 40.809f, 34.516f, 40.809f, 28.854f, 35.146f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(52.895f, 32.318f)
+      lineTo(31.682f, 11.105f)
+      curveToRelative(-0.976f, -0.976f, -0.976f, -2.559f, 0f, -3.536f)
+      lineToRelative(0f, 0f)
+      curveToRelative(0.976f, -0.976f, 2.559f, -0.976f, 3.536f, 0f)
+      lineToRelative(21.213f, 21.213f)
+      curveToRelative(0.976f, 0.976f, 0.976f, 2.559f, 0f, 3.536f)
+      lineToRelative(0f, 0f)
+      curveTo(55.454f, 33.294f, 53.871f, 33.294f, 52.895f, 32.318f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(21.782f, 42.218f)
+      lineTo(21.782f, 42.218f)
+      curveToRelative(-1.367f, -1.367f, -1.367f, -3.583f, 0f, -4.95f)
+      lineToRelative(4.243f, -4.243f)
+      curveToRelative(1.367f, -1.367f, 3.583f, -1.367f, 4.95f, 0f)
+      lineToRelative(0f, 0f)
+      curveToRelative(1.367f, 1.367f, 1.367f, 3.583f, 0f, 4.95f)
+      lineToRelative(-4.243f, 4.243f)
+      curveTo(25.365f, 43.584f, 23.149f, 43.584f, 21.782f, 42.218f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(24.257f, 39.743f)
+      moveToRelative(-3.5f, 0f)
+      arcToRelative(3.5f, 3.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 7f, 0f)
+      arcToRelative(3.5f, 3.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -7f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(31.682f, 7.569f)
+      curveToRelative(-0.976f, 0.976f, -0.976f, 2.559f, 0f, 3.536f)
+      lineToRelative(0.354f, 0.354f)
+      lineToRelative(-3.182f, 3.182f)
+      curveToRelative(-3.415f, 3.415f, -4.755f, 8.107f, -4.052f, 12.537f)
+      lineTo(12.825f, 39.154f)
+      curveToRelative(0f, 0f, 0f, 0f, 0f, 0f)
+      curveToRelative(0.976f, 0.976f, 2.256f, 1.464f, 3.535f, 1.464f)
+      reflectiveCurveToRelative(2.56f, -0.488f, 3.535f, -1.464f)
+      lineToRelative(8.441f, -8.441f)
+      curveToRelative(1.133f, -1.132f, 1.654f, -2.738f, 1.403f, -4.319f)
+      curveToRelative(-0.485f, -3.054f, 0.48f, -6.049f, 2.648f, -8.218f)
+      lineToRelative(3.182f, -3.182f)
+      curveToRelative(0.001f, 0f, 0.001f, 0f, 0.001f, 0f)
+      lineToRelative(2.718f, 2.718f)
+      curveToRelative(1.951f, 1.952f, 5.119f, 1.952f, 7.07f, 0f)
+      curveToRelative(0f, 0f, 0f, 0f, 0f, 0f)
+      lineTo(35.218f, 7.569f)
+      curveTo(34.241f, 6.593f, 32.658f, 6.593f, 31.682f, 7.569f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(29.056f, 21.859f)
+      curveToRelative(0.482f, -1.608f, 1.358f, -3.123f, 2.626f, -4.391f)
+      lineToRelative(1.061f, -1.06f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(45.6f, 31.828f)
+      curveToRelative(-2.144f, 2.011f, -5.053f, 2.897f, -7.992f, 2.433f)
+      curveToRelative(-1.582f, -0.25f, -3.188f, 0.271f, -4.319f, 1.402f)
+      lineTo(15.86f, 53.09f)
+      curveToRelative(-0.082f, 0.082f, -0.133f, 0.15f, -0.195f, 0.223f)
+      lineToRelative(0.693f, 0.693f)
+      curveToRelative(1.562f, 1.562f, 4.095f, 1.562f, 5.657f, 0f)
+      lineToRelative(14.808f, -14.808f)
+      curveToRelative(4.43f, 0.703f, 9.122f, -0.637f, 12.537f, -4.052f)
+      lineToRelative(3.182f, -3.182f)
+      lineToRelative(0.01f, -0.01f)
+      curveTo(50.654f, 30.049f, 47.577f, 29.975f, 45.6f, 31.828f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Globe.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Globe.kt
@@ -1,0 +1,222 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Globe: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Globe",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF68E5FD))) {
+      moveTo(53.17f, 41f)
+      curveToRelative(-0.44f, 1.03f, -0.95f, 2.03f, -1.55f, 3f)
+      curveToRelative(-0.92f, 1.52f, -2.04f, 2.95f, -3.36f, 4.26f)
+      curveToRelative(-1.42f, 1.42f, -2.98f, 2.62f, -4.63f, 3.58f)
+      curveToRelative(-2.39f, 1.41f, -4.98f, 2.34f, -7.63f, 2.8f)
+      curveToRelative(-2.64f, 0.48f, -5.36f, 0.48f, -8f, 0f)
+      curveToRelative(-1.48f, -0.26f, -2.95f, -0.67f, -4.37f, -1.22f)
+      curveToRelative(-2.88f, -1.11f, -5.57f, -2.83f, -7.89f, -5.16f)
+      curveToRelative(-1.32f, -1.31f, -2.44f, -2.74f, -3.36f, -4.26f)
+      curveToRelative(-0.6f, -0.97f, -1.11f, -1.97f, -1.55f, -3f)
+      curveToRelative(-2.44f, -5.73f, -2.44f, -12.27f, 0f, -18f)
+      curveToRelative(0.44f, -1.03f, 0.95f, -2.03f, 1.55f, -3f)
+      curveToRelative(0.92f, -1.52f, 2.04f, -2.95f, 3.36f, -4.26f)
+      curveToRelative(3.09f, -3.09f, 6.84f, -5.12f, 10.79f, -6.08f)
+      curveToRelative(4.85f, -1.19f, 10.02f, -0.77f, 14.65f, 1.25f)
+      curveToRelative(2.57f, 1.11f, 4.98f, 2.72f, 7.08f, 4.83f)
+      curveToRelative(1.32f, 1.31f, 2.44f, 2.74f, 3.36f, 4.26f)
+      curveToRelative(0.6f, 0.97f, 1.11f, 1.97f, 1.55f, 3f)
+      curveTo(55.61f, 28.73f, 55.61f, 35.27f, 53.17f, 41f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(48.26f, 48.26f)
+      curveToRelative(-1.42f, 1.42f, -2.98f, 2.62f, -4.63f, 3.58f)
+      lineToRelative(-1.19f, -10.07f)
+      curveTo(42.32f, 40.76f, 41.47f, 40f, 40.46f, 40f)
+      horizontalLineTo(39f)
+      curveToRelative(-1.1f, 0f, -2f, -0.9f, -2f, -2f)
+      verticalLineToRelative(-1f)
+      curveToRelative(0f, -1.1f, 0.9f, -2f, 2f, -2f)
+      horizontalLineToRelative(11f)
+      verticalLineToRelative(-9f)
+      curveToRelative(0f, -0.55f, -0.45f, -1f, -1f, -1f)
+      horizontalLineToRelative(-2f)
+      curveToRelative(-0.55f, 0f, -1f, 0.45f, -1f, 1f)
+      verticalLineToRelative(4f)
+      curveToRelative(0f, 1.1f, -0.9f, 2f, -2f, 2f)
+      horizontalLineToRelative(-6f)
+      curveToRelative(-1.1f, 0f, -2f, -0.9f, -2f, -2f)
+      verticalLineToRelative(-1f)
+      curveToRelative(0f, -1.1f, 0.9f, -2f, 2f, -2f)
+      horizontalLineToRelative(2f)
+      curveToRelative(0.55f, 0f, 1f, -0.45f, 1f, -1f)
+      verticalLineToRelative(-1f)
+      curveToRelative(0f, -0.55f, -0.45f, -1f, -1f, -1f)
+      reflectiveCurveToRelative(-1.05f, -0.22f, -1.41f, -0.59f)
+      curveTo(38.22f, 23.05f, 38f, 22.55f, 38f, 22f)
+      curveToRelative(0f, -1.1f, 0.9f, -2f, 2f, -2f)
+      horizontalLineToRelative(5.2f)
+      curveToRelative(0.95f, 0f, 1.25f, -1.28f, 0.4f, -1.7f)
+      lineToRelative(-3.71f, -1.85f)
+      curveToRelative(-0.58f, -0.29f, -1.05f, -0.76f, -1.34f, -1.34f)
+      lineToRelative(-0.66f, -1.32f)
+      curveToRelative(-0.49f, -0.99f, -0.09f, -2.19f, 0.9f, -2.68f)
+      lineToRelative(0.39f, -0.2f)
+      curveToRelative(2.57f, 1.11f, 4.98f, 2.72f, 7.08f, 4.83f)
+      curveTo(57.25f, 24.72f, 57.25f, 39.28f, 48.26f, 48.26f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(29f, 22f)
+      verticalLineToRelative(4f)
+      curveToRelative(0f, 0.55f, -0.22f, 1.05f, -0.59f, 1.41f)
+      curveTo(28.05f, 27.78f, 27.55f, 28f, 27f, 28f)
+      curveToRelative(-1.1f, 0f, -2f, 0.9f, -2f, 2f)
+      verticalLineToRelative(3f)
+      curveToRelative(0f, 1.1f, -0.9f, 2f, -2f, 2f)
+      horizontalLineToRelative(-1f)
+      curveToRelative(-1.1f, 0f, -2f, -0.9f, -2f, -2f)
+      verticalLineToRelative(-1f)
+      curveToRelative(0f, -0.55f, -0.22f, -1.05f, -0.59f, -1.41f)
+      curveTo(19.05f, 30.22f, 18.55f, 30f, 18f, 30f)
+      curveToRelative(-1.1f, 0f, -2f, 0.9f, -2f, 2f)
+      verticalLineToRelative(5f)
+      curveToRelative(0f, 1.66f, 1.34f, 3f, 3f, 3f)
+      horizontalLineToRelative(3.42f)
+      curveToRelative(1.87f, 0f, 3.28f, 1.68f, 2.96f, 3.52f)
+      lineToRelative(-1.75f, 9.9f)
+      curveToRelative(-2.88f, -1.11f, -5.57f, -2.83f, -7.89f, -5.16f)
+      curveToRelative(-8.99f, -8.98f, -8.99f, -23.54f, 0f, -32.52f)
+      curveToRelative(3.09f, -3.09f, 6.84f, -5.12f, 10.79f, -6.08f)
+      curveToRelative(0.27f, 0.17f, 0.5f, 0.41f, 0.66f, 0.72f)
+      curveToRelative(0.45f, 0.89f, 0.08f, 1.98f, -0.81f, 2.43f)
+      lineToRelative(-2.72f, 1.36f)
+      curveTo(22.64f, 14.68f, 22f, 15.72f, 22f, 16.85f)
+      verticalLineTo(18f)
+      curveToRelative(0f, 1.1f, 0.9f, 2f, 2f, 2f)
+      horizontalLineToRelative(3f)
+      curveTo(28.1f, 20f, 29f, 20.9f, 29f, 22f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(32f, 9f)
+      curveToRelative(-7.535f, 0f, -13.438f, 10.103f, -13.438f, 23f)
+      reflectiveCurveTo(24.465f, 55f, 32f, 55f)
+      reflectiveCurveToRelative(13.437f, -10.103f, 13.437f, -23f)
+      reflectiveCurveTo(39.535f, 9f, 32f, 9f)
+      close()
+      moveTo(21.562f, 32f)
+      curveToRelative(0f, -9.865f, 3.962f, -18.313f, 8.938f, -19.758f)
+      verticalLineToRelative(39.517f)
+      curveTo(25.524f, 50.313f, 21.562f, 41.865f, 21.562f, 32f)
+      close()
+      moveTo(33.5f, 51.758f)
+      verticalLineTo(12.242f)
+      curveToRelative(4.976f, 1.445f, 8.937f, 9.893f, 8.937f, 19.758f)
+      reflectiveCurveTo(38.477f, 50.313f, 33.5f, 51.758f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(54.928f, 30.5f)
+      horizontalLineTo(9.072f)
+      curveToRelative(-0.065f, 1f, -0.065f, 2f, 0f, 3f)
+      horizontalLineToRelative(45.857f)
+      curveTo(54.993f, 32.5f, 54.993f, 31.5f, 54.928f, 30.5f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(53.17f, 23f)
+      horizontalLineTo(10.83f)
+      curveToRelative(0.44f, -1.03f, 0.95f, -2.03f, 1.55f, -3f)
+      horizontalLineToRelative(39.24f)
+      curveTo(52.22f, 20.97f, 52.73f, 21.97f, 53.17f, 23f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(53.17f, 41f)
+      curveToRelative(-0.44f, 1.03f, -0.95f, 2.03f, -1.55f, 3f)
+      horizontalLineTo(12.38f)
+      curveToRelative(-0.6f, -0.97f, -1.11f, -1.97f, -1.55f, -3f)
+      horizontalLineTo(53.17f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(15.045f, 24.927f)
+      curveToRelative(-0.229f, 0f, -0.46f, -0.053f, -0.678f, -0.163f)
+      curveToRelative(-0.739f, -0.375f, -1.033f, -1.278f, -0.658f, -2.017f)
+      curveToRelative(2.019f, -3.977f, 5.339f, -7.241f, 9.347f, -9.192f)
+      curveToRelative(0.743f, -0.364f, 1.642f, -0.053f, 2.005f, 0.692f)
+      curveToRelative(0.363f, 0.745f, 0.053f, 1.643f, -0.692f, 2.005f)
+      curveToRelative(-3.424f, 1.667f, -6.26f, 4.456f, -7.985f, 7.853f)
+      curveTo(16.119f, 24.627f, 15.592f, 24.927f, 15.045f, 24.927f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(32f, 14f)
+      curveToRelative(2.577f, 0f, 4.674f, -1.957f, 4.946f, -4.461f)
+      curveTo(35.352f, 9.19f, 33.699f, 9f, 32f, 9f)
+      curveTo(19.297f, 9f, 9f, 19.297f, 9f, 32f)
+      curveToRelative(0f, 1.699f, 0.19f, 3.352f, 0.539f, 4.946f)
+      curveTo(12.044f, 36.674f, 14f, 34.577f, 14f, 32f)
+      curveTo(14f, 22.075f, 22.075f, 14f, 32f, 14f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(54.461f, 27.054f)
+      curveTo(51.956f, 27.326f, 50f, 29.423f, 50f, 32f)
+      curveToRelative(0f, 9.925f, -8.075f, 18f, -18f, 18f)
+      curveToRelative(-2.577f, 0f, -4.674f, 1.957f, -4.946f, 4.461f)
+      curveTo(28.648f, 54.81f, 30.301f, 55f, 32f, 55f)
+      curveToRelative(12.703f, 0f, 23f, -10.297f, 23f, -23f)
+      curveTo(55f, 30.301f, 54.81f, 28.648f, 54.461f, 27.054f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(26f, 34f)
+      horizontalLineTo(7f)
+      curveToRelative(-1.104f, 0f, -2f, -0.896f, -2f, -2f)
+      reflectiveCurveToRelative(0.896f, -2f, 2f, -2f)
+      horizontalLineToRelative(19f)
+      curveToRelative(1.104f, 0f, 2f, 0.896f, 2f, 2f)
+      reflectiveCurveTo(27.104f, 34f, 26f, 34f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(22.477f, 28.128f)
+      verticalLineToRelative(7.745f)
+      curveToRelative(0f, 1.27f, 1.313f, 2.049f, 2.333f, 1.385f)
+      lineToRelative(5.962f, -3.88f)
+      curveToRelative(1.002f, -0.652f, 1.001f, -2.12f, -0.002f, -2.771f)
+      lineToRelative(-5.962f, -3.866f)
+      curveTo(23.788f, 26.08f, 22.477f, 26.859f, 22.477f, 28.128f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/HotAirBalloon.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/HotAirBalloon.kt
@@ -1,0 +1,150 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.HotAirBalloon: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.HotAirBalloon",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(51f, 20f)
+      curveToRelative(0f, 10f, -14f, 24f, -14f, 24f)
+      reflectiveCurveToRelative(-3.171f, 0f, -5f, 0f)
+      curveToRelative(-1.707f, 0f, -5f, 0f, -5f, 0f)
+      reflectiveCurveTo(13f, 30f, 13f, 20f)
+      curveTo(13f, 8.954f, 20.954f, 0f, 32f, 0f)
+      reflectiveCurveTo(51f, 8.954f, 51f, 20f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA7B3C7))) {
+      moveTo(27f, 44f)
+      horizontalLineToRelative(3f)
+      verticalLineToRelative(6f)
+      horizontalLineToRelative(-3f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA7B3C7))) {
+      moveTo(34f, 44f)
+      horizontalLineToRelative(3f)
+      verticalLineToRelative(6f)
+      horizontalLineToRelative(-3f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(35f, 55f)
+      horizontalLineToRelative(-6f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(-5f)
+      horizontalLineToRelative(10f)
+      verticalLineToRelative(5f)
+      curveTo(37f, 54.105f, 36.105f, 55f, 35f, 55f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(26.18f, 4.863f)
+      curveTo(12f, 20f, 27.105f, 39.909f, 27.247f, 40.176f)
+      curveToRelative(0.45f, 0.844f, 1.313f, 1.324f, 2.207f, 1.324f)
+      curveToRelative(0.396f, 0f, 0.799f, -0.095f, 1.173f, -0.294f)
+      curveToRelative(1.219f, -0.648f, 0.681f, -0.162f, 0.033f, -1.381f)
+      curveToRelative(-0.134f, -0.252f, -6.214f, -22.029f, 1.787f, -37.724f)
+      curveTo(29.442f, 2.401f, 26.18f, 4.863f, 26.18f, 4.863f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(37.933f, 4.863f)
+      curveTo(52.114f, 20f, 37.009f, 39.909f, 36.867f, 40.176f)
+      curveToRelative(-0.45f, 0.844f, -1.313f, 1.324f, -2.207f, 1.324f)
+      curveToRelative(-0.396f, 0f, -0.799f, -0.095f, -1.173f, -0.294f)
+      curveToRelative(-1.219f, -0.648f, -0.681f, -0.162f, -0.033f, -1.381f)
+      curveToRelative(0.134f, -0.252f, 6.214f, -22.029f, -1.787f, -37.724f)
+      curveTo(34.672f, 2.401f, 37.933f, 4.863f, 37.933f, 4.863f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(22.535f, 39f)
+      curveTo(25.012f, 42.012f, 27f, 44f, 27f, 44f)
+      reflectiveCurveToRelative(3.293f, 0f, 5f, 0f)
+      curveToRelative(1.829f, 0f, 5f, 0f, 5f, 0f)
+      reflectiveCurveToRelative(1.988f, -1.988f, 4.465f, -5f)
+      horizontalLineTo(22.535f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(29.535f, 0.17f)
+      curveToRelative(-0.49f, 0.062f, -0.978f, 0.128f, -1.453f, 0.225f)
+      curveToRelative(-0.065f, 0.013f, -0.129f, 0.03f, -0.194f, 0.044f)
+      curveToRelative(-3.288f, 0.711f, -6.178f, 2.272f, -8.523f, 4.439f)
+      curveTo(22.101f, 6.151f, 26.952f, 7f, 32.5f, 7f)
+      curveToRelative(5.118f, 0f, 9.604f, -0.731f, 12.422f, -1.842f)
+      curveToRelative(-2.403f, -2.318f, -5.406f, -3.991f, -8.847f, -4.728f)
+      curveToRelative(-0.042f, -0.008f, -0.082f, -0.02f, -0.123f, -0.029f)
+      curveToRelative(-0.478f, -0.099f, -0.97f, -0.164f, -1.463f, -0.227f)
+      curveToRelative(-0.179f, -0.022f, -0.355f, -0.057f, -0.535f, -0.075f)
+      curveTo(33.314f, 0.036f, 32.663f, 0f, 32f, 0f)
+      curveToRelative(-0.655f, 0f, -1.298f, 0.036f, -1.93f, 0.098f)
+      curveTo(29.89f, 0.115f, 29.714f, 0.148f, 29.535f, 0.17f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(32f, 0f)
+      curveTo(20.954f, 0f, 13f, 8.954f, 13f, 20f)
+      curveToRelative(0f, 1.842f, 0.477f, 3.819f, 1.252f, 5.819f)
+      curveToRelative(2.547f, -0.662f, 4.173f, -3.187f, 3.651f, -5.8f)
+      curveToRelative(-0.867f, -4.334f, 1.298f, -7.78f, 2.665f, -9.448f)
+      curveTo(23.387f, 7.135f, 27.767f, 5f, 32f, 5f)
+      curveToRelative(2.537f, 0f, 4.61f, -1.896f, 4.934f, -4.344f)
+      curveTo(35.374f, 0.243f, 33.73f, 0f, 32f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(19.499f, 11f)
+      curveToRelative(-0.313f, 0f, -0.629f, -0.098f, -0.899f, -0.3f)
+      curveToRelative(-0.662f, -0.497f, -0.797f, -1.438f, -0.3f, -2.1f)
+      curveToRelative(3.335f, -4.446f, 7.32f, -5.061f, 7.488f, -5.085f)
+      curveToRelative(0.813f, -0.119f, 1.579f, 0.453f, 1.697f, 1.273f)
+      curveToRelative(0.116f, 0.816f, -0.447f, 1.572f, -1.261f, 1.695f)
+      curveTo(26.084f, 6.506f, 23.24f, 7.013f, 20.7f, 10.4f)
+      curveTo(20.405f, 10.793f, 19.955f, 11f, 19.499f, 11f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(33.941f, 50f)
+      horizontalLineTo(30f)
+      curveToRelative(-1.131f, 0f, -2.162f, 0.39f, -3f, 1.023f)
+      verticalLineTo(53f)
+      curveToRelative(0f, 1.105f, 0.895f, 2f, 2f, 2f)
+      horizontalLineToRelative(6f)
+      curveToRelative(1.105f, 0f, 2f, -0.895f, 2f, -2f)
+      verticalLineToRelative(-1.929f)
+      curveTo(36.152f, 50.41f, 35.1f, 50f, 33.941f, 50f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(19f, 61f)
+      arcToRelative(13f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 26f, 0f)
+      arcToRelative(13f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -26f, 0f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Lake.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Lake.kt
@@ -1,0 +1,172 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Lake: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Lake",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(42f, 31f)
+      lineTo(42f, 31f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(-6f)
+      horizontalLineToRelative(4f)
+      verticalLineToRelative(6f)
+      curveTo(44f, 30.105f, 43.105f, 31f, 42f, 31f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(50f, 31f)
+      lineTo(50f, 31f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(-6f)
+      horizontalLineToRelative(4f)
+      verticalLineToRelative(6f)
+      curveTo(52f, 30.105f, 51.105f, 31f, 50f, 31f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(9f, 61f)
+      arcToRelative(23f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 46f, 0f)
+      arcToRelative(23f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -46f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(48.635f, 33f)
+      horizontalLineTo(37.484f)
+      curveToRelative(-2.667f, 0f, -4.7f, -2.286f, -4.505f, -4.946f)
+      curveToRelative(0.022f, -0.299f, 0.026f, -0.603f, 0.012f, -0.91f)
+      curveTo(32.803f, 23.09f, 29.252f, 20f, 25.194f, 20f)
+      curveToRelative(0f, 0f, -5.545f, 0.006f, -6.667f, 0.271f)
+      curveTo(10.281f, 21.685f, 4f, 28.851f, 4f, 37.5f)
+      curveTo(4f, 47.165f, 11.835f, 55f, 21.5f, 55f)
+      curveToRelative(0.443f, 0f, 27.5f, 0f, 27.5f, 0f)
+      curveToRelative(6.144f, 0f, 11.111f, -5.037f, 10.998f, -11.206f)
+      curveTo(59.887f, 37.738f, 54.692f, 33f, 48.635f, 33f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color(0xFFA0EFFE)),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(30.5f, 47f)
+      curveToRelative(-5.238f, 0f, -12f, -2.5f, -14f, -9.5f)
+    }
+    path(
+      stroke = SolidColor(Color(0xFFA0EFFE)),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(24.974f, 28f)
+      curveToRelative(-0.114f, 3.298f, 1.098f, 6.574f, 3.366f, 9.016f)
+      curveTo(30.693f, 39.548f, 34.026f, 41f, 37.484f, 41f)
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(13.281f, 26.166f)
+      curveToRelative(1.686f, -1.217f, 3.665f, -2.073f, 5.837f, -2.445f)
+      lineToRelative(0.107f, -0.019f)
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(23.496f, 20.014f)
+      curveToRelative(-1.728f, 0.024f, -4.251f, 0.087f, -4.969f, 0.257f)
+      curveTo(10.281f, 21.685f, 4f, 28.851f, 4f, 37.5f)
+      curveToRelative(0f, 1.713f, 0.257f, 3.363f, 0.716f, 4.928f)
+      curveTo(7.135f, 42.078f, 9f, 40.016f, 9f, 37.5f)
+      curveToRelative(0f, -6.097f, 4.362f, -11.271f, 10.372f, -12.301f)
+      curveTo(21.896f, 24.766f, 23.626f, 22.51f, 23.496f, 20.014f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(59.998f, 43.794f)
+      curveToRelative(-0.032f, -1.746f, -0.497f, -3.376f, -1.273f, -4.821f)
+      curveToRelative(-2.177f, 0.574f, -3.769f, 2.562f, -3.726f, 4.912f)
+      curveToRelative(0.03f, 1.626f, -0.58f, 3.16f, -1.717f, 4.318f)
+      curveTo(52.144f, 49.362f, 50.624f, 50f, 49f, 50f)
+      horizontalLineToRelative(-9f)
+      curveToRelative(-2.761f, 0f, -5f, 2.239f, -5f, 5f)
+      curveToRelative(6.958f, 0f, 14f, 0f, 14f, 0f)
+      curveTo(55.144f, 55f, 60.111f, 49.963f, 59.998f, 43.794f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF548500))) {
+      moveTo(47.033f, 18.194f)
+      curveTo(47.624f, 17.646f, 48f, 16.87f, 48f, 16f)
+      curveToRelative(0f, -1.657f, -1.343f, -3f, -3f, -3f)
+      curveToRelative(-0.065f, 0f, -0.126f, 0.015f, -0.19f, 0.019f)
+      curveTo(44.926f, 12.7f, 45f, 12.36f, 45f, 12f)
+      curveToRelative(0f, -1.657f, -1.343f, -3f, -3f, -3f)
+      reflectiveCurveToRelative(-3f, 1.343f, -3f, 3f)
+      curveToRelative(0f, 0.36f, 0.074f, 0.7f, 0.19f, 1.019f)
+      curveTo(39.126f, 13.015f, 39.065f, 13f, 39f, 13f)
+      curveToRelative(-1.657f, 0f, -3f, 1.343f, -3f, 3f)
+      curveToRelative(0f, 0.87f, 0.376f, 1.646f, 0.967f, 2.194f)
+      curveTo(35.821f, 18.616f, 35f, 19.708f, 35f, 21f)
+      curveToRelative(0f, 1.657f, 1.343f, 3f, 3f, 3f)
+      horizontalLineToRelative(8f)
+      curveToRelative(1.657f, 0f, 3f, -1.343f, 3f, -3f)
+      curveTo(49f, 19.708f, 48.179f, 18.616f, 47.033f, 18.194f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(56.912f, 23.208f)
+      lineTo(53.895f, 19f)
+      horizontalLineToRelative(0.609f)
+      curveToRelative(0.186f, 0f, 0.356f, -0.103f, 0.442f, -0.267f)
+      reflectiveCurveToRelative(0.075f, -0.363f, -0.03f, -0.516f)
+      lineTo(52.708f, 15f)
+      horizontalLineToRelative(0.798f)
+      curveToRelative(0.186f, 0f, 0.357f, -0.104f, 0.443f, -0.269f)
+      curveToRelative(0.086f, -0.165f, 0.073f, -0.364f, -0.033f, -0.517f)
+      lineToRelative(-3.476f, -5f)
+      curveTo(50.347f, 9.08f, 50.221f, 9.036f, 50.03f, 9f)
+      curveToRelative(-0.162f, 0f, -0.314f, 0.079f, -0.408f, 0.211f)
+      lineToRelative(-3.536f, 5f)
+      curveToRelative(-0.108f, 0.152f, -0.122f, 0.353f, -0.036f, 0.519f)
+      reflectiveCurveTo(46.307f, 15f, 46.494f, 15f)
+      horizontalLineToRelative(0.845f)
+      lineToRelative(-2.243f, 3.214f)
+      curveToRelative(-0.106f, 0.153f, -0.119f, 0.352f, -0.033f, 0.518f)
+      curveTo(45.149f, 18.896f, 45.32f, 19f, 45.506f, 19f)
+      horizontalLineToRelative(0.65f)
+      lineToRelative(-3.066f, 4.206f)
+      curveToRelative(-0.111f, 0.152f, -0.127f, 0.354f, -0.042f, 0.521f)
+      curveTo(43.134f, 23.895f, 43.306f, 24f, 43.494f, 24f)
+      horizontalLineToRelative(13.012f)
+      curveToRelative(0.188f, 0f, 0.359f, -0.105f, 0.445f, -0.271f)
+      curveTo(57.036f, 23.562f, 57.021f, 23.361f, 56.912f, 23.208f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Lantern.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Lantern.kt
@@ -1,0 +1,150 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Lantern: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Lantern",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(12f, 61f)
+      arcToRelative(20f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 40f, 0f)
+      arcToRelative(20f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -40f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA11AC9))) {
+      moveTo(49f, 51f)
+      horizontalLineTo(15f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, -1.105f, 0.895f, -2f, 2f, -2f)
+      horizontalLineToRelative(34f)
+      curveToRelative(1.105f, 0f, 2f, 0.895f, 2f, 2f)
+      verticalLineToRelative(0f)
+      curveTo(51f, 50.105f, 50.105f, 51f, 49f, 51f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA11AC9))) {
+      moveTo(52f, 55f)
+      horizontalLineTo(12f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, -1.105f, 0.895f, -2f, 2f, -2f)
+      horizontalLineToRelative(40f)
+      curveToRelative(1.105f, 0f, 2f, 0.895f, 2f, 2f)
+      verticalLineToRelative(0f)
+      curveTo(54f, 54.105f, 53.105f, 55f, 52f, 55f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA11AC9))) {
+      moveTo(49f, 16f)
+      horizontalLineToRelative(-1f)
+      horizontalLineToRelative(-0.76f)
+      curveTo(45.179f, 11.361f, 39.138f, 8f, 32f, 8f)
+      reflectiveCurveToRelative(-13.179f, 3.361f, -15.24f, 8f)
+      horizontalLineTo(16f)
+      horizontalLineToRelative(-1f)
+      curveToRelative(-1.105f, 0f, -2f, 0.895f, -2f, 2f)
+      curveToRelative(0f, 1.105f, 0.895f, 2f, 2f, 2f)
+      horizontalLineToRelative(1f)
+      verticalLineToRelative(30f)
+      horizontalLineToRelative(32f)
+      verticalLineTo(20f)
+      horizontalLineToRelative(1f)
+      curveToRelative(1.105f, 0f, 2f, -0.895f, 2f, -2f)
+      curveTo(51f, 16.895f, 50.105f, 16f, 49f, 16f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(21f, 31f)
+      verticalLineTo(20f)
+      curveToRelative(0f, -0.396f, -0.046f, -0.78f, -0.133f, -1.148f)
+      curveToRelative(0.178f, -0.256f, 0.332f, -0.529f, 0.461f, -0.82f)
+      curveToRelative(0.562f, -1.265f, 1.812f, -2.461f, 3.52f, -3.368f)
+      curveToRelative(2.231f, -1.186f, 3.173f, -3.817f, 2.328f, -6.124f)
+      curveTo(22.239f, 9.662f, 18.335f, 12.455f, 16.76f, 16f)
+      horizontalLineTo(16f)
+      horizontalLineToRelative(-1f)
+      curveToRelative(-1.105f, 0f, -2f, 0.895f, -2f, 2f)
+      curveToRelative(0f, 1.105f, 0.895f, 2f, 2f, 2f)
+      horizontalLineToRelative(1f)
+      verticalLineToRelative(16f)
+      curveTo(18.762f, 36f, 21f, 33.762f, 21f, 31f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(43f, 25f)
+      verticalLineToRelative(17f)
+      curveToRelative(0f, 2.762f, 2.238f, 5f, 5f, 5f)
+      verticalLineTo(20f)
+      curveTo(45.238f, 20f, 43f, 22.238f, 43f, 25f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color(0xFFA11AC9)),
+      strokeLineWidth = 2f,
+    ) {
+      moveTo(32f, 6f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(21f, 20f)
+      horizontalLineToRelative(22f)
+      verticalLineToRelative(27f)
+      horizontalLineToRelative(-22f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(25f, 39.85f)
+      curveToRelative(0f, -2.784f, 3.48f, -8.752f, 5.533f, -12.029f)
+      curveToRelative(0.685f, -1.094f, 2.25f, -1.094f, 2.935f, 0f)
+      curveTo(35.52f, 31.098f, 39f, 37.065f, 39f, 39.85f)
+      curveToRelative(0f, 3.949f, -3.134f, 7.15f, -7f, 7.15f)
+      reflectiveCurveTo(25f, 43.799f, 25f, 39.85f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFE691))) {
+      moveTo(28f, 43.067f)
+      curveToRelative(0f, -1.531f, 1.989f, -4.814f, 3.162f, -6.616f)
+      curveToRelative(0.391f, -0.602f, 1.285f, -0.602f, 1.677f, 0f)
+      curveTo(34.011f, 38.254f, 36f, 41.536f, 36f, 43.067f)
+      curveTo(36f, 45.239f, 34.209f, 47f, 32f, 47f)
+      reflectiveCurveTo(28f, 45.239f, 28f, 43.067f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(21.798f, 14.948f)
+      curveToRelative(1.037f, -0.946f, 2.369f, -1.737f, 3.893f, -2.321f)
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/LogCabin.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/LogCabin.kt
@@ -1,0 +1,144 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.LogCabin: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.LogCabin",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(55f, 26.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      lineTo(48f, 16f)
+      lineTo(32f, 7f)
+      lineTo(13f, 17f)
+      lineToRelative(-1.5f, 2f)
+      curveTo(10.119f, 19f, 9f, 20.119f, 9f, 21.5f)
+      curveToRelative(0f, 1.381f, 1.119f, 2.5f, 2.5f, 2.5f)
+      curveTo(10.119f, 24f, 9f, 25.119f, 9f, 26.5f)
+      curveToRelative(0f, 1.381f, 1.119f, 2.5f, 2.5f, 2.5f)
+      curveTo(10.119f, 29f, 9f, 30.119f, 9f, 31.5f)
+      curveToRelative(0f, 1.381f, 1.119f, 2.5f, 2.5f, 2.5f)
+      curveTo(10.119f, 34f, 9f, 35.119f, 9f, 36.5f)
+      curveToRelative(0f, 1.381f, 1.119f, 2.5f, 2.5f, 2.5f)
+      curveTo(10.119f, 39f, 9f, 40.119f, 9f, 41.5f)
+      curveToRelative(0f, 1.381f, 1.119f, 2.5f, 2.5f, 2.5f)
+      curveTo(10.119f, 44f, 9f, 45.119f, 9f, 46.5f)
+      curveToRelative(0f, 1.381f, 1.119f, 2.5f, 2.5f, 2.5f)
+      curveTo(10.119f, 49f, 9f, 50.119f, 9f, 51.5f)
+      curveToRelative(0f, 1.381f, 1.119f, 2.5f, 2.5f, 2.5f)
+      horizontalLineToRelative(41f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveTo(53.881f, 29f, 55f, 27.881f, 55f, 26.5f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(55f, 51.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(1.381f, 0f, 2.5f, -1.119f, 2.5f, -2.5f)
+      curveToRelative(0f, -1.381f, -1.119f, -2.5f, -2.5f, -2.5f)
+      curveToRelative(-2.761f, 0f, -5f, 2.238f, -5f, 5f)
+      curveToRelative(0f, 0.911f, 0.244f, 1.765f, 0.669f, 2.5f)
+      curveTo(47.744f, 37.235f, 47.5f, 38.089f, 47.5f, 39f)
+      reflectiveCurveToRelative(0.244f, 1.765f, 0.669f, 2.5f)
+      curveTo(47.744f, 42.235f, 47.5f, 43.089f, 47.5f, 44f)
+      reflectiveCurveToRelative(0.244f, 1.765f, 0.669f, 2.5f)
+      curveTo(47.744f, 47.235f, 47.5f, 48.089f, 47.5f, 49f)
+      horizontalLineTo(46f)
+      curveToRelative(-2.761f, 0f, -5f, 2.238f, -5f, 5f)
+      horizontalLineToRelative(11.5f)
+      curveTo(53.881f, 54f, 55f, 52.881f, 55f, 51.5f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(11.875f, 61f)
+      arcToRelative(20.125f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 40.25f, 0f)
+      arcToRelative(20.125f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -40.25f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(55.498f, 23f)
+      curveToRelative(-0.409f, 0f, -0.824f, -0.101f, -1.208f, -0.312f)
+      lineTo(32f, 10.357f)
+      lineTo(9.71f, 22.688f)
+      curveToRelative(-1.206f, 0.667f, -2.729f, 0.231f, -3.397f, -0.978f)
+      curveToRelative(-0.668f, -1.208f, -0.23f, -2.729f, 0.978f, -3.397f)
+      lineToRelative(23.5f, -13f)
+      curveToRelative(0.752f, -0.416f, 1.668f, -0.416f, 2.42f, 0f)
+      lineToRelative(23.5f, 13f)
+      curveToRelative(1.208f, 0.668f, 1.646f, 2.189f, 0.978f, 3.397f)
+      curveTo(57.231f, 22.535f, 56.378f, 23f, 55.498f, 23f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(32.453f, 5.057f)
+      curveToRelative(-0.562f, -0.104f, -1.15f, -0.029f, -1.663f, 0.255f)
+      lineToRelative(-23.5f, 13f)
+      curveToRelative(-0.197f, 0.109f, -0.365f, 0.247f, -0.519f, 0.396f)
+      curveToRelative(0.923f, 1.597f, 2.597f, 2.501f, 4.328f, 2.501f)
+      curveToRelative(0.818f, 0f, 1.648f, -0.201f, 2.415f, -0.626f)
+      lineToRelative(16.754f, -9.268f)
+      curveTo(32.51f, 10.076f, 33.401f, 7.372f, 32.453f, 5.057f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(25.472f, 12.225f)
+      lineTo(17.517f, 16.64f)
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(41f, 54f)
+      horizontalLineTo(23f)
+      verticalLineTo(36f)
+      curveToRelative(0f, -4.971f, 4.029f, -9f, 9f, -9f)
+      horizontalLineToRelative(0f)
+      curveToRelative(4.971f, 0f, 9f, 4.029f, 9f, 9f)
+      verticalLineTo(54f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/MapleLeaf.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/MapleLeaf.kt
@@ -1,0 +1,147 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.MapleLeaf: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.MapleLeaf",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(53.843f, 47.457f)
+      curveToRelative(-1.139f, -2.741f, -2.141f, -5.91f, -2.591f, -8.675f)
+      curveToRelative(-0.277f, -1.703f, -1.585f, -3.049f, -3.277f, -3.387f)
+      lineToRelative(-7.854f, -1.571f)
+      curveToRelative(-1.314f, -0.263f, -1.534f, -2.049f, -0.323f, -2.623f)
+      lineToRelative(12.678f, -6.005f)
+      curveToRelative(1.252f, -0.593f, 1.86f, -2.064f, 1.326f, -3.343f)
+      curveToRelative(-1.383f, -3.319f, -1.61f, -7.819f, -1.245f, -11.241f)
+      curveToRelative(0.134f, -1.256f, -0.912f, -2.303f, -2.169f, -2.169f)
+      curveToRelative(-3.422f, 0.365f, -7.923f, 0.138f, -11.241f, -1.245f)
+      curveToRelative(-1.279f, -0.533f, -2.749f, 0.074f, -3.343f, 1.326f)
+      lineToRelative(-6.005f, 12.678f)
+      curveToRelative(-0.574f, 1.211f, -2.36f, 0.991f, -2.623f, -0.323f)
+      lineToRelative(-1.571f, -7.854f)
+      curveToRelative(-0.338f, -1.692f, -1.684f, -3f, -3.387f, -3.277f)
+      curveToRelative(-2.765f, -0.45f, -5.934f, -1.452f, -8.675f, -2.591f)
+      curveToRelative(-1.267f, -0.527f, -2.698f, 0.226f, -2.954f, 1.574f)
+      curveToRelative(-0.563f, 2.969f, -1.547f, 6.134f, -3.07f, 8.902f)
+      curveToRelative(-0.833f, 1.514f, -0.663f, 3.379f, 0.453f, 4.698f)
+      lineToRelative(7.661f, 9.054f)
+      curveToRelative(0.679f, 0.802f, 0.387f, 2.029f, -0.579f, 2.441f)
+      curveToRelative(-1.265f, 0.538f, -2.857f, 1.253f, -4.209f, 1.868f)
+      curveToRelative(-1.117f, 0.508f, -1.116f, 2.094f, 0.001f, 2.601f)
+      lineTo(19f, 42f)
+      lineToRelative(3.706f, 8.154f)
+      curveToRelative(0.508f, 1.117f, 2.093f, 1.118f, 2.601f, 0.001f)
+      curveToRelative(0.615f, -1.351f, 1.329f, -2.943f, 1.867f, -4.207f)
+      curveToRelative(0.412f, -0.967f, 1.639f, -1.26f, 2.441f, -0.581f)
+      lineToRelative(9.054f, 7.661f)
+      curveToRelative(1.319f, 1.116f, 3.184f, 1.286f, 4.698f, 0.453f)
+      curveToRelative(2.768f, -1.523f, 5.933f, -2.507f, 8.902f, -3.07f)
+      curveTo(53.617f, 50.155f, 54.37f, 48.724f, 53.843f, 47.457f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(11.586f, 46.586f)
+      lineToRelative(23.854f, -23.146f)
+      curveToRelative(0.595f, -0.577f, 1.544f, -0.563f, 2.121f, 0.032f)
+      curveToRelative(0.566f, 0.583f, 0.561f, 1.51f, 0f, 2.089f)
+      lineTo(14.414f, 49.414f)
+      curveToRelative(-0.769f, 0.793f, -2.036f, 0.812f, -2.828f, 0.043f)
+      curveToRelative(-0.793f, -0.769f, -0.812f, -2.036f, -0.043f, -2.828f)
+      curveTo(11.555f, 46.616f, 11.574f, 46.598f, 11.586f, 46.586f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(22.13f, 37.709f)
+      lineToRelative(-5.033f, -14.677f)
+      curveToRelative(-0.269f, -0.784f, 0.149f, -1.638f, 0.933f, -1.906f)
+      curveToRelative(0.752f, -0.258f, 1.569f, 0.12f, 1.872f, 0.842f)
+      lineToRelative(5.967f, 14.323f)
+      curveToRelative(0.425f, 1.02f, -0.057f, 2.192f, -1.078f, 2.617f)
+      reflectiveCurveToRelative(-2.192f, -0.057f, -2.617f, -1.078f)
+      curveTo(22.16f, 37.792f, 22.143f, 37.748f, 22.13f, 37.709f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(24.743f, 35.143f)
+      lineToRelative(14.814f, 6.464f)
+      curveToRelative(0.76f, 0.331f, 1.107f, 1.216f, 0.775f, 1.976f)
+      curveToRelative(-0.318f, 0.73f, -1.151f, 1.077f, -1.889f, 0.81f)
+      lineToRelative(-15.186f, -5.536f)
+      curveToRelative(-1.038f, -0.378f, -1.573f, -1.527f, -1.195f, -2.565f)
+      reflectiveCurveToRelative(1.527f, -1.573f, 2.565f, -1.195f)
+      curveTo(24.665f, 35.111f, 24.707f, 35.128f, 24.743f, 35.143f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(12f, 61f)
+      arcToRelative(20f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 40f, 0f)
+      arcToRelative(20f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -40f, 0f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(52.27f, 50.41f)
+      curveToRelative(-2.97f, 0.56f, -6.13f, 1.55f, -8.9f, 3.07f)
+      curveToRelative(-1.52f, 0.83f, -3.38f, 0.66f, -4.7f, -0.45f)
+      lineToRelative(-3.82f, -3.23f)
+      curveToRelative(1.65f, -1.96f, 4.48f, -2.32f, 6.57f, -0.95f)
+      curveToRelative(1.99f, -1.04f, 4.23f, -1.92f, 6.63f, -2.58f)
+      curveToRelative(-0.8f, -2.34f, -1.4f, -4.64f, -1.73f, -6.69f)
+      curveToRelative(-0.27f, -1.61f, 0.27f, -3.17f, 1.32f, -4.26f)
+      horizontalLineToRelative(0.01f)
+      lineToRelative(0.32f, 0.07f)
+      curveToRelative(1.7f, 0.34f, 3f, 1.69f, 3.28f, 3.39f)
+      curveToRelative(0.45f, 2.77f, 1.45f, 5.94f, 2.59f, 8.68f)
+      curveTo(54.37f, 48.72f, 53.62f, 50.16f, 52.27f, 50.41f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(26.59f, 17.93f)
+      curveToRelative(-2.51f, 0.5f, -4.96f, -0.97f, -5.74f, -3.34f)
+      curveToRelative(-1.9f, -0.35f, -3.99f, -0.91f, -6.12f, -1.64f)
+      curveToRelative(-0.72f, 2.59f, -1.68f, 4.99f, -2.83f, 7.09f)
+      curveToRelative(-0.79f, 1.45f, -2.19f, 2.34f, -3.71f, 2.55f)
+      lineToRelative(-0.22f, -0.26f)
+      curveToRelative(-1.11f, -1.32f, -1.28f, -3.18f, -0.45f, -4.7f)
+      curveToRelative(1.52f, -2.77f, 2.51f, -5.93f, 3.07f, -8.9f)
+      curveToRelative(0.25f, -1.35f, 1.69f, -2.1f, 2.95f, -1.57f)
+      curveToRelative(2.74f, 1.14f, 5.91f, 2.14f, 8.68f, 2.59f)
+      curveToRelative(1.7f, 0.28f, 3.05f, 1.58f, 3.39f, 3.28f)
+      lineTo(26.59f, 17.93f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(10.499f, 21f)
+      curveToRelative(-0.286f, 0f, -0.575f, -0.081f, -0.831f, -0.252f)
+      curveToRelative(-0.689f, -0.46f, -0.876f, -1.391f, -0.416f, -2.08f)
+      curveToRelative(0.925f, -1.388f, 1.368f, -2.272f, 1.825f, -3.643f)
+      curveToRelative(0.261f, -0.785f, 1.11f, -1.213f, 1.897f, -0.948f)
+      curveToRelative(0.786f, 0.262f, 1.21f, 1.111f, 0.948f, 1.897f)
+      curveToRelative(-0.546f, 1.638f, -1.095f, 2.737f, -2.175f, 4.357f)
+      curveTo(11.459f, 20.766f, 10.983f, 21f, 10.499f, 21f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Mushroom.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Mushroom.kt
@@ -1,0 +1,139 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Mushroom: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Mushroom",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(15f, 61f)
+      arcToRelative(17f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 34f, 0f)
+      arcToRelative(17f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -34f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(41.24f, 48.89f)
+      curveTo(40.8f, 51.27f, 38.74f, 53f, 36.32f, 53f)
+      horizontalLineTo(32f)
+      horizontalLineToRelative(-4.32f)
+      curveToRelative(-2.42f, 0f, -4.48f, -1.73f, -4.92f, -4.11f)
+      curveToRelative(-0.82f, -4.38f, -0.51f, -10.77f, 0.59f, -15.89f)
+      curveToRelative(0.41f, -1.9f, 0.93f, -3.62f, 1.53f, -5f)
+      curveToRelative(0.35f, -0.79f, 0.72f, -1.47f, 1.12f, -2f)
+      horizontalLineToRelative(12f)
+      curveToRelative(0.4f, 0.53f, 0.77f, 1.21f, 1.12f, 2f)
+      curveToRelative(0.6f, 1.38f, 1.12f, 3.1f, 1.53f, 5f)
+      curveToRelative(0.404f, 1.883f, 0.702f, 3.937f, 0.876f, 6f)
+      curveTo(41.825f, 42.547f, 41.758f, 46.121f, 41.24f, 48.89f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(32f, 6f)
+      curveToRelative(-8.07f, 0f, -15.125f, 4.345f, -18.953f, 10.823f)
+      curveTo(10.129f, 21.759f, 13.655f, 28f, 19.39f, 28f)
+      horizontalLineTo(44.61f)
+      curveToRelative(5.734f, 0f, 9.26f, -6.241f, 6.343f, -11.177f)
+      curveTo(47.125f, 10.345f, 40.07f, 6f, 32f, 6f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(41f, 16f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(37f, 21f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(45f, 21f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(40.65f, 33f)
+      horizontalLineToRelative(-17.3f)
+      curveToRelative(0.41f, -1.9f, 0.93f, -3.62f, 1.53f, -5f)
+      horizontalLineToRelative(14.24f)
+      curveTo(39.72f, 29.38f, 40.24f, 31.1f, 40.65f, 33f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(41.24f, 48.89f)
+      curveTo(40.8f, 51.27f, 38.74f, 53f, 36.32f, 53f)
+      horizontalLineTo(30f)
+      curveToRelative(0f, -2.76f, 2.24f, -5f, 5f, -5f)
+      horizontalLineToRelative(1.32f)
+      curveToRelative(0.34f, -1.8f, 0.46f, -4.2f, 0.34f, -6.78f)
+      curveToRelative(-0.12f, -2.68f, 1.88f, -4.96f, 4.52f, -5.2f)
+      curveTo(41.33f, 37f, 41.44f, 38f, 41.53f, 39f)
+      curveTo(41.83f, 42.55f, 41.76f, 46.12f, 41.24f, 48.89f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(36.96f, 6.56f)
+      curveTo(36.69f, 9.06f, 34.57f, 11f, 32f, 11f)
+      curveToRelative(-5.99f, 0f, -11.6f, 3.21f, -14.65f, 8.37f)
+      lineToRelative(-0.04f, 0.07f)
+      curveToRelative(-0.92f, 1.63f, -2.61f, 2.55f, -4.36f, 2.55f)
+      curveToRelative(-0.28f, 0f, -0.56f, -0.02f, -0.83f, -0.07f)
+      curveToRelative(-0.3f, -1.66f, -0.04f, -3.45f, 0.93f, -5.1f)
+      curveTo(16.88f, 10.34f, 23.93f, 6f, 32f, 6f)
+      curveTo(33.71f, 6f, 35.37f, 6.19f, 36.96f, 6.56f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(23.501f, 13f)
+      curveToRelative(-0.51f, 0f, -1.006f, -0.26f, -1.288f, -0.729f)
+      curveToRelative(-0.426f, -0.71f, -0.196f, -1.632f, 0.514f, -2.058f)
+      curveTo(25.516f, 8.541f, 29.842f, 8f, 31.5f, 8f)
+      curveTo(32.329f, 8f, 33f, 8.672f, 33f, 9.5f)
+      reflectiveCurveTo(32.329f, 11f, 31.5f, 11f)
+      curveToRelative(-1.482f, 0f, -5.125f, 0.524f, -7.228f, 1.786f)
+      curveTo(24.03f, 12.932f, 23.764f, 13f, 23.501f, 13f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Night.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Night.kt
@@ -1,0 +1,213 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Night: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Night",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(59.93f, 26.77f)
+      curveToRelative(-0.12f, 0.34f, -0.25f, 0.67f, -0.4f, 0.99f)
+      curveTo(56.92f, 33.79f, 50.93f, 38f, 43.95f, 38f)
+      curveToRelative(-1.72f, 0f, -3.38f, -0.25f, -4.94f, -0.73f)
+      curveToRelative(-5.37f, -1.63f, -9.61f, -5.84f, -11.28f, -11.18f)
+      curveToRelative(-0.5f, -1.56f, -0.77f, -3.21f, -0.78f, -4.93f)
+      curveToRelative(-0.08f, -8.15f, 5.87f, -15.29f, 13.87f, -16.85f)
+      curveToRelative(1.71f, -0.34f, 3.39f, -0.39f, 4.99f, -0.2f)
+      curveToRelative(0.04f, 0f, 0.09f, 0f, 0.13f, 0.01f)
+      curveToRelative(0.96f, 0.12f, 1.36f, 1.33f, 0.65f, 1.99f)
+      curveToRelative(-2.7f, 2.53f, -4.18f, 6.33f, -3.46f, 10.46f)
+      curveToRelative(0.81f, 4.64f, 4.52f, 8.38f, 9.16f, 9.23f)
+      curveToRelative(2.19f, 0.4f, 4.28f, 0.18f, 6.15f, -0.52f)
+      curveTo(59.35f, 24.94f, 60.26f, 25.85f, 59.93f, 26.77f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(33f, 30f)
+      curveToRelative(0f, 4.99f, -3.66f, 9.13f, -8.45f, 9.88f)
+      curveTo(24.05f, 39.96f, 23.53f, 40f, 23f, 40f)
+      curveToRelative(-3.03f, 0f, -5.74f, -1.35f, -7.58f, -3.48f)
+      curveToRelative(-1.08f, -1.26f, -1.86f, -2.79f, -2.22f, -4.49f)
+      curveTo(13.07f, 31.38f, 13f, 30.7f, 13f, 30f)
+      curveToRelative(0f, -5.52f, 4.48f, -10f, 10f, -10f)
+      curveToRelative(1.75f, 0f, 3.4f, 0.45f, 4.84f, 1.25f)
+      curveTo(30.92f, 22.95f, 33f, 26.23f, 33f, 30f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(48.02f, 32.01f)
+      curveToRelative(0f, 0.68f, -0.08f, 1.35f, -0.22f, 1.99f)
+      curveToRelative(-0.08f, 0.35f, -0.18f, 0.69f, -0.3f, 1.03f)
+      curveToRelative(-0.44f, 1.24f, -1.14f, 2.35f, -2.04f, 3.27f)
+      curveToRelative(-1.64f, 1.68f, -3.92f, 2.72f, -6.45f, 2.72f)
+      curveToRelative(-0.19f, 0f, -0.37f, -0.01f, -0.55f, -0.02f)
+      curveToRelative(-3.68f, -0.22f, -6.76f, -2.65f, -7.94f, -5.97f)
+      curveTo(30.18f, 34.09f, 30f, 33.07f, 30f, 32.01f)
+      curveToRelative(0f, -4.98f, 4.03f, -9.01f, 9.01f, -9.01f)
+      curveToRelative(3.93f, 0f, 7.27f, 2.52f, 8.5f, 6.03f)
+      curveTo(47.84f, 29.96f, 48.02f, 30.97f, 48.02f, 32.01f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(25f, 43f)
+      curveToRelative(0f, 6.08f, -4.92f, 11f, -11f, 11f)
+      curveToRelative(-4.33f, 0f, -8.07f, -2.5f, -9.87f, -6.13f)
+      curveTo(3.41f, 46.4f, 3f, 44.75f, 3f, 43f)
+      curveToRelative(0f, -5.81f, 4.5f, -10.56f, 10.2f, -10.97f)
+      curveTo(13.47f, 32.01f, 13.73f, 32f, 14f, 32f)
+      curveToRelative(1.46f, 0f, 2.86f, 0.29f, 4.14f, 0.81f)
+      curveToRelative(3.08f, 1.24f, 5.46f, 3.85f, 6.41f, 7.07f)
+      curveTo(24.84f, 40.87f, 25f, 41.91f, 25f, 43f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(58f, 44f)
+      curveToRelative(0f, 5.51f, -4.46f, 9.98f, -9.96f, 10f)
+      horizontalLineTo(48f)
+      curveToRelative(-3.7f, 0f, -6.93f, -2.01f, -8.66f, -5f)
+      curveTo(38.49f, 47.53f, 38f, 45.82f, 38f, 44f)
+      curveToRelative(0f, -1.05f, 0.16f, -2.05f, 0.46f, -3f)
+      curveToRelative(0.77f, -2.47f, 2.48f, -4.52f, 4.7f, -5.75f)
+      curveToRelative(0.14f, -0.08f, 0.28f, -0.15f, 0.43f, -0.22f)
+      curveToRelative(1.27f, -0.63f, 2.7f, -1f, 4.21f, -1.03f)
+      horizontalLineTo(48f)
+      curveTo(53.52f, 34f, 58f, 38.48f, 58f, 44f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(9f, 61f)
+      arcToRelative(22f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 44f, 0f)
+      arcToRelative(22f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -44f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(14.5f, 35.03f)
+      horizontalLineToRelative(33.54f)
+      verticalLineToRelative(18.97f)
+      horizontalLineToRelative(-33.54f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(22.512f, 9.768f)
+      lineToRelative(1.122f, 0.613f)
+      curveToRelative(0.489f, 0.267f, 0.489f, 0.969f, 0f, 1.237f)
+      lineToRelative(-1.122f, 0.613f)
+      curveToRelative(-0.118f, 0.065f, -0.215f, 0.162f, -0.28f, 0.28f)
+      lineToRelative(-0.613f, 1.122f)
+      curveToRelative(-0.267f, 0.489f, -0.969f, 0.489f, -1.237f, 0f)
+      lineToRelative(-0.613f, -1.122f)
+      curveToRelative(-0.065f, -0.118f, -0.162f, -0.215f, -0.28f, -0.28f)
+      lineToRelative(-1.122f, -0.613f)
+      curveToRelative(-0.489f, -0.267f, -0.489f, -0.969f, 0f, -1.237f)
+      lineToRelative(1.122f, -0.613f)
+      curveToRelative(0.118f, -0.065f, 0.215f, -0.162f, 0.28f, -0.28f)
+      lineToRelative(0.613f, -1.122f)
+      curveToRelative(0.267f, -0.489f, 0.969f, -0.489f, 1.237f, 0f)
+      lineToRelative(0.613f, 1.122f)
+      curveTo(22.296f, 9.606f, 22.394f, 9.704f, 22.512f, 9.768f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(10.512f, 18.768f)
+      lineToRelative(1.122f, 0.613f)
+      curveToRelative(0.489f, 0.267f, 0.489f, 0.969f, 0f, 1.237f)
+      lineToRelative(-1.122f, 0.613f)
+      curveToRelative(-0.118f, 0.065f, -0.215f, 0.162f, -0.28f, 0.28f)
+      lineToRelative(-0.613f, 1.122f)
+      curveToRelative(-0.267f, 0.489f, -0.969f, 0.489f, -1.237f, 0f)
+      lineToRelative(-0.613f, -1.122f)
+      curveToRelative(-0.065f, -0.118f, -0.162f, -0.215f, -0.28f, -0.28f)
+      lineToRelative(-1.122f, -0.613f)
+      curveToRelative(-0.489f, -0.267f, -0.489f, -0.969f, 0f, -1.237f)
+      lineToRelative(1.122f, -0.613f)
+      curveToRelative(0.118f, -0.065f, 0.215f, -0.162f, 0.28f, -0.28f)
+      lineToRelative(0.613f, -1.122f)
+      curveToRelative(0.267f, -0.489f, 0.969f, -0.489f, 1.237f, 0f)
+      lineToRelative(0.613f, 1.122f)
+      curveTo(10.296f, 18.606f, 10.394f, 18.704f, 10.512f, 18.768f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(53.02f, 35.36f)
+      curveTo(55.99f, 37.1f, 58f, 40.31f, 58f, 44f)
+      curveToRelative(0f, 5.51f, -4.46f, 9.98f, -9.96f, 10f)
+      horizontalLineTo(36f)
+      curveToRelative(0f, -2.76f, 2.24f, -5f, 5f, -5f)
+      horizontalLineToRelative(7f)
+      curveToRelative(2.77f, -0.01f, 5f, -2.25f, 5f, -5f)
+      curveToRelative(0f, -1.79f, -0.93f, -3.41f, -2.5f, -4.32f)
+      curveToRelative(-1.5f, -0.88f, -2.45f, -2.48f, -2.48f, -4.22f)
+      curveToRelative(-0.03f, -1.75f, 0.85f, -3.38f, 2.32f, -4.32f)
+      curveToRelative(1.16f, -0.74f, 2.18f, -1.66f, 3.03f, -2.73f)
+      curveToRelative(1.56f, -1.98f, 4.3f, -2.47f, 6.41f, -1.24f)
+      curveToRelative(-0.08f, 0.2f, -0.16f, 0.4f, -0.25f, 0.59f)
+      curveTo(58.17f, 30.91f, 55.88f, 33.55f, 53.02f, 35.36f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(45.81f, 4.11f)
+      curveToRelative(0.11f, 2.43f, -1.58f, 4.63f, -4.03f, 5.11f)
+      curveToRelative(-5.54f, 1.08f, -9.76f, 6.09f, -9.82f, 11.66f)
+      curveToRelative(-0.02f, 1.68f, -0.87f, 3.23f, -2.28f, 4.15f)
+      curveToRelative(-1.4f, 0.91f, -3.17f, 1.06f, -4.71f, 0.39f)
+      curveTo(24.33f, 25.14f, 23.67f, 25f, 23f, 25f)
+      curveToRelative(-2.76f, 0f, -5f, 2.24f, -5f, 5f)
+      curveToRelative(0f, 0.35f, 0.03f, 0.71f, 0.1f, 1.05f)
+      curveToRelative(0.28f, 1.4f, -0.05f, 2.87f, -0.92f, 4.01f)
+      reflectiveCurveToRelative(-2.19f, 1.85f, -3.62f, 1.96f)
+      curveTo(10.44f, 37.24f, 8f, 39.87f, 8f, 43f)
+      curveToRelative(0f, 2.37f, -1.65f, 4.36f, -3.87f, 4.87f)
+      curveTo(3.41f, 46.4f, 3f, 44.75f, 3f, 43f)
+      curveToRelative(0f, -5.81f, 4.5f, -10.56f, 10.2f, -10.97f)
+      curveTo(13.07f, 31.38f, 13f, 30.7f, 13f, 30f)
+      curveToRelative(0f, -5.52f, 4.48f, -10f, 10f, -10f)
+      curveToRelative(1.41f, 0f, 2.74f, 0.3f, 3.96f, 0.83f)
+      curveToRelative(0.08f, -8.01f, 5.97f, -14.98f, 13.86f, -16.52f)
+      curveTo(42.53f, 3.97f, 44.21f, 3.92f, 45.81f, 4.11f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(18f, 31.5f)
+      curveToRelative(-0.829f, 0f, -1.5f, -0.671f, -1.5f, -1.5f)
+      curveToRelative(0f, -3.584f, 2.916f, -6.5f, 6.5f, -6.5f)
+      curveToRelative(0.829f, 0f, 1.5f, 0.671f, 1.5f, 1.5f)
+      reflectiveCurveToRelative(-0.671f, 1.5f, -1.5f, 1.5f)
+      curveToRelative(-1.93f, 0f, -3.5f, 1.57f, -3.5f, 3.5f)
+      curveTo(19.5f, 30.829f, 18.829f, 31.5f, 18f, 31.5f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(33.963f, 16f)
+      curveToRelative(-0.285f, 0f, -0.574f, -0.081f, -0.829f, -0.251f)
+      curveToRelative(-0.689f, -0.458f, -0.877f, -1.39f, -0.418f, -2.08f)
+      curveToRelative(1.034f, -1.555f, 2.403f, -2.919f, 3.959f, -3.945f)
+      curveToRelative(0.691f, -0.457f, 1.622f, -0.265f, 2.078f, 0.427f)
+      curveToRelative(0.456f, 0.691f, 0.265f, 1.622f, -0.427f, 2.078f)
+      curveToRelative(-1.223f, 0.806f, -2.298f, 1.878f, -3.111f, 3.101f)
+      curveTo(34.925f, 15.765f, 34.449f, 16f, 33.963f, 16f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Owl.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Owl.kt
@@ -1,0 +1,165 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Owl: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Owl",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(35f, 49f)
+      horizontalLineToRelative(-6f)
+      curveTo(16.297f, 49f, 6f, 38.703f, 6f, 26f)
+      verticalLineToRelative(0f)
+      curveToRelative(0f, -7.18f, 5.82f, -13f, 13f, -13f)
+      horizontalLineToRelative(26f)
+      curveToRelative(7.18f, 0f, 13f, 5.82f, 13f, 13f)
+      verticalLineToRelative(0f)
+      curveTo(58f, 38.703f, 47.703f, 49f, 35f, 49f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(47.386f, 19.434f)
+      curveToRelative(-0.698f, -1.5f, -1.117f, -3.123f, -1.425f, -4.769f)
+      curveTo(44.825f, 8.581f, 39.857f, 4f, 33.895f, 4f)
+      horizontalLineToRelative(-3.789f)
+      curveToRelative(-5.962f, 0f, -10.93f, 4.581f, -12.067f, 10.665f)
+      curveToRelative(-0.307f, 1.645f, -0.727f, 3.269f, -1.425f, 4.769f)
+      curveTo(14.957f, 22.997f, 14f, 27.179f, 14f, 31.656f)
+      curveToRelative(0f, 7.826f, 6.512f, 14.761f, 11.703f, 19.045f)
+      curveToRelative(3.714f, 3.066f, 8.88f, 3.066f, 12.594f, 0f)
+      curveTo(43.488f, 46.416f, 50f, 39.482f, 50f, 31.656f)
+      curveTo(50f, 27.179f, 49.043f, 22.997f, 47.386f, 19.434f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(48.505f, 15.564f)
+      curveToRelative(-0.423f, -2.273f, -1.299f, -4.367f, -2.519f, -6.171f)
+      lineToRelative(-0.241f, -0.174f)
+      lineToRelative(1.965f, -4.258f)
+      curveToRelative(0.781f, -1.692f, -0.973f, -3.439f, -2.662f, -2.651f)
+      lineToRelative(-5.383f, 2.602f)
+      curveTo(38.083f, 3.767f, 35.247f, 3f, 32f, 3f)
+      curveToRelative(-3.517f, 0f, -6.555f, 0.899f, -8.035f, 2.206f)
+      lineToRelative(-6.013f, -2.895f)
+      curveToRelative(-1.689f, -0.788f, -3.443f, 0.958f, -2.662f, 2.651f)
+      lineToRelative(2.339f, 5.069f)
+      curveToRelative(-1.011f, 1.657f, -1.759f, 3.519f, -2.135f, 5.535f)
+      curveTo(15.357f, 16.3f, 15.187f, 19.027f, 15f, 19.748f)
+      curveToRelative(0.794f, -0.157f, 1.606f, -0.257f, 2.438f, -0.257f)
+      curveToRelative(4.837f, 0f, 9.123f, 0.755f, 11.769f, 4.993f)
+      curveToRelative(1.337f, 2.142f, 4.226f, 2.142f, 5.563f, 0f)
+      curveToRelative(2.646f, -4.239f, 6.931f, -4.993f, 11.769f, -4.993f)
+      curveToRelative(0.841f, 0f, 1.659f, 0.101f, 2.461f, 0.261f)
+      curveTo(48.812f, 19.029f, 48.642f, 16.301f, 48.505f, 15.564f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(26.5f, 14.5f)
+      moveToRelative(-3.5f, 0f)
+      arcToRelative(3.5f, 3.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 7f, 0f)
+      arcToRelative(3.5f, 3.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -7f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(37.5f, 14.5f)
+      moveToRelative(-3.5f, 0f)
+      arcToRelative(3.5f, 3.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 7f, 0f)
+      arcToRelative(3.5f, 3.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -7f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(32f, 17f)
+      curveToRelative(-0.415f, 0f, -0.83f, -0.086f, -1.218f, -0.259f)
+      lineToRelative(-8.896f, -3.954f)
+      curveToRelative(-1.327f, -0.59f, -2.145f, -2.027f, -1.816f, -3.441f)
+      curveToRelative(0.442f, -1.901f, 2.458f, -2.839f, 4.148f, -2.088f)
+      lineToRelative(0.827f, 0.367f)
+      curveToRelative(4.356f, 1.936f, 9.35f, 1.822f, 13.613f, -0.31f)
+      lineToRelative(0f, 0f)
+      curveToRelative(1.658f, -0.825f, 3.712f, 0.021f, 4.24f, 1.9f)
+      curveToRelative(0.392f, 1.397f, -0.359f, 2.869f, -1.657f, 3.518f)
+      lineToRelative(-7.899f, 3.949f)
+      curveTo(32.92f, 16.895f, 32.46f, 17f, 32f, 17f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(31f, 17f)
+      horizontalLineToRelative(2f)
+      curveToRelative(0.824f, 0f, 1.294f, 0.941f, 0.8f, 1.6f)
+      lineToRelative(-1f, 1.333f)
+      curveToRelative(-0.4f, 0.533f, -1.2f, 0.533f, -1.6f, 0f)
+      lineToRelative(-1f, -1.333f)
+      curveTo(29.706f, 17.941f, 30.176f, 17f, 31f, 17f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(50f, 31.656f)
+      curveToRelative(0f, -2.054f, -0.21f, -4.042f, -0.588f, -5.941f)
+      curveTo(46.931f, 26.009f, 45f, 28.095f, 45f, 30.655f)
+      curveToRelative(0f, 6.116f, -6.193f, 12.142f, -9.886f, 15.189f)
+      curveToRelative(-1.863f, 1.537f, -4.365f, 1.537f, -6.229f, 0f)
+      curveToRelative(-2.129f, -1.758f, -5.281f, -1.457f, -7.039f, 0.672f)
+      curveToRelative(-0.103f, 0.125f, -0.175f, 0.263f, -0.263f, 0.394f)
+      curveToRelative(1.372f, 1.417f, 2.789f, 2.692f, 4.12f, 3.79f)
+      curveToRelative(3.714f, 3.066f, 8.88f, 3.066f, 12.594f, 0f)
+      curveTo(43.488f, 46.417f, 50f, 39.481f, 50f, 31.656f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(32f, 3f)
+      curveToRelative(-3.517f, 0f, -6.555f, 0.899f, -8.035f, 2.206f)
+      lineToRelative(-6.013f, -2.895f)
+      curveToRelative(-1.689f, -0.788f, -3.443f, 0.958f, -2.662f, 2.651f)
+      lineToRelative(2.339f, 5.069f)
+      curveToRelative(-0.627f, 1.026f, -1.145f, 2.133f, -1.538f, 3.309f)
+      curveToRelative(-1.662f, 0.381f, -3.197f, 1.088f, -4.549f, 2.037f)
+      curveToRelative(0.551f, 1.231f, 1.582f, 2.242f, 2.961f, 2.704f)
+      curveToRelative(0.527f, 0.177f, 1.062f, 0.26f, 1.589f, 0.26f)
+      curveToRelative(2.091f, 0f, 4.04f, -1.321f, 4.741f, -3.413f)
+      curveToRelative(0.269f, -0.803f, 0.627f, -1.575f, 1.066f, -2.293f)
+      curveToRelative(0.486f, -0.798f, 0.732f, -1.701f, 0.731f, -2.608f)
+      curveToRelative(1.604f, 0.449f, 3.347f, 0.073f, 4.629f, -1.058f)
+      curveTo(27.645f, 8.664f, 29.375f, 8f, 32f, 8f)
+      curveToRelative(2.533f, 0f, 4.604f, -1.89f, 4.933f, -4.334f)
+      curveTo(35.516f, 3.25f, 33.828f, 3f, 32f, 3f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(23.508f, 10.98f)
+      curveToRelative(-0.396f, 0f, -0.79f, -0.153f, -1.082f, -0.459f)
+      curveToRelative(-0.561f, -0.59f, -0.563f, -1.507f, 0.013f, -2.082f)
+      curveToRelative(0.241f, -0.241f, 2.564f, -2.384f, 9.849f, -3.425f)
+      curveToRelative(0.814f, -0.118f, 1.579f, 0.453f, 1.697f, 1.273f)
+      curveToRelative(0.117f, 0.82f, -0.453f, 1.58f, -1.273f, 1.697f)
+      curveToRelative(-6.227f, 0.889f, -8.159f, 2.584f, -8.178f, 2.602f)
+      curveTo(24.244f, 10.85f, 23.875f, 10.98f, 23.508f, 10.98f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/PaperMap.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/PaperMap.kt
@@ -1,0 +1,113 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.PaperMap: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.PaperMap",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(37.682f, 13.663f)
+      lineToRelative(-12.349f, 2.906f)
+      curveToRelative(-1.205f, 0.284f, -2.46f, 0.284f, -3.665f, 0f)
+      lineToRelative(-10.385f, -2.444f)
+      curveTo(8.84f, 13.551f, 6.5f, 15.404f, 6.5f, 17.913f)
+      verticalLineToRelative(28.711f)
+      curveToRelative(0f, 1.392f, 0.958f, 2.601f, 2.313f, 2.92f)
+      lineToRelative(11.869f, 2.793f)
+      curveToRelative(1.853f, 0.436f, 3.783f, 0.436f, 5.636f, 0f)
+      lineToRelative(12.349f, -2.906f)
+      curveToRelative(1.205f, -0.284f, 2.46f, -0.284f, 3.665f, 0f)
+      lineToRelative(10.385f, 2.444f)
+      curveToRelative(2.443f, 0.575f, 4.783f, -1.279f, 4.783f, -3.788f)
+      verticalLineTo(19.376f)
+      curveToRelative(0f, -1.392f, -0.958f, -2.601f, -2.313f, -2.92f)
+      lineToRelative(-11.869f, -2.793f)
+      curveTo(41.465f, 13.227f, 39.535f, 13.227f, 37.682f, 13.663f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(8.75f, 61f)
+      arcToRelative(23.25f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 46.5f, 0f)
+      arcToRelative(23.25f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -46.5f, 0f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(37.682f, 13.663f)
+      lineToRelative(-12.349f, 2.906f)
+      curveToRelative(-0.603f, 0.142f, -1.217f, 0.213f, -1.832f, 0.213f)
+      verticalLineToRelative(35.882f)
+      curveToRelative(0.946f, 0f, 1.891f, -0.109f, 2.818f, -0.327f)
+      lineToRelative(12.349f, -2.906f)
+      curveToRelative(0.603f, -0.142f, 1.217f, -0.213f, 1.832f, -0.213f)
+      verticalLineTo(13.336f)
+      curveTo(39.554f, 13.336f, 38.609f, 13.445f, 37.682f, 13.663f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(21.668f, 16.569f)
+      lineToRelative(-10.385f, -2.444f)
+      curveTo(8.84f, 13.551f, 6.5f, 15.404f, 6.5f, 17.913f)
+      verticalLineTo(28f)
+      curveToRelative(2.762f, 0f, 5f, -2.239f, 5f, -5f)
+      verticalLineToRelative(-3.687f)
+      lineToRelative(5.778f, 1.36f)
+      curveToRelative(2.691f, 0.629f, 5.38f, -1.034f, 6.013f, -3.722f)
+      curveToRelative(0.014f, -0.06f, 0.012f, -0.12f, 0.024f, -0.18f)
+      curveTo(22.762f, 16.758f, 22.21f, 16.696f, 21.668f, 16.569f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(52.5f, 34f)
+      verticalLineToRelative(11.359f)
+      curveToRelative(0f, 0.654f, -0.618f, 1.132f, -1.251f, 0.968f)
+      lineToRelative(-4.492f, -1.167f)
+      curveToRelative(-2.808f, -0.729f, -5.705f, 1.093f, -6.193f, 4.036f)
+      curveToRelative(0.009f, 0.011f, 0.013f, 0.015f, 0.022f, 0.027f)
+      curveToRelative(0.586f, 0.006f, 1.172f, 0.073f, 1.746f, 0.208f)
+      lineToRelative(10.385f, 2.444f)
+      curveToRelative(2.443f, 0.575f, 4.783f, -1.279f, 4.783f, -3.788f)
+      verticalLineTo(29f)
+      curveTo(54.738f, 29f, 52.5f, 31.239f, 52.5f, 34f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(10.5f, 22.5f)
+      verticalLineToRelative(-2.924f)
+      curveToRelative(0f, -0.645f, 0.601f, -1.121f, 1.229f, -0.973f)
+      lineToRelative(3.178f, 0.748f)
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/ParkBench.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/ParkBench.kt
@@ -1,0 +1,169 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.ParkBench: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.ParkBench",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFDA7200))) {
+      moveTo(22f, 53f)
+      horizontalLineToRelative(-4f)
+      curveToRelative(-1.105f, 0f, -2f, -0.895f, -2f, -2f)
+      verticalLineToRelative(-9f)
+      horizontalLineToRelative(8f)
+      verticalLineToRelative(9f)
+      curveTo(24f, 52.105f, 23.105f, 53f, 22f, 53f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF5E8700))) {
+      moveTo(35.288f, 41.171f)
+      lineToRelative(-6.969f, -9.064f)
+      curveTo(27.971f, 31.655f, 28.294f, 31f, 28.864f, 31f)
+      horizontalLineToRelative(1.075f)
+      curveToRelative(1.659f, 0f, 2.597f, -1.904f, 1.586f, -3.219f)
+      lineToRelative(-5.131f, -6.674f)
+      curveTo(26.046f, 20.655f, 26.369f, 20f, 26.94f, 20f)
+      horizontalLineToRelative(0f)
+      curveToRelative(1.659f, 0f, 2.597f, -1.904f, 1.586f, -3.219f)
+      lineToRelative(-6.147f, -7.995f)
+      curveToRelative(-1.201f, -1.562f, -3.556f, -1.562f, -4.757f, 0f)
+      lineToRelative(-6.147f, 7.995f)
+      curveTo(10.464f, 18.096f, 11.401f, 20f, 13.06f, 20f)
+      horizontalLineToRelative(0f)
+      curveToRelative(0.571f, 0f, 0.893f, 0.655f, 0.545f, 1.107f)
+      lineToRelative(-5.131f, 6.674f)
+      curveTo(7.464f, 29.096f, 8.401f, 31f, 10.06f, 31f)
+      horizontalLineToRelative(1.075f)
+      curveToRelative(0.571f, 0f, 0.893f, 0.655f, 0.545f, 1.107f)
+      lineToRelative(-6.969f, 9.064f)
+      curveTo(3.195f, 43.144f, 4.602f, 46f, 7.091f, 46f)
+      horizontalLineToRelative(25.819f)
+      curveTo(35.398f, 46f, 36.805f, 43.144f, 35.288f, 41.171f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(11.496f, 32.348f)
+      curveToRelative(0.741f, -0.327f, 1.415f, -0.833f, 1.943f, -1.519f)
+      lineToRelative(5.134f, -6.678f)
+      curveToRelative(1.328f, -1.731f, 1.554f, -4.022f, 0.589f, -5.979f)
+      curveToRelative(-0.184f, -0.373f, -0.403f, -0.719f, -0.653f, -1.034f)
+      lineToRelative(4.078f, -5.304f)
+      curveToRelative(0.399f, -0.519f, 0.671f, -1.093f, 0.839f, -1.687f)
+      lineToRelative(-1.047f, -1.361f)
+      curveToRelative(-1.201f, -1.563f, -3.556f, -1.563f, -4.757f, 0f)
+      lineToRelative(-6.147f, 7.995f)
+      curveTo(10.464f, 18.096f, 11.401f, 20f, 13.06f, 20f)
+      curveToRelative(0.571f, 0f, 0.893f, 0.655f, 0.545f, 1.107f)
+      lineToRelative(-5.131f, 6.674f)
+      curveTo(7.464f, 29.096f, 8.401f, 31f, 10.06f, 31f)
+      horizontalLineToRelative(1.075f)
+      curveToRelative(0.571f, 0f, 0.893f, 0.655f, 0.545f, 1.107f)
+      lineTo(11.496f, 32.348f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(12f, 61f)
+      arcToRelative(20f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 40f, 0f)
+      arcToRelative(20f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -40f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA7B3C7))) {
+      moveTo(40.502f, 53f)
+      curveToRelative(-0.098f, 0f, -0.197f, -0.009f, -0.296f, -0.029f)
+      curveToRelative(-0.813f, -0.162f, -1.34f, -0.952f, -1.177f, -1.765f)
+      lineToRelative(1.5f, -7.5f)
+      curveToRelative(0.162f, -0.812f, 0.962f, -1.344f, 1.765f, -1.177f)
+      curveToRelative(0.813f, 0.162f, 1.34f, 0.952f, 1.177f, 1.765f)
+      lineToRelative(-1.5f, 7.5f)
+      curveTo(41.828f, 52.507f, 41.202f, 53f, 40.502f, 53f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA7B3C7))) {
+      moveTo(58.498f, 53f)
+      curveToRelative(-0.754f, 0f, -1.403f, -0.567f, -1.489f, -1.334f)
+      lineToRelative(-1f, -9f)
+      curveToRelative(-0.091f, -0.823f, 0.502f, -1.565f, 1.325f, -1.657f)
+      curveToRelative(0.826f, -0.089f, 1.564f, 0.501f, 1.657f, 1.325f)
+      lineToRelative(1f, 9f)
+      curveToRelative(0.091f, 0.823f, -0.502f, 1.565f, -1.325f, 1.657f)
+      curveTo(58.609f, 52.997f, 58.554f, 53f, 58.498f, 53f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(58f, 44f)
+      horizontalLineTo(41f)
+      curveToRelative(-1.657f, 0f, -3f, -1.343f, -3f, -3f)
+      lineToRelative(0f, 0f)
+      curveToRelative(0f, -1.657f, 1.343f, -3f, 3f, -3f)
+      horizontalLineToRelative(17f)
+      curveToRelative(1.657f, 0f, 3f, 1.343f, 3f, 3f)
+      lineToRelative(0f, 0f)
+      curveTo(61f, 42.657f, 59.657f, 44f, 58f, 44f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA7B3C7))) {
+      moveTo(57.5f, 50f)
+      horizontalLineToRelative(-16f)
+      curveToRelative(-0.828f, 0f, -1.5f, -0.672f, -1.5f, -1.5f)
+      reflectiveCurveToRelative(0.672f, -1.5f, 1.5f, -1.5f)
+      horizontalLineToRelative(16f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.672f, 1.5f, 1.5f)
+      reflectiveCurveTo(58.328f, 50f, 57.5f, 50f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(28.319f, 32.107f)
+      curveTo(27.971f, 31.655f, 28.294f, 31f, 28.864f, 31f)
+      horizontalLineToRelative(1.075f)
+      curveToRelative(1.659f, 0f, 2.597f, -1.904f, 1.586f, -3.219f)
+      lineToRelative(-5.131f, -6.674f)
+      curveToRelative(-0.119f, -0.155f, -0.154f, -0.332f, -0.134f, -0.5f)
+      curveToRelative(-0.236f, 0.127f, -0.471f, 0.259f, -0.69f, 0.428f)
+      curveToRelative(-1.345f, 1.035f, -2.026f, 3.178f, -1.958f, 5.057f)
+      curveToRelative(0.039f, 1.091f, -0.329f, 2.113f, -0.847f, 3.075f)
+      curveToRelative(-0.002f, 0.003f, -0.003f, 0.005f, -0.004f, 0.008f)
+      curveToRelative(-0.965f, 1.958f, -0.736f, 4.25f, 0.594f, 5.979f)
+      lineTo(27.849f, 41f)
+      horizontalLineToRelative(-8.634f)
+      curveToRelative(-2.612f, 0f, -4.943f, 1.91f, -5.191f, 4.509f)
+      curveToRelative(-0.016f, 0.166f, -0.02f, 0.329f, -0.02f, 0.491f)
+      horizontalLineToRelative(18.906f)
+      curveToRelative(2.489f, 0f, 3.895f, -2.855f, 2.378f, -4.829f)
+      lineTo(28.319f, 32.107f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(17.499f, 18f)
+      curveToRelative(-0.286f, 0f, -0.575f, -0.081f, -0.831f, -0.252f)
+      curveToRelative(-0.689f, -0.46f, -0.876f, -1.391f, -0.416f, -2.08f)
+      lineToRelative(2f, -3f)
+      curveToRelative(0.46f, -0.689f, 1.392f, -0.876f, 2.08f, -0.416f)
+      curveToRelative(0.689f, 0.46f, 0.876f, 1.391f, 0.416f, 2.08f)
+      lineToRelative(-2f, 3f)
+      curveTo(18.459f, 17.766f, 17.983f, 18f, 17.499f, 18f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/SailBoat.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/SailBoat.kt
@@ -1,0 +1,137 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.SailBoat: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.SailBoat",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFDA7200))) {
+      moveTo(31.5f, 5f)
+      lineTo(31.5f, 5f)
+      curveTo(30.672f, 5f, 30f, 5.672f, 30f, 6.5f)
+      verticalLineTo(31f)
+      horizontalLineToRelative(3f)
+      verticalLineTo(6.5f)
+      curveTo(33f, 5.672f, 32.328f, 5f, 31.5f, 5f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(42f, 46f)
+      horizontalLineTo(25f)
+      lineToRelative(-11.707f, -9.198f)
+      curveTo(11.845f, 35.664f, 11f, 33.925f, 11f, 32.084f)
+      verticalLineToRelative(0f)
+      curveTo(11f, 30.933f, 11.933f, 30f, 13.084f, 30f)
+      horizontalLineToRelative(39.3f)
+      curveToRelative(1.751f, 0f, 2.657f, 2.091f, 1.459f, 3.368f)
+      lineTo(42f, 46f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(52.978f, 40f)
+      curveToRelative(-2.612f, 0f, -3.826f, 2f, -6.649f, 2f)
+      curveToRelative(-1.403f, 0f, -2.044f, -0.357f, -2.855f, -0.81f)
+      curveToRelative(-2.236f, -1.565f, -6.41f, -1.557f, -8.631f, 0f)
+      curveTo(34.002f, 41.659f, 33.393f, 41.998f, 32f, 42f)
+      curveToRelative(-1.393f, -0.002f, -2.002f, -0.341f, -2.842f, -0.809f)
+      curveToRelative(-2.231f, -1.562f, -6.399f, -1.562f, -8.631f, 0f)
+      curveTo(19.716f, 41.642f, 19.075f, 42f, 17.672f, 42f)
+      curveToRelative(-2.824f, 0f, -4.037f, -2f, -6.649f, -2f)
+      curveTo(8.924f, 39.999f, 9f, 42.084f, 9f, 42.084f)
+      lineTo(8.999f, 49f)
+      curveToRelative(0f, 2.209f, 1.791f, 4f, 4f, 4f)
+      lineToRelative(38f, 0.001f)
+      curveToRelative(2.209f, 0f, 4f, -1.791f, 4f, -4f)
+      lineTo(55f, 42.085f)
+      curveTo(55f, 42.085f, 55.076f, 40.001f, 52.978f, 40f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(54.999f, 49.001f)
+      lineTo(55f, 42.085f)
+      curveToRelative(0f, 0f, 0.001f, -0.033f, -0.001f, -0.086f)
+      curveToRelative(-2.76f, 0f, -4.998f, 2.238f, -4.999f, 4.997f)
+      verticalLineTo(48f)
+      lineToRelative(-11f, -0.001f)
+      curveToRelative(-2.761f, 0f, -5f, 2.238f, -5f, 5f)
+      curveTo(34f, 53f, 34f, 53f, 34f, 53f)
+      lineToRelative(16.999f, 0f)
+      curveTo(53.208f, 53f, 54.999f, 51.21f, 54.999f, 49.001f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(33f, 7f)
+      verticalLineToRelative(19f)
+      lineToRelative(12.719f, -0.748f)
+      curveToRelative(1.696f, -0.1f, 2.503f, -2.135f, 1.337f, -3.37f)
+      lineTo(33f, 7f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(28f, 26f)
+      verticalLineTo(7f)
+      lineTo(17.028f, 17.972f)
+      curveToRelative(-0.984f, 0.984f, -0.687f, 2.647f, 0.576f, 3.23f)
+      lineTo(28f, 26f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(28f, 7f)
+      lineTo(17.028f, 17.972f)
+      curveToRelative(-0.694f, 0.694f, -0.74f, 1.72f, -0.269f, 2.473f)
+      curveTo(17.464f, 20.8f, 18.228f, 21f, 19f, 21f)
+      curveToRelative(1.279f, 0f, 2.56f, -0.488f, 3.535f, -1.465f)
+      lineTo(28f, 14.07f)
+      verticalLineTo(7f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFE691))) {
+      moveTo(53.25f, 34f)
+      horizontalLineTo(11.319f)
+      curveToRelative(0.369f, 1.093f, 1.046f, 2.072f, 1.974f, 2.802f)
+      lineTo(13.545f, 37f)
+      horizontalLineToRelative(36.892f)
+      lineTo(53.25f, 34f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(22.5f, 19f)
+      curveToRelative(-0.384f, 0f, -0.768f, -0.146f, -1.061f, -0.439f)
+      curveToRelative(-0.586f, -0.586f, -0.586f, -1.535f, 0f, -2.121f)
+      lineToRelative(3f, -3f)
+      curveToRelative(0.586f, -0.586f, 1.535f, -0.586f, 2.121f, 0f)
+      reflectiveCurveToRelative(0.586f, 1.535f, 0f, 2.121f)
+      lineToRelative(-3f, 3f)
+      curveTo(23.268f, 18.854f, 22.884f, 19f, 22.5f, 19f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/SleepingBag.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/SleepingBag.kt
@@ -1,0 +1,125 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.SleepingBag: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.SleepingBag",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(22.05f, 9.851f)
+      lineTo(22.05f, 9.851f)
+      curveToRelative(-2.656f, 7.969f, -3.247f, 16.481f, -1.717f, 24.741f)
+      lineToRelative(2.702f, 14.585f)
+      curveTo(23.596f, 51.981f, 26.059f, 54f, 28.919f, 54f)
+      horizontalLineToRelative(6.162f)
+      curveToRelative(2.86f, 0f, 5.323f, -2.019f, 5.883f, -4.823f)
+      lineToRelative(2.702f, -14.585f)
+      curveToRelative(1.53f, -8.259f, 0.94f, -16.772f, -1.717f, -24.741f)
+      lineToRelative(0f, 0f)
+      curveTo(40.575f, 5.726f, 37f, 2f, 32f, 2f)
+      reflectiveCurveTo(23.425f, 5.726f, 22.05f, 9.851f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(36.808f, 3.3f)
+      curveTo(35.413f, 2.489f, 33.801f, 2f, 32f, 2f)
+      curveToRelative(-5f, 0f, -8.575f, 3.726f, -9.95f, 7.851f)
+      horizontalLineToRelative(0f)
+      curveToRelative(-1.1f, 3.3f, -1.825f, 6.695f, -2.212f, 10.125f)
+      curveToRelative(0.266f, 0.043f, 0.532f, 0.071f, 0.794f, 0.071f)
+      curveToRelative(2.303f, 0f, 4.374f, -1.601f, 4.882f, -3.942f)
+      curveToRelative(0.341f, -1.574f, 0.772f, -3.146f, 1.281f, -4.673f)
+      curveTo(27.475f, 9.388f, 29.247f, 7f, 32f, 7f)
+      curveTo(34.309f, 7f, 36.233f, 5.427f, 36.808f, 3.3f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF4CCFF1))) {
+      moveTo(41f, 33.543f)
+      horizontalLineTo(23f)
+      verticalLineToRelative(-5.752f)
+      curveTo(23f, 22.936f, 27.029f, 19f, 32f, 19f)
+      lineToRelative(0f, 0f)
+      curveToRelative(4.971f, 0f, 9f, 3.936f, 9f, 8.791f)
+      verticalLineTo(33.543f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(32f, 12f)
+      moveToRelative(-5f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 10f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -10f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(14.937f, 61f)
+      arcToRelative(17.063f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 34.126f, 0f)
+      arcToRelative(17.063f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -34.126f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(40.965f, 49.177f)
+      lineToRelative(2.702f, -14.585f)
+      curveToRelative(0.851f, -4.593f, 1.022f, -9.263f, 0.57f, -13.875f)
+      curveTo(30f, 21f, 20.179f, 29.348f, 19.712f, 29.831f)
+      curveToRelative(0.138f, 1.592f, 0.328f, 3.182f, 0.621f, 4.761f)
+      lineToRelative(2.702f, 14.585f)
+      curveTo(23.596f, 51.981f, 26.059f, 54f, 28.919f, 54f)
+      horizontalLineToRelative(6.162f)
+      curveTo(37.941f, 54f, 40.404f, 51.981f, 40.965f, 49.177f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFCD2E42))) {
+      moveTo(20f, 30f)
+      curveToRelative(0f, 0f, 12.211f, -4.367f, 14f, 1f)
+      curveToRelative(3f, 9f, 10.126f, 0.264f, 10.407f, -7.916f)
+      curveToRelative(-0.041f, -0.79f, -0.093f, -1.58f, -0.17f, -2.368f)
+      curveToRelative(-14.172f, 0.282f, -23.96f, 8.549f, -24.511f, 9.101f)
+      lineTo(20f, 30f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(40.965f, 49.177f)
+      lineToRelative(1.893f, -10.218f)
+      curveToRelative(0f, 0f, 0f, 0f, 0f, 0f)
+      curveToRelative(-2.713f, -0.505f, -5.327f, 1.29f, -5.827f, 4.006f)
+      lineToRelative(-0.968f, 5.231f)
+      curveTo(35.969f, 48.662f, 35.556f, 49f, 35.081f, 49f)
+      curveToRelative(-2.761f, 0f, -5f, 2.238f, -5f, 5f)
+      horizontalLineToRelative(5f)
+      curveTo(37.941f, 54f, 40.404f, 51.981f, 40.965f, 49.177f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(25.501f, 13f)
+      curveToRelative(-0.106f, 0f, -0.213f, -0.011f, -0.32f, -0.034f)
+      curveToRelative(-0.81f, -0.177f, -1.323f, -0.976f, -1.147f, -1.785f)
+      curveToRelative(1.465f, -6.73f, 6.654f, -7.022f, 6.875f, -7.032f)
+      curveToRelative(0.817f, -0.037f, 1.526f, 0.608f, 1.561f, 1.437f)
+      curveToRelative(0.034f, 0.822f, -0.599f, 1.517f, -1.418f, 1.561f)
+      curveToRelative(-0.333f, 0.024f, -3.147f, 0.361f, -4.085f, 4.674f)
+      curveTo(26.813f, 12.521f, 26.191f, 13f, 25.501f, 13f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Snowflake.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Snowflake.kt
@@ -1,0 +1,204 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Snowflake: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Snowflake",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(10.5f, 61f)
+      arcToRelative(21.5f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 43f, 0f)
+      arcToRelative(21.5f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -43f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(32f, 55f)
+      curveToRelative(-1.657f, 0f, -3f, -1.343f, -3f, -3f)
+      verticalLineTo(9f)
+      curveToRelative(0f, -1.657f, 1.343f, -3f, 3f, -3f)
+      reflectiveCurveToRelative(3f, 1.343f, 3f, 3f)
+      verticalLineToRelative(43f)
+      curveTo(35f, 53.657f, 33.657f, 55f, 32f, 55f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color(0xFF37D0EE)),
+      strokeLineWidth = 5f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(26.5f, 48.52f)
+      lineToRelative(5.499f, -5f)
+      lineToRelative(5.507f, 5f)
+    }
+    path(
+      stroke = SolidColor(Color(0xFF37D0EE)),
+      strokeLineWidth = 5f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(26.5f, 12.52f)
+      lineToRelative(5.499f, 5f)
+      lineToRelative(5.507f, -5f)
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(13.374f, 44.23f)
+      curveToRelative(-1.038f, 0f, -2.047f, -0.539f, -2.603f, -1.503f)
+      curveToRelative(-0.827f, -1.436f, -0.334f, -3.27f, 1.103f, -4.097f)
+      lineToRelative(37.26f, -21.463f)
+      curveToRelative(1.435f, -0.828f, 3.269f, -0.333f, 4.097f, 1.102f)
+      curveToRelative(0.827f, 1.436f, 0.334f, 3.27f, -1.103f, 4.097f)
+      lineToRelative(-37.26f, 21.463f)
+      curveTo(14.396f, 44.101f, 13.882f, 44.23f, 13.374f, 44.23f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color(0xFF37D0EE)),
+      strokeLineWidth = 5f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(13.641f, 34.727f)
+      lineToRelative(7.078f, 2.269f)
+      lineToRelative(-1.584f, 7.267f)
+    }
+    path(
+      stroke = SolidColor(Color(0xFF37D0EE)),
+      strokeLineWidth = 5f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(44.836f, 16.758f)
+      lineToRelative(-1.588f, 7.261f)
+      lineToRelative(7.081f, 2.275f)
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(50.628f, 44.255f)
+      curveToRelative(-0.508f, 0f, -1.022f, -0.129f, -1.494f, -0.401f)
+      lineToRelative(-37.26f, -21.463f)
+      curveToRelative(-1.437f, -0.827f, -1.93f, -2.661f, -1.103f, -4.097f)
+      curveToRelative(0.828f, -1.436f, 2.66f, -1.929f, 4.097f, -1.102f)
+      lineToRelative(37.26f, 21.463f)
+      curveToRelative(1.437f, 0.827f, 1.93f, 2.662f, 1.103f, 4.097f)
+      curveTo(52.675f, 43.716f, 51.666f, 44.255f, 50.628f, 44.255f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color(0xFF37D0EE)),
+      strokeLineWidth = 5f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(13.641f, 26.294f)
+      lineToRelative(7.078f, -2.269f)
+      lineToRelative(-1.584f, -7.267f)
+    }
+    path(
+      stroke = SolidColor(Color(0xFF37D0EE)),
+      strokeLineWidth = 5f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(44.836f, 44.263f)
+      lineToRelative(-1.588f, -7.261f)
+      lineToRelative(7.081f, -2.275f)
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(52.128f, 38.655f)
+      lineTo(37.99f, 30.51f)
+      lineToRelative(14.138f, -8.144f)
+      curveToRelative(1.437f, -0.827f, 1.93f, -2.661f, 1.103f, -4.097f)
+      curveToRelative(-0.828f, -1.436f, -2.662f, -1.93f, -4.097f, -1.102f)
+      lineTo(35f, 25.309f)
+      verticalLineTo(9f)
+      curveToRelative(0f, -1.657f, -1.343f, -3f, -3f, -3f)
+      reflectiveCurveToRelative(-3f, 1.343f, -3f, 3f)
+      verticalLineToRelative(16.332f)
+      lineToRelative(-14.132f, -8.141f)
+      curveToRelative(-1.437f, -0.827f, -3.269f, -0.333f, -4.097f, 1.102f)
+      curveToRelative(-0.827f, 1.436f, -0.334f, 3.27f, 1.103f, 4.097f)
+      lineToRelative(14.096f, 8.12f)
+      lineToRelative(-14.096f, 8.12f)
+      curveToRelative(-1.437f, 0.827f, -1.93f, 2.661f, -1.103f, 4.097f)
+      curveToRelative(0.556f, 0.964f, 1.564f, 1.503f, 2.603f, 1.503f)
+      curveToRelative(0.508f, 0f, 1.022f, -0.129f, 1.494f, -0.401f)
+      lineTo(29f, 35.689f)
+      verticalLineTo(52f)
+      curveToRelative(0f, 1.657f, 1.343f, 3f, 3f, 3f)
+      reflectiveCurveToRelative(3f, -1.343f, 3f, -3f)
+      verticalLineTo(35.712f)
+      lineToRelative(14.134f, 8.142f)
+      curveToRelative(0.472f, 0.272f, 0.986f, 0.401f, 1.494f, 0.401f)
+      curveToRelative(1.038f, 0f, 2.047f, -0.539f, 2.603f, -1.503f)
+      curveTo(54.058f, 41.316f, 53.564f, 39.482f, 52.128f, 38.655f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(53.608f, 41.628f)
+      curveToRelative(-0.423f, -0.853f, -1.091f, -1.595f, -1.978f, -2.106f)
+      lineTo(37.496f, 31.38f)
+      curveToRelative(-1.548f, -0.891f, -3.454f, -0.89f, -4.998f, 0.003f)
+      curveTo(30.952f, 32.277f, 30f, 33.927f, 30f, 35.712f)
+      verticalLineTo(52f)
+      curveToRelative(0f, 1.023f, 0.31f, 1.974f, 0.838f, 2.766f)
+      curveTo(31.195f, 54.916f, 31.588f, 55f, 32f, 55f)
+      curveToRelative(1.657f, 0f, 3f, -1.343f, 3f, -3f)
+      verticalLineTo(35.712f)
+      lineToRelative(14.134f, 8.142f)
+      curveToRelative(0.472f, 0.272f, 0.986f, 0.401f, 1.494f, 0.401f)
+      curveToRelative(1.038f, 0f, 2.047f, -0.539f, 2.603f, -1.503f)
+      curveTo(53.436f, 42.395f, 53.56f, 42.013f, 53.608f, 41.628f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(34f, 25.332f)
+      verticalLineTo(9f)
+      curveToRelative(0f, -1.023f, -0.31f, -1.974f, -0.838f, -2.766f)
+      curveTo(32.805f, 6.084f, 32.412f, 6f, 32f, 6f)
+      curveToRelative(-1.657f, 0f, -3f, 1.343f, -3f, 3f)
+      verticalLineToRelative(16.332f)
+      lineToRelative(-14.132f, -8.141f)
+      curveToRelative(-1.437f, -0.827f, -3.269f, -0.333f, -4.097f, 1.102f)
+      curveToRelative(-0.206f, 0.357f, -0.329f, 0.739f, -0.377f, 1.124f)
+      curveToRelative(0.423f, 0.853f, 1.091f, 1.595f, 1.978f, 2.106f)
+      lineToRelative(14.132f, 8.141f)
+      curveToRelative(0.772f, 0.445f, 1.635f, 0.667f, 2.496f, 0.667f)
+      curveToRelative(0.864f, 0f, 1.729f, -0.224f, 2.502f, -0.671f)
+      curveTo(33.048f, 28.768f, 34f, 27.118f, 34f, 25.332f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(31.5f, 14.5f)
+      lineTo(31.5f, 19.5f)
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Star.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Star.kt
@@ -1,0 +1,100 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Star: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Star",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(32f, 50.165f)
+      lineToRelative(-12.123f, 6.374f)
+      curveToRelative(-2.887f, 1.518f, -6.262f, -0.934f, -5.711f, -4.149f)
+      lineToRelative(2.315f, -13.5f)
+      lineTo(6.673f, 29.33f)
+      curveToRelative(-2.336f, -2.277f, -1.047f, -6.244f, 2.181f, -6.713f)
+      lineToRelative(13.554f, -1.97f)
+      lineToRelative(6.062f, -12.282f)
+      curveToRelative(1.444f, -2.925f, 5.615f, -2.925f, 7.059f, 0f)
+      lineToRelative(6.062f, 12.282f)
+      lineToRelative(13.554f, 1.97f)
+      curveToRelative(3.228f, 0.469f, 4.517f, 4.436f, 2.181f, 6.713f)
+      lineToRelative(-9.808f, 9.561f)
+      lineToRelative(2.315f, 13.5f)
+      curveToRelative(0.551f, 3.215f, -2.823f, 5.667f, -5.711f, 4.149f)
+      lineTo(32f, 50.165f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(28.353f, 17.643f)
+      lineTo(31.115f, 12.047f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(53.837f, 25.75f)
+      lineToRelative(-9.809f, 9.561f)
+      curveToRelative(-1.179f, 1.149f, -1.716f, 2.804f, -1.438f, 4.426f)
+      lineToRelative(1.95f, 11.375f)
+      lineTo(34.327f, 45.74f)
+      curveToRelative(-1.457f, -0.766f, -3.197f, -0.766f, -4.654f, 0f)
+      lineTo(17.55f, 52.113f)
+      curveToRelative(-1.382f, 0.727f, -2.261f, 2.015f, -2.551f, 3.435f)
+      curveToRelative(1.113f, 1.346f, 3.088f, 1.931f, 4.877f, 0.991f)
+      lineTo(32f, 50.165f)
+      lineToRelative(12.123f, 6.374f)
+      curveToRelative(2.887f, 1.518f, 6.262f, -0.934f, 5.711f, -4.149f)
+      lineToRelative(-2.315f, -13.5f)
+      lineToRelative(9.808f, -9.561f)
+      curveToRelative(1.448f, -1.411f, 1.501f, -3.47f, 0.565f, -4.945f)
+      curveTo(56.452f, 24.222f, 54.956f, 24.66f, 53.837f, 25.75f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(28.471f, 8.365f)
+      lineToRelative(-6.062f, 12.282f)
+      lineToRelative(-13.554f, 1.97f)
+      curveToRelative(-2.006f, 0.292f, -3.262f, 1.934f, -3.365f, 3.683f)
+      curveToRelative(0.9f, 0.821f, 2.084f, 1.318f, 3.36f, 1.318f)
+      curveToRelative(0.239f, 0f, 0.481f, -0.017f, 0.725f, -0.052f)
+      lineToRelative(13.555f, -1.97f)
+      curveToRelative(1.629f, -0.237f, 3.037f, -1.26f, 3.765f, -2.735f)
+      lineToRelative(6.062f, -12.282f)
+      curveToRelative(0.692f, -1.401f, 0.646f, -2.96f, 0.045f, -4.278f)
+      curveTo(31.308f, 5.865f, 29.366f, 6.551f, 28.471f, 8.365f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Suitcase.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Suitcase.kt
@@ -1,0 +1,155 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Suitcase: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Suitcase",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFBD6300))) {
+      moveTo(43f, 22f)
+      horizontalLineTo(21f)
+      verticalLineToRelative(-9f)
+      curveToRelative(0f, -2.206f, 1.794f, -4f, 4f, -4f)
+      horizontalLineToRelative(14f)
+      curveToRelative(2.206f, 0f, 4f, 1.794f, 4f, 4f)
+      verticalLineTo(22f)
+      close()
+      moveTo(25f, 18f)
+      horizontalLineToRelative(14f)
+      verticalLineToRelative(-5f)
+      horizontalLineTo(25f)
+      verticalLineTo(18f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFDA7200))) {
+      moveTo(56f, 21f)
+      verticalLineToRelative(26f)
+      curveToRelative(0f, 2.76f, -2.24f, 5f, -5f, 5f)
+      horizontalLineTo(13f)
+      curveToRelative(-2.76f, 0f, -5f, -2.24f, -5f, -5f)
+      verticalLineTo(21.01f)
+      curveToRelative(0f, -1.39f, 0.56f, -2.64f, 1.46f, -3.54f)
+      curveToRelative(0.34f, -0.34f, 0.73f, -0.63f, 1.16f, -0.87f)
+      curveToRelative(0.14f, -0.07f, 0.28f, -0.14f, 0.43f, -0.21f)
+      curveToRelative(0.3f, -0.12f, 0.62f, -0.22f, 0.94f, -0.29f)
+      curveTo(12.32f, 16.04f, 12.66f, 16f, 13f, 16f)
+      horizontalLineToRelative(38f)
+      curveTo(53.76f, 16f, 56f, 18.24f, 56f, 21f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(41.121f, 28.885f)
+      lineToRelative(-7.236f, 7.236f)
+      curveToRelative(-1.172f, 1.172f, -3.071f, 1.172f, -4.243f, 0f)
+      lineToRelative(-2.828f, -2.828f)
+      curveToRelative(-1.172f, -1.172f, -1.172f, -3.071f, 0f, -4.243f)
+      lineToRelative(7.236f, -7.236f)
+      curveToRelative(1.172f, -1.172f, 3.071f, -1.172f, 4.243f, 0f)
+      lineToRelative(2.828f, 2.828f)
+      curveTo(42.293f, 25.814f, 42.293f, 27.714f, 41.121f, 28.885f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF68E5FD))) {
+      moveTo(29.316f, 30.571f)
+      lineToRelative(6.276f, -6.277f)
+      curveToRelative(0.421f, -0.421f, 1.103f, -0.421f, 1.524f, 0f)
+      lineToRelative(1.525f, 1.525f)
+      curveToRelative(0.421f, 0.421f, 0.421f, 1.104f, 0f, 1.525f)
+      lineToRelative(-6.276f, 6.277f)
+      curveToRelative(-0.421f, 0.421f, -1.104f, 0.421f, -1.525f, 0f)
+      lineToRelative(-1.525f, -1.525f)
+      curveTo(28.895f, 31.674f, 28.895f, 30.992f, 29.316f, 30.571f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF68E5FD))) {
+      moveTo(42f, 40f)
+      moveToRelative(-5f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 10f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -10f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(45f, 16f)
+      horizontalLineToRelative(6f)
+      verticalLineToRelative(36f)
+      horizontalLineToRelative(-6f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(13f, 16f)
+      horizontalLineToRelative(6f)
+      verticalLineToRelative(36f)
+      horizontalLineToRelative(-6f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(55.509f, 25.023f)
+      curveTo(52.91f, 25.271f, 51f, 27.603f, 51f, 30.214f)
+      verticalLineTo(45f)
+      curveToRelative(0f, 1.105f, -0.895f, 2f, -2f, 2f)
+      horizontalLineTo(25.997f)
+      curveTo(23.235f, 47f, 21f, 49.239f, 21f, 52f)
+      horizontalLineToRelative(30f)
+      curveToRelative(2.761f, 0f, 5f, -2.239f, 5f, -5f)
+      verticalLineTo(25.003f)
+      curveTo(55.838f, 25.003f, 55.675f, 25.008f, 55.509f, 25.023f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(43f, 16f)
+      curveToRelative(0f, 2.77f, -2.24f, 5.01f, -5f, 5.01f)
+      horizontalLineTo(15f)
+      curveToRelative(-1.1f, 0f, -2f, 0.89f, -2f, 2f)
+      verticalLineToRelative(13.98f)
+      curveTo(13f, 39.76f, 10.76f, 42f, 8f, 42f)
+      verticalLineTo(21.01f)
+      curveToRelative(0f, -1.39f, 0.56f, -2.64f, 1.46f, -3.54f)
+      curveToRelative(0.34f, -0.34f, 0.73f, -0.63f, 1.16f, -0.87f)
+      curveToRelative(0.14f, -0.07f, 0.28f, -0.14f, 0.43f, -0.21f)
+      curveToRelative(0.3f, -0.12f, 0.62f, -0.22f, 0.94f, -0.29f)
+      curveTo(12.32f, 16.04f, 12.66f, 16f, 13f, 16f)
+      horizontalLineTo(43f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(12f, 26f)
+      curveToRelative(-0.828f, 0f, -1.5f, -0.671f, -1.5f, -1.5f)
+      verticalLineToRelative(-3.466f)
+      curveToRelative(0f, -1.378f, 1.121f, -2.5f, 2.5f, -2.5f)
+      horizontalLineToRelative(6.5f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.671f, 1.5f, 1.5f)
+      reflectiveCurveToRelative(-0.672f, 1.5f, -1.5f, 1.5f)
+      horizontalLineToRelative(-6f)
+      verticalLineTo(24.5f)
+      curveTo(13.5f, 25.329f, 12f, 26f, 12f, 26f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Sun.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Sun.kt
@@ -1,0 +1,110 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Sun: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Sun",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(50.027f, 36.464f)
+      curveToRelative(-1.159f, 2.784f, 2.448f, 8.829f, 0.357f, 10.92f)
+      curveToRelative(-2.091f, 2.091f, -8.136f, -1.517f, -10.92f, -0.357f)
+      curveTo(36.777f, 48.132f, 35.087f, 55f, 32f, 55f)
+      curveToRelative(-1.582f, 0f, -2.784f, -1.788f, -3.954f, -3.694f)
+      curveToRelative(-1.116f, -1.82f, -2.199f, -3.738f, -3.51f, -4.279f)
+      curveToRelative(-1.343f, -0.563f, -3.445f, -0.011f, -5.503f, 0.477f)
+      curveToRelative(-2.199f, 0.52f, -4.333f, 0.964f, -5.417f, -0.119f)
+      curveToRelative(-2.091f, -2.091f, 1.517f, -8.136f, 0.357f, -10.92f)
+      curveTo(12.868f, 33.777f, 6f, 32.087f, 6f, 29f)
+      reflectiveCurveToRelative(6.868f, -4.777f, 7.973f, -7.464f)
+      curveToRelative(1.159f, -2.784f, -2.448f, -8.829f, -0.357f, -10.92f)
+      curveToRelative(2.091f, -2.091f, 8.136f, 1.517f, 10.92f, 0.357f)
+      curveTo(27.223f, 9.868f, 28.913f, 3f, 32f, 3f)
+      reflectiveCurveToRelative(4.777f, 6.868f, 7.464f, 7.973f)
+      curveToRelative(1.322f, 0.553f, 3.369f, 0.033f, 5.395f, -0.444f)
+      curveToRelative(2.232f, -0.542f, 4.42f, -1.018f, 5.525f, 0.087f)
+      curveToRelative(1.105f, 1.105f, 0.628f, 3.293f, 0.087f, 5.525f)
+      curveToRelative(-0.477f, 2.026f, -0.997f, 4.073f, -0.444f, 5.395f)
+      curveTo(51.132f, 24.223f, 58f, 25.913f, 58f, 29f)
+      reflectiveCurveTo(51.132f, 33.777f, 50.027f, 36.464f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(44f, 29f)
+      curveToRelative(0f, 6.63f, -5.37f, 12f, -12f, 12f)
+      curveToRelative(-1.74f, 0f, -3.4f, -0.37f, -4.89f, -1.04f)
+      curveToRelative(-2.7f, -1.2f, -4.87f, -3.37f, -6.07f, -6.07f)
+      curveTo(20.37f, 32.4f, 20f, 30.74f, 20f, 29f)
+      curveToRelative(0f, -6.63f, 5.37f, -12f, 12f, -12f)
+      curveToRelative(1.74f, 0f, 3.4f, 0.37f, 4.89f, 1.04f)
+      curveToRelative(2.7f, 1.2f, 4.87f, 3.37f, 6.07f, 6.07f)
+      curveTo(43.63f, 25.6f, 44f, 27.26f, 44f, 29f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(44f, 29f)
+      curveToRelative(0f, 6.63f, -5.37f, 12f, -12f, 12f)
+      curveToRelative(-1.74f, 0f, -3.4f, -0.37f, -4.89f, -1.04f)
+      curveTo(27.59f, 37.7f, 29.6f, 36f, 32f, 36f)
+      curveToRelative(1.04f, 0f, 2.03f, -0.22f, 2.95f, -0.66f)
+      curveToRelative(1.51f, -0.7f, 2.69f, -1.88f, 3.38f, -3.36f)
+      curveTo(38.78f, 31.03f, 39f, 30.04f, 39f, 29f)
+      curveToRelative(0f, -2.4f, 1.7f, -4.41f, 3.96f, -4.89f)
+      curveTo(43.63f, 25.6f, 44f, 27.26f, 44f, 29f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(36.89f, 18.04f)
+      curveTo(36.41f, 20.3f, 34.4f, 22f, 32f, 22f)
+      curveToRelative(-1.04f, 0f, -2.03f, 0.22f, -2.95f, 0.66f)
+      curveToRelative(-1.51f, 0.7f, -2.69f, 1.88f, -3.38f, 3.36f)
+      curveTo(25.22f, 26.97f, 25f, 27.96f, 25f, 29f)
+      curveToRelative(0f, 2.4f, -1.7f, 4.41f, -3.96f, 4.89f)
+      curveTo(20.37f, 32.4f, 20f, 30.74f, 20f, 29f)
+      curveToRelative(0f, -6.63f, 5.37f, -12f, 12f, -12f)
+      curveTo(33.74f, 17f, 35.4f, 17.37f, 36.89f, 18.04f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(27.078f, 25.522f)
+      curveToRelative(-0.388f, 0f, -0.775f, -0.149f, -1.068f, -0.447f)
+      curveToRelative(-0.582f, -0.59f, -0.574f, -1.54f, 0.016f, -2.121f)
+      curveToRelative(0.692f, -0.682f, 1.497f, -1.239f, 2.394f, -1.654f)
+      curveTo(29.521f, 20.771f, 30.731f, 20.5f, 32f, 20.5f)
+      curveToRelative(0.828f, 0f, 1.5f, 0.671f, 1.5f, 1.5f)
+      reflectiveCurveToRelative(-0.672f, 1.5f, -1.5f, 1.5f)
+      curveToRelative(-0.816f, 0f, -1.592f, 0.173f, -2.303f, 0.513f)
+      curveToRelative(-0.599f, 0.278f, -1.12f, 0.638f, -1.566f, 1.077f)
+      curveTo(27.839f, 25.378f, 27.458f, 25.522f, 27.078f, 25.522f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(14f, 61f)
+      arcToRelative(18f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 36f, 0f)
+      arcToRelative(18f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -36f, 0f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Train.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Train.kt
@@ -1,0 +1,171 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Train: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Train",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(14.669f, 54.836f)
+      lineTo(14.669f, 54.836f)
+      curveToRelative(-1.608f, -0.401f, -2.586f, -2.029f, -2.185f, -3.637f)
+      lineToRelative(1.936f, -7.762f)
+      lineToRelative(5.822f, 1.452f)
+      lineToRelative(-1.936f, 7.762f)
+      curveTo(17.905f, 54.259f, 16.276f, 55.237f, 14.669f, 54.836f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(50.012f, 54.653f)
+      lineTo(50.012f, 54.653f)
+      curveToRelative(-1.561f, 0.556f, -3.277f, -0.259f, -3.832f, -1.82f)
+      lineToRelative(-3.018f, -8.479f)
+      lineToRelative(5.653f, -2.012f)
+      lineToRelative(3.018f, 8.479f)
+      curveTo(52.388f, 52.381f, 51.573f, 54.097f, 50.012f, 54.653f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(13f, 61.009f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFD3C4F))) {
+      moveTo(47f, 47f)
+      horizontalLineTo(17f)
+      curveToRelative(-3.314f, 0f, -6f, -2.686f, -6f, -6f)
+      verticalLineTo(23.046f)
+      curveToRelative(0f, -3.307f, 0.863f, -6.556f, 2.503f, -9.427f)
+      lineToRelative(2.905f, -5.084f)
+      curveTo(18.011f, 5.731f, 20.993f, 4f, 24.223f, 4f)
+      horizontalLineToRelative(15.554f)
+      curveToRelative(3.23f, 0f, 6.212f, 1.731f, 7.814f, 4.535f)
+      lineToRelative(2.905f, 5.084f)
+      curveTo(52.137f, 16.49f, 53f, 19.739f, 53f, 23.046f)
+      verticalLineTo(41f)
+      curveTo(53f, 44.314f, 50.314f, 47f, 47f, 47f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(16.409f, 8.535f)
+      lineToRelative(-2.905f, 5.084f)
+      curveTo(11.863f, 16.49f, 11f, 19.739f, 11f, 23.046f)
+      verticalLineToRelative(5f)
+      curveToRelative(2.761f, 0f, 5f, -2.238f, 5f, -5f)
+      curveToRelative(0f, -2.433f, 0.638f, -4.834f, 1.845f, -6.946f)
+      lineToRelative(2.905f, -5.084f)
+      curveTo(21.46f, 9.772f, 22.791f, 9f, 24.223f, 9f)
+      horizontalLineToRelative(3.554f)
+      curveToRelative(2.761f, 0f, 5f, -2.238f, 5f, -5f)
+      horizontalLineToRelative(-8.554f)
+      curveTo(20.993f, 4f, 18.011f, 5.73f, 16.409f, 8.535f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFCD2E42))) {
+      moveTo(47f, 47f)
+      horizontalLineTo(17f)
+      curveToRelative(-3.314f, 0f, -6f, -2.686f, -6f, -6f)
+      verticalLineToRelative(-6f)
+      horizontalLineToRelative(42f)
+      verticalLineToRelative(6f)
+      curveTo(53f, 44.314f, 50.314f, 47f, 47f, 47f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFCD2E42))) {
+      moveTo(21f, 35f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFCD2E42))) {
+      moveTo(42f, 35f)
+      moveToRelative(-6f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, 12f, 0f)
+      arcToRelative(6f, 6f, 0f, isMoreThanHalf = true, isPositiveArc = true, -12f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(42f, 35f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(21f, 35f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(45f, 25f)
+      horizontalLineTo(19f)
+      curveToRelative(-1.657f, 0f, -3f, -1.343f, -3f, -3f)
+      verticalLineToRelative(-1.407f)
+      curveToRelative(0f, -1.044f, 0.272f, -2.07f, 0.791f, -2.977f)
+      lineToRelative(2.058f, -3.601f)
+      curveTo(19.56f, 12.769f, 20.886f, 12f, 22.321f, 12f)
+      horizontalLineToRelative(19.357f)
+      curveToRelative(1.435f, 0f, 2.761f, 0.769f, 3.473f, 2.015f)
+      lineToRelative(2.058f, 3.601f)
+      curveTo(47.728f, 18.523f, 48f, 19.549f, 48f, 20.593f)
+      verticalLineTo(22f)
+      curveTo(48f, 23.657f, 46.657f, 25f, 45f, 25f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFE691))) {
+      moveTo(32f, 5f)
+      moveToRelative(-5f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 10f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -10f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(53f, 41f)
+      curveToRelative(0f, 0f, 0f, -14f, 0f, -15f)
+      curveToRelative(-2.449f, 0.323f, -5f, 2.508f, -5f, 5.046f)
+      verticalLineTo(41f)
+      curveToRelative(0f, 0.552f, -0.449f, 1f, -1f, 1f)
+      horizontalLineToRelative(-8f)
+      curveToRelative(-2.761f, 0f, -5f, 2.238f, -5f, 5f)
+      horizontalLineToRelative(13f)
+      curveTo(50.314f, 47f, 53f, 44.313f, 53f, 41f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(18.528f, 13.753f)
+      curveToRelative(-0.271f, 0f, -0.546f, -0.073f, -0.793f, -0.228f)
+      curveToRelative(-0.703f, -0.439f, -0.916f, -1.365f, -0.477f, -2.067f)
+      lineToRelative(1.502f, -2.403f)
+      curveTo(19.955f, 7.142f, 22.015f, 6f, 24.271f, 6f)
+      horizontalLineTo(24.5f)
+      curveTo(25.329f, 6f, 26f, 6.672f, 26f, 7.5f)
+      reflectiveCurveTo(25.329f, 9f, 24.5f, 9f)
+      horizontalLineToRelative(-0.229f)
+      curveToRelative(-1.215f, 0f, -2.324f, 0.615f, -2.968f, 1.645f)
+      lineToRelative(-1.502f, 2.403f)
+      curveTo(19.517f, 13.503f, 19.028f, 13.753f, 18.528f, 13.753f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Trekking.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Trekking.kt
@@ -1,0 +1,148 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Trekking: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Trekking",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(
+      stroke = SolidColor(Color(0xFFFFCE29)),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(49.5f, 15.5f)
+      lineTo(49.5f, 55.5f)
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(43.502f, 29f)
+      curveToRelative(-0.754f, 0f, -1.493f, -0.34f, -1.981f, -0.973f)
+      lineToRelative(-8.314f, -8.183f)
+      curveToRelative(-0.843f, -1.093f, -0.641f, -2.663f, 0.452f, -3.507f)
+      curveToRelative(1.094f, -0.841f, 2.797f, -0.504f, 3.64f, 0.59f)
+      lineToRelative(6.85f, 6.323f)
+      lineToRelative(5.11f, -2.92f)
+      curveToRelative(1.198f, -0.686f, 2.725f, -0.27f, 3.411f, 0.93f)
+      curveToRelative(0.685f, 1.199f, 0.269f, 2.726f, -0.931f, 3.411f)
+      lineToRelative(-7f, 4f)
+      curveTo(44.351f, 28.893f, 43.924f, 29f, 43.502f, 29f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(41.001f, 57f)
+      curveToRelative(-1.381f, 0f, -2.623f, -0.959f, -2.929f, -2.363f)
+      lineToRelative(-1.785f, -10.555f)
+      lineToRelative(-8.971f, -7.352f)
+      curveToRelative(-1.231f, -1.108f, -1.642f, -4.006f, -0.533f, -5.237f)
+      reflectiveCurveToRelative(5.499f, -2.602f, 6.73f, -1.493f)
+      lineToRelative(7.507f, 10.27f)
+      curveToRelative(0.468f, 0.421f, 0.791f, 0.978f, 0.925f, 1.593f)
+      lineToRelative(1.99f, 11.5f)
+      curveToRelative(0.352f, 1.619f, -0.675f, 3.217f, -2.294f, 3.569f)
+      curveTo(41.427f, 56.978f, 41.212f, 57f, 41.001f, 57f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(23.004f, 56f)
+      curveToRelative(-0.451f, 0f, -0.909f, -0.102f, -1.339f, -0.317f)
+      curveToRelative(-1.482f, -0.741f, -2.083f, -2.543f, -1.341f, -4.025f)
+      lineTo(25.514f, 42f)
+      verticalLineToRelative(-9f)
+      curveToRelative(0.297f, -1.63f, 3.908f, -4.243f, 5.537f, -3.952f)
+      curveToRelative(1.63f, 0.296f, 2.711f, 1.858f, 2.415f, 3.488f)
+      lineToRelative(-2f, 11f)
+      curveToRelative(-0.051f, 0.28f, -0.141f, 0.551f, -0.269f, 0.805f)
+      lineToRelative(-5.508f, 10f)
+      curveTo(25.164f, 55.393f, 24.104f, 56f, 23.004f, 56f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF9C34C2))) {
+      moveTo(27.302f, 18.621f)
+      curveToRelative(0.268f, -2.089f, 2.063f, -3.645f, 4.168f, -3.611f)
+      curveToRelative(1.301f, 0.021f, 2.566f, 0.079f, 3.08f, 0.215f)
+      lineToRelative(0f, 0f)
+      curveToRelative(2.513f, 0.666f, 4.021f, 2.787f, 3.958f, 5.384f)
+      lineToRelative(-1.899f, 14.933f)
+      lineToRelative(-4.181f, 2.287f)
+      curveToRelative(-3.618f, 0.926f, -7.153f, -1.665f, -6.903f, -5.392f)
+      lineTo(27.302f, 18.621f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(30.345f, 15.164f)
+      curveToRelative(-1.587f, 0.423f, -2.824f, 1.755f, -3.043f, 3.456f)
+      lineToRelative(-1.776f, 13.816f)
+      curveToRelative(-0.038f, 0.914f, -0.019f, 1.751f, 0f, 2.579f)
+      curveToRelative(2.417f, -0.07f, 4.955f, -1.914f, 5.273f, -4.387f)
+      lineToRelative(1.404f, -10.927f)
+      curveTo(32.435f, 17.903f, 31.667f, 16.218f, 30.345f, 15.164f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFCE29))) {
+      moveTo(34.519f, 9f)
+      moveToRelative(-5f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 10f, 0f)
+      arcToRelative(5f, 5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -10f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(12.014f, 61f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 38f, 0f)
+      arcToRelative(19f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -38f, 0f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(43.218f, 56.016f)
+      curveToRelative(0.63f, -0.694f, 0.932f, -1.667f, 0.718f, -2.653f)
+      lineToRelative(-1.99f, -11.5f)
+      curveToRelative(-0.134f, -0.615f, -0.457f, -1.172f, -0.925f, -1.593f)
+      lineToRelative(-1.775f, -2.428f)
+      curveToRelative(-1.682f, 1.102f, -2.606f, 3.152f, -2.153f, 5.235f)
+      lineToRelative(1.451f, 9.019f)
+      curveTo(39.037f, 54.364f, 41.001f, 55.922f, 43.218f, 56.016f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFF98C900))) {
+      moveTo(23.104f, 31f)
+      horizontalLineToRelative(-4.101f)
+      curveToRelative(-1.8f, 0f, -2.978f, -1.652f, -2.978f, -3.362f)
+      curveToRelative(0f, -5.537f, 4.39f, -12.639f, 8.501f, -12.639f)
+      curveToRelative(1.822f, 0f, 3.226f, 1.616f, 2.969f, 3.422f)
+      lineToRelative(-1.421f, 10f)
+      curveTo(25.864f, 29.901f, 24.598f, 31f, 23.104f, 31f)
+      close()
+    }
+    path(
+      stroke = SolidColor(Color.White),
+      strokeLineWidth = 3f,
+      strokeLineCap = StrokeCap.Round,
+      strokeLineJoin = StrokeJoin.Round,
+    ) {
+      moveTo(30.461f, 20.534f)
+      lineTo(30.056f, 24.461f)
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Waterfall.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/theme/Waterfall.kt
@@ -1,0 +1,199 @@
+package app.campfire.common.compose.icons.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Theme.Waterfall: ImageVector by lazy(LazyThreadSafetyMode.PUBLICATION) {
+  ImageVector.Builder(
+    name = "Theme.Waterfall",
+    defaultWidth = 64.dp,
+    defaultHeight = 64.dp,
+    viewportWidth = 64f,
+    viewportHeight = 64f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFF008AA9))) {
+      moveTo(20f, 9f)
+      horizontalLineToRelative(25f)
+      verticalLineToRelative(31f)
+      horizontalLineToRelative(-25f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(12f, 61f)
+      arcToRelative(20f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, 40f, 0f)
+      arcToRelative(20f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = false, -40f, 0f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(23f, 48f)
+      horizontalLineTo(9f)
+      verticalLineTo(12f)
+      curveToRelative(0f, -1.657f, 1.343f, -3f, 3f, -3f)
+      horizontalLineToRelative(8f)
+      curveToRelative(1.657f, 0f, 3f, 1.343f, 3f, 3f)
+      verticalLineTo(48f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFFFA500))) {
+      moveTo(55f, 47f)
+      lineToRelative(-14f, 1f)
+      verticalLineTo(12f)
+      curveToRelative(0f, -1.657f, 1.343f, -3f, 3f, -3f)
+      horizontalLineToRelative(8f)
+      curveToRelative(1.657f, 0f, 3f, 1.343f, 3f, 3f)
+      verticalLineTo(47f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(24f, 36f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(19f, 37f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(45f, 37f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(28f, 35f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(36f, 35f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(32f, 37f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(32f, 33f)
+      moveToRelative(-4f, 0f)
+      arcToRelative(4f, 4f, 0f, isMoreThanHalf = true, isPositiveArc = true, 8f, 0f)
+      arcToRelative(4f, 4f, 0f, isMoreThanHalf = true, isPositiveArc = true, -8f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(40f, 36f)
+      moveToRelative(-3f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, 6f, 0f)
+      arcToRelative(3f, 3f, 0f, isMoreThanHalf = true, isPositiveArc = true, -6f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFF37D0EE))) {
+      moveTo(52.978f, 36f)
+      curveToRelative(-2.612f, 0f, -3.826f, 2f, -6.649f, 2f)
+      curveToRelative(-1.403f, 0f, -2.044f, -0.357f, -2.855f, -0.81f)
+      curveToRelative(-2.236f, -1.565f, -6.41f, -1.557f, -8.631f, 0f)
+      curveTo(34.002f, 37.659f, 33.393f, 37.998f, 32f, 38f)
+      curveToRelative(-1.393f, -0.002f, -2.002f, -0.341f, -2.842f, -0.809f)
+      curveToRelative(-2.231f, -1.562f, -6.399f, -1.562f, -8.631f, 0f)
+      curveTo(19.716f, 37.642f, 19.075f, 38f, 17.672f, 38f)
+      curveToRelative(-2.824f, 0f, -4.037f, -2f, -6.649f, -2f)
+      curveTo(8.924f, 35.999f, 9f, 38.084f, 9f, 38.084f)
+      lineTo(8.999f, 47f)
+      curveToRelative(0f, 2.209f, 1.791f, 4f, 4f, 4f)
+      lineToRelative(38f, 0.001f)
+      curveToRelative(2.209f, 0f, 4f, -1.791f, 4f, -4f)
+      lineTo(55f, 38.085f)
+      curveTo(55f, 38.085f, 55.076f, 36.001f, 52.978f, 36f)
+      close()
+    }
+    path(
+      fill = SolidColor(Color.Black),
+      fillAlpha = 0.15f,
+      strokeAlpha = 0.15f,
+    ) {
+      moveTo(50f, 35f)
+      lineToRelative(0f, 11f)
+      horizontalLineToRelative(-8f)
+      curveToRelative(-2.761f, 0f, -5f, 2.238f, -5f, 5f)
+      lineToRelative(13.999f, 0f)
+      curveToRelative(2.209f, 0f, 4f, -1.791f, 4f, -4f)
+      verticalLineTo(47f)
+      horizontalLineTo(55f)
+      verticalLineTo(30f)
+      curveTo(52.239f, 30f, 50f, 32.238f, 50f, 35f)
+      close()
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(26f, 28f)
+      moveToRelative(-1f, 0f)
+      arcToRelative(1f, 1f, 0f, isMoreThanHalf = true, isPositiveArc = true, 2f, 0f)
+      arcToRelative(1f, 1f, 0f, isMoreThanHalf = true, isPositiveArc = true, -2f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(48f, 32f)
+      moveToRelative(-1f, 0f)
+      arcToRelative(1f, 1f, 0f, isMoreThanHalf = true, isPositiveArc = true, 2f, 0f)
+      arcToRelative(1f, 1f, 0f, isMoreThanHalf = true, isPositiveArc = true, -2f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(15.5f, 31.5f)
+      moveToRelative(-1.5f, 0f)
+      arcToRelative(1.5f, 1.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 3f, 0f)
+      arcToRelative(1.5f, 1.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -3f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(37.5f, 27.5f)
+      moveToRelative(-1.5f, 0f)
+      arcToRelative(1.5f, 1.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, 3f, 0f)
+      arcToRelative(1.5f, 1.5f, 0f, isMoreThanHalf = true, isPositiveArc = true, -3f, 0f)
+    }
+    path(fill = SolidColor(Color(0xFFA0EFFE))) {
+      moveTo(33f, 43f)
+      moveToRelative(-2f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, 4f, 0f)
+      arcToRelative(2f, 2f, 0f, isMoreThanHalf = true, isPositiveArc = true, -4f, 0f)
+    }
+    path(
+      fill = SolidColor(Color.White),
+      fillAlpha = 0.3f,
+      strokeAlpha = 0.3f,
+    ) {
+      moveTo(14f, 24f)
+      verticalLineTo(14f)
+      horizontalLineToRelative(8f)
+      curveToRelative(2.761f, 0f, 5f, -2.238f, 5f, -5f)
+      horizontalLineToRelative(-7f)
+      horizontalLineToRelative(-8f)
+      curveToRelative(-1.657f, 0f, -3f, 1.343f, -3f, 3f)
+      verticalLineToRelative(17f)
+      curveTo(11.761f, 29f, 14f, 26.762f, 14f, 24f)
+      close()
+    }
+    path(fill = SolidColor(Color.White)) {
+      moveTo(12.5f, 18f)
+      curveToRelative(-0.829f, 0f, -1.5f, -0.672f, -1.5f, -1.5f)
+      verticalLineToRelative(-4f)
+      curveToRelative(0f, -0.828f, 0.671f, -1.5f, 1.5f, -1.5f)
+      horizontalLineToRelative(4f)
+      curveToRelative(0.829f, 0f, 1.5f, 0.672f, 1.5f, 1.5f)
+      reflectiveCurveTo(17.329f, 14f, 16.5f, 14f)
+      horizontalLineTo(14f)
+      verticalLineToRelative(2.5f)
+      curveTo(14f, 17.328f, 13.329f, 18f, 12.5f, 18f)
+      close()
+    }
+  }.build()
+}

--- a/ui/theming/api/src/commonMain/kotlin/app/campfire/ui/theming/api/AppTheme.kt
+++ b/ui/theming/api/src/commonMain/kotlin/app/campfire/ui/theming/api/AppTheme.kt
@@ -7,12 +7,49 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.theme.Airplane
+import app.campfire.common.compose.icons.theme.Axe
+import app.campfire.common.compose.icons.theme.BeachUmbrella
+import app.campfire.common.compose.icons.theme.Bicycle
+import app.campfire.common.compose.icons.theme.Binoculars
+import app.campfire.common.compose.icons.theme.Cactus
+import app.campfire.common.compose.icons.theme.Camera
+import app.campfire.common.compose.icons.theme.Camper
+import app.campfire.common.compose.icons.theme.Campfire
+import app.campfire.common.compose.icons.theme.Cloud
+import app.campfire.common.compose.icons.theme.Compass
+import app.campfire.common.compose.icons.theme.CrescentMoon
+import app.campfire.common.compose.icons.theme.Deer
+import app.campfire.common.compose.icons.theme.Dinghy
+import app.campfire.common.compose.icons.theme.Evergreen
+import app.campfire.common.compose.icons.theme.Fishing
+import app.campfire.common.compose.icons.theme.Flashlight
 import app.campfire.common.compose.icons.theme.Forest
+import app.campfire.common.compose.icons.theme.Globe
+import app.campfire.common.compose.icons.theme.HotAirBalloon
+import app.campfire.common.compose.icons.theme.Lake
+import app.campfire.common.compose.icons.theme.Lantern
 import app.campfire.common.compose.icons.theme.LifeFloat
+import app.campfire.common.compose.icons.theme.LogCabin
+import app.campfire.common.compose.icons.theme.MapleLeaf
 import app.campfire.common.compose.icons.theme.Mountain
+import app.campfire.common.compose.icons.theme.Mushroom
+import app.campfire.common.compose.icons.theme.Night
+import app.campfire.common.compose.icons.theme.Owl
+import app.campfire.common.compose.icons.theme.PaperMap
+import app.campfire.common.compose.icons.theme.ParkBench
 import app.campfire.common.compose.icons.theme.Rucksack
+import app.campfire.common.compose.icons.theme.SailBoat
+import app.campfire.common.compose.icons.theme.SleepingBag
+import app.campfire.common.compose.icons.theme.Snowflake
+import app.campfire.common.compose.icons.theme.Star
+import app.campfire.common.compose.icons.theme.Suitcase
+import app.campfire.common.compose.icons.theme.Sun
 import app.campfire.common.compose.icons.theme.Tent
+import app.campfire.common.compose.icons.theme.Train
+import app.campfire.common.compose.icons.theme.Trekking
 import app.campfire.common.compose.icons.theme.WaterBottle
+import app.campfire.common.compose.icons.theme.Waterfall
 import app.campfire.common.compose.icons.theme.rememberWallVectorPainter
 import app.campfire.common.compose.theme.ColorPalette
 import app.campfire.common.compose.theme.LocalUseDarkColors
@@ -65,6 +102,43 @@ sealed interface AppTheme {
     Forest(icon = { CampfireIcons.Theme.Forest }),
     Mountain(icon = { CampfireIcons.Theme.Mountain }),
     LifeFloat(icon = { CampfireIcons.Theme.LifeFloat }),
+    Campfire(icon = { CampfireIcons.Theme.Campfire }),
+    Compass(icon = { CampfireIcons.Theme.Compass }),
+    Binoculars(icon = { CampfireIcons.Theme.Binoculars }),
+    Lantern(icon = { CampfireIcons.Theme.Lantern }),
+    PaperMap(icon = { CampfireIcons.Theme.PaperMap }),
+    Axe(icon = { CampfireIcons.Theme.Axe }),
+    SleepingBag(icon = { CampfireIcons.Theme.SleepingBag }),
+    Evergreen(icon = { CampfireIcons.Theme.Evergreen }),
+    Suitcase(icon = { CampfireIcons.Theme.Suitcase }),
+    LogCabin(icon = { CampfireIcons.Theme.LogCabin }),
+    Dinghy(icon = { CampfireIcons.Theme.Dinghy }),
+    Fishing(icon = { CampfireIcons.Theme.Fishing }),
+    HotAirBalloon(icon = { CampfireIcons.Theme.HotAirBalloon }),
+    Airplane(icon = { CampfireIcons.Theme.Airplane }),
+    Camera(icon = { CampfireIcons.Theme.Camera }),
+    Flashlight(icon = { CampfireIcons.Theme.Flashlight }),
+    Waterfall(icon = { CampfireIcons.Theme.Waterfall }),
+    Camper(icon = { CampfireIcons.Theme.Camper }),
+    Trekking(icon = { CampfireIcons.Theme.Trekking }),
+    Sun(icon = { CampfireIcons.Theme.Sun }),
+    CrescentMoon(icon = { CampfireIcons.Theme.CrescentMoon }),
+    SailBoat(icon = { CampfireIcons.Theme.SailBoat }),
+    Globe(icon = { CampfireIcons.Theme.Globe }),
+    MapleLeaf(icon = { CampfireIcons.Theme.MapleLeaf }),
+    Snowflake(icon = { CampfireIcons.Theme.Snowflake }),
+    Lake(icon = { CampfireIcons.Theme.Lake }),
+    ParkBench(icon = { CampfireIcons.Theme.ParkBench }),
+    Cactus(icon = { CampfireIcons.Theme.Cactus }),
+    Mushroom(icon = { CampfireIcons.Theme.Mushroom }),
+    Cloud(icon = { CampfireIcons.Theme.Cloud }),
+    Star(icon = { CampfireIcons.Theme.Star }),
+    Bicycle(icon = { CampfireIcons.Theme.Bicycle }),
+    Train(icon = { CampfireIcons.Theme.Train }),
+    BeachUmbrella(icon = { CampfireIcons.Theme.BeachUmbrella }),
+    Deer(icon = { CampfireIcons.Theme.Deer }),
+    Owl(icon = { CampfireIcons.Theme.Owl }),
+    Night(icon = { CampfireIcons.Theme.Night }),
   }
 }
 

--- a/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/builder/composables/IconPicker.kt
+++ b/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/builder/composables/IconPicker.kt
@@ -2,27 +2,32 @@ package app.campfire.ui.theming.ui.builder.composables
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import app.campfire.common.compose.extensions.thenIf
 import app.campfire.common.compose.icons.icon
 import app.campfire.ui.theming.api.AppTheme
 
 internal val IconSize = 48.dp
+private const val ColumnCount = 5
+private val IconSpacing = 8.dp
+private val GridPadding = 8.dp
+private val GridWidth = IconSize * ColumnCount + IconSpacing * (ColumnCount - 1) + GridPadding * 2
 
 @Composable
 internal fun IconPicker(
@@ -48,29 +53,30 @@ internal fun IconPicker(
     DropdownMenu(
       expanded = isExpanded,
       onDismissRequest = { isExpanded = false },
-      offset = DpOffset((-8).dp, -(IconSize + 8.dp)),
-      containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-      modifier = Modifier.padding(
-        horizontal = 8.dp,
-      ),
+      offset = DpOffset(-GridPadding, -(IconSize + GridPadding)),
+      containerColor = MaterialTheme.colorScheme.surfaceContainer,
+      shape = MaterialTheme.shapes.medium,
     ) {
-      AppTheme.Icon.entries.forEachIndexed { index, ico ->
-        Image(
-          ico.icon(),
-          contentDescription = null,
-          modifier = Modifier
-            .thenIf(index == 0) { padding(bottom = 4.dp) }
-            .thenIf(index == AppTheme.Icon.entries.lastIndex) { padding(top = 4.dp) }
-            .thenIf(index > 0 && index < AppTheme.Icon.entries.lastIndex) {
-              padding(vertical = 4.dp)
-            }
-            .clip(RoundedCornerShape(8.dp))
-            .size(IconSize)
-            .clickable {
-              onIconClick(ico)
-              isExpanded = false
-            },
-        )
+      FlowRow(
+        maxItemsInEachRow = ColumnCount,
+        horizontalArrangement = Arrangement.spacedBy(IconSpacing, Alignment.CenterHorizontally),
+        verticalArrangement = Arrangement.spacedBy(IconSpacing),
+        modifier = Modifier
+          .width(GridWidth),
+      ) {
+        AppTheme.Icon.entries.forEach { ico ->
+          Image(
+            ico.icon(),
+            contentDescription = null,
+            modifier = Modifier
+              .clip(RoundedCornerShape(8.dp))
+              .clickable {
+                onIconClick(ico)
+                isExpanded = false
+              }
+              .size(IconSize),
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds 37 new Icons8 Arcade-style ImageVectors under `CampfireIcons.Theme.*` (camping/nature/travel) and wires each into `AppTheme.Icon`, which both OOTB `AppTheme.Fixed` themes and user-built `AppTheme.Fixed.Custom` themes select from.
- Replaces the theme-builder `IconPicker` dropdown's tall single column with a 5-wide `FlowRow` grid (`IconPicker.kt`) so the now-43-entry list isn't a long scroll.
- Adds `.claude/skills/add-theme-icons/SKILL.md` documenting the Valkyrie + Icons8 MCP workflow used to generate the icons (incl. the `--trailing-comma=true` and `LazyThreadSafetyMode.PUBLICATION` post-process steps).

<img width="298" height="591" alt="Screenshot 2026-04-24 at 9 08 30 PM" src="https://github.com/user-attachments/assets/3e37dfb5-efe5-403d-94ed-89e2e43007ad" />



## Test plan
- [ ] Open the theme builder, tap the icon swatch — confirm the grid popup renders 5-wide with even spacing, last row centered, and tapping an icon updates the selection + dismisses.
- [ ] Verify the popup doesn't clip when the swatch is near the right edge of the screen.
- [ ] Spot-check a handful of new icons render at expected size with correct Arcade colors (no monochrome tinting).
- [ ] `./scripts/ktlint --check` and `./gradlew :common:compose:compileKotlinIosSimulatorArm64 :ui:theming:api:compileKotlinIosSimulatorArm64` pass locally — CI to confirm Android + Desktop targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)