### PR TITLE
Expose cover art to Android Auto and Media notification via ContentProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setting to disable marquee scrolling on library item cards
 - Android Auto settings pane: toggle, reorder, and choose list/grid layout per top-level category
 - 37 new theme icons (camping/nature/travel) selectable when building a custom theme
+- Cover art now renders in the Media playback notification, on the lockscreen, and in Android Auto browsable items via a new `ContentProvider` that bridges the authenticated Audiobookshelf endpoints to system processes
 
 ### Changed
 

--- a/app/common/src/commonMain/kotlin/app/campfire/common/image/CoilAppInitializer.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/image/CoilAppInitializer.kt
@@ -1,28 +1,20 @@
 package app.campfire.common.image
 
-import app.campfire.account.api.AccountManager
-import app.campfire.account.api.UserSessionManager
 import app.campfire.core.app.AppInitializer
 import app.campfire.core.di.AppScope
-import app.campfire.core.session.userId
-import app.campfire.network.asBearerTokens
-import app.campfire.network.plugins.suspendingDefaultHeaders
+import app.campfire.network.di.UserClient
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
 import com.r0adkll.kimchi.annotations.ContributesMultibinding
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.auth.Auth
-import io.ktor.client.plugins.auth.providers.bearer
-import io.ktor.client.request.header
 import me.tatarka.inject.annotations.Inject
 
 @ContributesMultibinding(AppScope::class)
 @Inject
 class CoilAppInitializer(
-  private val userSessionManager: UserSessionManager,
-  private val accountManager: AccountManager,
+  @UserClient private val httpClient: Lazy<HttpClient>,
 ) : AppInitializer {
 
   override val priority: Int = AppInitializer.HIGHEST_PRIORITY
@@ -35,32 +27,12 @@ class CoilAppInitializer(
           add(
             KtorNetworkFetcherFactory(
               httpClient = {
-                authenticatingHttpClient()
+                httpClient.value
               },
             ),
           )
         }
         .build()
-    }
-  }
-
-  private fun authenticatingHttpClient(): HttpClient = HttpClient {
-    install(Auth) {
-      bearer {
-        loadTokens {
-          userSessionManager.current.userId?.let { userId ->
-            accountManager.getToken(userId)?.asBearerTokens()
-          }
-        }
-        sendWithoutRequest { true }
-      }
-    }
-
-    suspendingDefaultHeaders {
-      userSessionManager.current.userId?.let { userId ->
-        val extraHeaders = accountManager.getExtraHeaders(userId)
-        extraHeaders?.forEach { (name, value) -> header(name, value) }
-      }
     }
   }
 }

--- a/infra/audioplayer/impl/build.gradle.kts
+++ b/infra/audioplayer/impl/build.gradle.kts
@@ -73,6 +73,7 @@ kotlin {
         implementation(libs.androidx.lifecycle.runtime)
         implementation(libs.androidx.activity.compose)
         implementation(libs.kotlinx.coroutines.guava)
+        implementation(libs.coil)
       }
     }
 

--- a/infra/audioplayer/impl/src/androidMain/AndroidManifest.xml
+++ b/infra/audioplayer/impl/src/androidMain/AndroidManifest.xml
@@ -52,5 +52,13 @@
       android:value="app.campfire.audioplayer.impl.cast.CastOptionsProvider"
       />
 
+    <provider
+      android:name="app.campfire.audioplayer.impl.content.CoverContentProvider"
+      android:authorities="${applicationId}.covers"
+      android:exported="true"
+      android:grantUriPermissions="true">
+      <grant-uri-permission android:pathPattern="/.*" />
+    </provider>
+
   </application>
 </manifest>

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -200,7 +200,7 @@ class ExoPlayerAudioPlayer(
     finishedListener = onFinished
     state.value = AudioPlayer.State.Initializing
 
-    val mediaItems = MediaItemBuilder.build(session).asPlatformMediaItems()
+    val mediaItems = MediaItemBuilder.build(session).asPlatformMediaItems(context)
 
     ibark {
       """

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaItemBuilder.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaItemBuilder.kt
@@ -1,5 +1,6 @@
 package app.campfire.audioplayer.impl
 
+import android.content.Context
 import androidx.annotation.OptIn
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem as PlatformMediaItem
@@ -7,15 +8,19 @@ import androidx.media3.common.MediaItem.ClippingConfiguration
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER
 import androidx.media3.common.util.UnstableApi
+import app.campfire.audioplayer.impl.content.coverContentUriForItem
 import app.campfire.audioplayer.impl.mediaitem.MediaItem
 
 /**
  * Convert our common [MediaItem] data class/holder into the Android
  * Media3 Platform version to be consumed by the likes of an [androidx.media3.exoplayer.ExoPlayer]
  * instance.
+ *
+ * The [context] is required so artwork can be exposed via the cover [android.content.ContentProvider]
+ * which the Android Auto host process and the system Media notification can read across processes.
  */
 @OptIn(UnstableApi::class)
-fun MediaItem.asPlatformMediaItem(): PlatformMediaItem {
+fun MediaItem.asPlatformMediaItem(context: Context): PlatformMediaItem {
   return PlatformMediaItem.Builder()
     .setMediaId(id)
     .setUri(uri)
@@ -34,6 +39,9 @@ fun MediaItem.asPlatformMediaItem(): PlatformMediaItem {
       }
 
       if (metadata != null) {
+        val artworkUri = metadata.libraryItemId
+          ?.let { coverContentUriForItem(context, it) }
+          ?: metadata.artworkUri?.toUri()
         setMediaMetadata(
           MediaMetadata.Builder()
             .setTitle(metadata.title)
@@ -42,7 +50,7 @@ fun MediaItem.asPlatformMediaItem(): PlatformMediaItem {
             .setDescription(metadata.description)
             .setSubtitle(metadata.subtitle)
             .setAlbumTitle(metadata.albumTitle)
-            .setArtworkUri(metadata.artworkUri?.toUri())
+            .setArtworkUri(artworkUri)
             .setDurationMs(metadata.durationMs)
             .build(),
         )
@@ -51,4 +59,5 @@ fun MediaItem.asPlatformMediaItem(): PlatformMediaItem {
     .build()
 }
 
-fun List<MediaItem>.asPlatformMediaItems(): List<PlatformMediaItem> = map { it.asPlatformMediaItem() }
+fun List<MediaItem>.asPlatformMediaItems(context: Context): List<PlatformMediaItem> =
+  map { it.asPlatformMediaItem(context) }

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
@@ -5,12 +5,13 @@ import android.content.Context
 import android.os.Bundle
 import androidx.annotation.OptIn
 import androidx.annotation.StringRes
-import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaConstants
 import app.campfire.audioplayer.impl.asPlatformMediaItem
+import app.campfire.audioplayer.impl.content.coverContentUriForAuthor
+import app.campfire.audioplayer.impl.content.coverContentUriForItem
 import app.campfire.audioplayer.impl.mediaitem.MediaItemBuilder
 import app.campfire.audioplayer.offline.OfflineDownload
 import app.campfire.audioplayer.offline.OfflineDownloadManager
@@ -112,7 +113,7 @@ class MediaTree(
   suspend fun resolveMediaItem(libraryItemId: LibraryItemId): List<MediaItem> {
     return try {
       val item = libraryItemRepository.getLibraryItem(libraryItemId)
-      MediaItemBuilder.build(item).map { it.asPlatformMediaItem() }
+      MediaItemBuilder.build(item).map { it.asPlatformMediaItem(application) }
     } catch (e: Throwable) {
       bark(LogPriority.ERROR, throwable = e) {
         "Unable to find item for ${libraryItemId.loggableId}"
@@ -285,7 +286,7 @@ class MediaTree(
       MediaMetadata.Builder()
         .setTitle(media.metadata.title)
         .setArtist(media.metadata.authorName)
-        .setArtworkUri(media.coverImageUrl.toUri())
+        .setArtworkUri(coverContentUriForItem(application, id))
         .setDescription(media.metadata.description)
         .setDurationMs(media.durationInMillis)
         .setGenre(media.metadata.genres.firstOrNull())
@@ -339,7 +340,8 @@ class MediaTree(
           books
             ?.sortedBy { it.media.metadata.seriesSequence?.id }
             ?.firstOrNull()
-            ?.media?.coverImageUrl?.toUri(),
+            ?.id
+            ?.let { coverContentUriForItem(application, it) },
         )
         .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS)
         .setIsBrowsable(true)
@@ -361,7 +363,7 @@ class MediaTree(
       MediaMetadata.Builder()
         .setTitle(name)
         .setDescription(description)
-        .setArtworkUri(books.firstOrNull()?.media?.coverImageUrl?.toUri())
+        .setArtworkUri(books.firstOrNull()?.id?.let { coverContentUriForItem(application, it) })
         .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS)
         .setIsBrowsable(true)
         .setIsPlayable(false)
@@ -375,7 +377,9 @@ class MediaTree(
       MediaMetadata.Builder()
         .setTitle(name)
         .setDescription(description)
-        .setArtworkUri(items.firstOrNull()?.libraryItem?.media?.coverImageUrl?.toUri())
+        .setArtworkUri(
+          items.firstOrNull()?.libraryItem?.id?.let { coverContentUriForItem(application, it) },
+        )
         .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS)
         .setIsBrowsable(true)
         .setIsPlayable(false)
@@ -392,7 +396,7 @@ class MediaTree(
       MediaMetadata.Builder()
         .setTitle(name)
         .setDescription(description)
-        .setArtworkUri(imagePath?.toUri())
+        .setArtworkUri(imagePath?.let { coverContentUriForAuthor(application, id) })
         .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS)
         .setIsBrowsable(true)
         .setIsPlayable(false)

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/content/CoverContentProvider.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/content/CoverContentProvider.kt
@@ -1,0 +1,104 @@
+package app.campfire.audioplayer.impl.content
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import app.campfire.account.api.UrlHydrator
+import app.campfire.core.di.ComponentHolder
+import app.campfire.core.logging.Corked
+import app.campfire.core.logging.LogPriority
+import app.campfire.core.logging.bark
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import java.io.FileNotFoundException
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+
+class CoverContentProvider : ContentProvider() {
+
+  override fun onCreate(): Boolean = true
+
+  override fun getType(uri: Uri): String = "image/*"
+
+  override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor {
+    if (mode != "r") {
+      throw SecurityException("CoverContentProvider only supports read mode, got '$mode' for $uri")
+    }
+
+    val ctx = context
+      ?: throw FileNotFoundException("ContentProvider has no context")
+    val url = resolveRemoteUrl(uri)
+      ?: throw FileNotFoundException("Unable to resolve remote URL for $uri")
+
+    val loader = ctx.imageLoader
+    val cache = loader.diskCache
+      ?: throw FileNotFoundException("Coil disk cache is not configured")
+
+    cache.openSnapshot(url)?.use { snapshot ->
+      dbark { "Cover snapshot for $url found" }
+      return ParcelFileDescriptor.open(snapshot.data.toFile(), ParcelFileDescriptor.MODE_READ_ONLY)
+    }
+
+    return runBlocking {
+      dbark { "Requesting cover snapshot for $url" }
+      val warmed = withTimeoutOrNull(CoverFetchTimeout) {
+        loader.execute(
+          ImageRequest.Builder(ctx)
+            .data(url)
+            .build()
+        )
+      }
+      if (warmed == null) {
+        wbark { "Timeout warming cover for $uri" }
+        throw FileNotFoundException("Timed out fetching cover for $uri")
+      }
+      cache.openSnapshot(url)?.use { snapshot ->
+        ParcelFileDescriptor.open(snapshot.data.toFile(), ParcelFileDescriptor.MODE_READ_ONLY)
+      } ?: throw FileNotFoundException("Cover not present in cache after fetch for $uri")
+    }
+  }
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?,
+  ): Cursor? = null
+
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+
+  override fun delete(
+    uri: Uri,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+
+  private fun resolveRemoteUrl(uri: Uri): String? {
+    val hydrator = ComponentHolder.maybeComponent<CoverContentUserComponent>()?.urlHydrator
+      ?: return null
+    val type = uri.pathSegments.getOrNull(0) ?: return null
+    val id = uri.pathSegments.getOrNull(1) ?: return null
+    return runCatching { hydrator.hydrate(type, id) }.getOrNull()
+  }
+
+  private fun UrlHydrator.hydrate(type: String, id: String): String? = when (type) {
+    PATH_ITEMS -> hydrateLibraryItem(id)
+    PATH_AUTHORS -> hydrateAuthor(id)
+    else -> null
+  }
+
+  private companion object : Corked("CoverContentProvider") {
+    val CoverFetchTimeout = 8.seconds
+  }
+}

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/content/CoverContentProvider.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/content/CoverContentProvider.kt
@@ -8,8 +8,6 @@ import android.os.ParcelFileDescriptor
 import app.campfire.account.api.UrlHydrator
 import app.campfire.core.di.ComponentHolder
 import app.campfire.core.logging.Corked
-import app.campfire.core.logging.LogPriority
-import app.campfire.core.logging.bark
 import coil3.imageLoader
 import coil3.request.ImageRequest
 import java.io.FileNotFoundException
@@ -48,7 +46,7 @@ class CoverContentProvider : ContentProvider() {
         loader.execute(
           ImageRequest.Builder(ctx)
             .data(url)
-            .build()
+            .build(),
         )
       }
       if (warmed == null) {

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/content/CoverContentUri.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/content/CoverContentUri.kt
@@ -1,0 +1,17 @@
+package app.campfire.audioplayer.impl.content
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+
+internal const val COVER_AUTHORITY_SUFFIX = ".covers"
+internal const val PATH_ITEMS = "items"
+internal const val PATH_AUTHORS = "authors"
+
+fun coverContentUriForItem(context: Context, libraryItemId: String): Uri {
+  return "content://${context.packageName}$COVER_AUTHORITY_SUFFIX/$PATH_ITEMS/$libraryItemId".toUri()
+}
+
+fun coverContentUriForAuthor(context: Context, authorId: String): Uri {
+  return "content://${context.packageName}$COVER_AUTHORITY_SUFFIX/$PATH_AUTHORS/$authorId".toUri()
+}

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/content/CoverContentUserComponent.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/content/CoverContentUserComponent.kt
@@ -1,0 +1,10 @@
+package app.campfire.audioplayer.impl.content
+
+import app.campfire.account.api.UrlHydrator
+import app.campfire.core.di.UserScope
+import com.r0adkll.kimchi.annotations.ContributesTo
+
+@ContributesTo(UserScope::class)
+interface CoverContentUserComponent {
+  val urlHydrator: UrlHydrator
+}

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItem.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItem.kt
@@ -25,6 +25,7 @@ data class MediaItem(
     val albumTitle: String?,
     val artworkUri: String?,
     val durationMs: Long?,
+    val libraryItemId: String? = null,
     val extras: Map<String, String>? = null,
   )
 }

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItemBuilder.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItemBuilder.kt
@@ -25,7 +25,7 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
     // items from its audio tracks.
     if (chapters.isEmpty()) {
       return audioTracks.map { track ->
-        createMediaItem(track, media)
+        createMediaItem(track, media, id)
       }
     }
 
@@ -34,7 +34,7 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
     if (chapters.size == audioTracks.size) {
       return audioTracks.mapIndexed { index, track ->
         val chapter = chapters[index]
-        createMediaItem(chapter, track, false, media)
+        createMediaItem(chapter, track, false, media, id)
       }
     }
 
@@ -67,8 +67,8 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
 
       // Regardless of state, slice the track to the chapters and let the user
       // see our error UI to correct the playback of this item
-      return@with chaptersForTrack.map { chapter ->
-        createMediaItem(chapter, track, true, media)
+      return chaptersForTrack.map { chapter ->
+        createMediaItem(chapter, track, true, media, id)
       }
     }
 
@@ -94,18 +94,18 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
           // If the chapter fail to fully cover the track, then just return the track and let the user fix
           // their item on the server
           recordMediaItemException("Remaining track after last chapter is too long", item)
-          listOf(createMediaItem(track, media))
+          listOf(createMediaItem(track, media, id))
         } else {
           // For each chapter filter to this track, cut a media item for each
           chaptersForTrack.map { chapter ->
-            createMediaItem(chapter, track, true, media)
+            createMediaItem(chapter, track, true, media, id)
           }
         }
       } else {
         // Otherwise, if we are unable to associate chapter data to this track,
         // just create a media item of just the track. This way we ensure playback occurs
         recordMediaItemException("Unable to find any chapters for the track[${track.index}]", item)
-        listOf(createMediaItem(track, media))
+        listOf(createMediaItem(track, media, id))
       }
     }
   }
@@ -126,6 +126,7 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
     track: AudioTrack,
     clipAudio: Boolean,
     media: Media,
+    libraryItemId: String,
   ): MediaItem {
     return MediaItem(
       id = "${media.id}_${chapter.id}",
@@ -147,25 +148,27 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
       } else {
         null
       },
-      metadata = createMediaMetadata(chapter, media),
+      metadata = createMediaMetadata(chapter, media, libraryItemId),
     )
   }
 
   private fun createMediaItem(
     track: AudioTrack,
     media: Media,
+    libraryItemId: String,
   ): MediaItem {
     return MediaItem(
       id = "${media.id}_${track.index}",
       uri = track.contentUrl,
       mimeType = track.mimeType,
-      metadata = createMediaMetadata(track, media),
+      metadata = createMediaMetadata(track, media, libraryItemId),
     )
   }
 
   internal fun createMediaMetadata(
     chapter: Chapter,
     media: Media,
+    libraryItemId: String,
   ): MediaItem.Metadata {
     return MediaItem.Metadata(
       id = chapter.id,
@@ -176,12 +179,14 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
       albumTitle = media.metadata.title,
       artworkUri = media.coverImageUrl,
       durationMs = chapter.duration.inWholeMilliseconds,
+      libraryItemId = libraryItemId,
     )
   }
 
   internal fun createMediaMetadata(
     track: AudioTrack,
     media: Media,
+    libraryItemId: String,
   ): MediaItem.Metadata {
     return MediaItem.Metadata(
       id = track.index,
@@ -192,6 +197,7 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
       albumTitle = media.metadata.title,
       artworkUri = media.coverImageUrl,
       durationMs = track.duration.seconds.inWholeMilliseconds,
+      libraryItemId = libraryItemId,
     )
   }
 

--- a/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItemBuilderTest.kt
+++ b/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItemBuilderTest.kt
@@ -175,6 +175,7 @@ class MediaItemBuilderTest {
     assertThat(m.description).isEqualTo("Desc")
     assertThat(m.albumTitle).isEqualTo("Book X")
     assertThat(m.durationMs).isEqualTo(60.seconds.inWholeMilliseconds)
+    assertThat(m.libraryItemId).isEqualTo("item-1")
   }
 
   // endregion
@@ -549,7 +550,7 @@ class MediaItemBuilderTest {
       ),
     )
 
-    val result = MediaItemBuilder.createMediaMetadata(ch, med)
+    val result = MediaItemBuilder.createMediaMetadata(ch, med, libraryItemId = "item-7")
 
     assertThat(result.id).isEqualTo(3)
     assertThat(result.title).isEqualTo("The Beginning")
@@ -559,6 +560,7 @@ class MediaItemBuilderTest {
     assertThat(result.albumTitle).isEqualTo("Title")
     assertThat(result.artworkUri).isEqualTo("/cover.png")
     assertThat(result.durationMs).isEqualTo(60.seconds.inWholeMilliseconds)
+    assertThat(result.libraryItemId).isEqualTo("item-7")
   }
 
   @Test
@@ -566,7 +568,7 @@ class MediaItemBuilderTest {
     val ch = chapter(id = 0, start = 0f, end = 10f)
     val med = media(metadata = metadata(description = null))
 
-    val result = MediaItemBuilder.createMediaMetadata(ch, med)
+    val result = MediaItemBuilder.createMediaMetadata(ch, med, libraryItemId = "item-1")
 
     assertThat(result.description).isEqualTo("")
   }
@@ -588,7 +590,7 @@ class MediaItemBuilderTest {
       ),
     )
 
-    val result = MediaItemBuilder.createMediaMetadata(tr, med)
+    val result = MediaItemBuilder.createMediaMetadata(tr, med, libraryItemId = "item-9")
 
     assertThat(result.id).isEqualTo(2)
     assertThat(result.title).isEqualTo("Track Title")
@@ -598,6 +600,7 @@ class MediaItemBuilderTest {
     assertThat(result.albumTitle).isEqualTo("Saga")
     assertThat(result.artworkUri).isEqualTo("/art.jpg")
     assertThat(result.durationMs).isEqualTo(120.seconds.inWholeMilliseconds)
+    assertThat(result.libraryItemId).isEqualTo("item-9")
   }
 
   @Test
@@ -605,7 +608,7 @@ class MediaItemBuilderTest {
     val tr = track(index = 0, title = "Fallback Title", tagTitle = "Tagged Title")
     val med = media()
 
-    val result = MediaItemBuilder.createMediaMetadata(tr, med)
+    val result = MediaItemBuilder.createMediaMetadata(tr, med, libraryItemId = "item-1")
 
     assertThat(result.title).isEqualTo("Tagged Title")
   }
@@ -615,7 +618,7 @@ class MediaItemBuilderTest {
     val tr = track(index = 0, title = "Fallback Title", tagTitle = null)
     val med = media()
 
-    val result = MediaItemBuilder.createMediaMetadata(tr, med)
+    val result = MediaItemBuilder.createMediaMetadata(tr, med, libraryItemId = "item-1")
 
     assertThat(result.title).isEqualTo("Fallback Title")
   }
@@ -625,7 +628,7 @@ class MediaItemBuilderTest {
     val tr = track(index = 0, duration = 10f)
     val med = media(metadata = metadata(description = null))
 
-    val result = MediaItemBuilder.createMediaMetadata(tr, med)
+    val result = MediaItemBuilder.createMediaMetadata(tr, med, libraryItemId = "item-1")
 
     assertThat(result.description).isEqualTo("")
   }

--- a/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/mediaitem/IosMediaItemBuilder.kt
+++ b/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/mediaitem/IosMediaItemBuilder.kt
@@ -30,7 +30,7 @@ object IosMediaItemBuilder {
           id = chapter.id,
           startMs = chapter.start.seconds.inWholeMilliseconds,
           endMs = chapter.end.seconds.inWholeMilliseconds,
-          metadata = MediaItemBuilder.createMediaMetadata(chapter, media),
+          metadata = MediaItemBuilder.createMediaMetadata(chapter, media, id),
         )
       } else {
         val audioFileRange = audio.startOffset.seconds..(audio.startOffset + audio.duration).seconds
@@ -41,7 +41,7 @@ object IosMediaItemBuilder {
               id = chapter.id,
               startMs = chapter.start.seconds.inWholeMilliseconds,
               endMs = chapter.end.seconds.inWholeMilliseconds,
-              metadata = MediaItemBuilder.createMediaMetadata(chapter, media),
+              metadata = MediaItemBuilder.createMediaMetadata(chapter, media, id),
             )
           }
         }


### PR DESCRIPTION
## Summary

- New `CoverContentProvider` exposes book and author covers to other Android processes via `content://${applicationId}.covers/items/{libraryItemId}` and `.../authors/{authorId}` URIs, so cover art renders in the Media playback notification, lockscreen, and Android Auto browsable items
- `MediaTree` and `MediaItemBuilder` now emit those `content://` URIs for `setArtworkUri(...)` instead of HTTPS endpoints the system loader can't authenticate against
- Refactors `CoilAppInitializer` to use the shared `@UserClient HttpClient` so the in-app loader and the provider share a single auth pipeline + disk cache

## Implementation notes

- `MediaItem.Metadata` (commonMain) gains an optional `libraryItemId: String?`; `MediaItemBuilder.build(item)` threads `item.id` through. Android's `asPlatformMediaItem(context)` uses it to build the content URI and falls back to `artworkUri` for non-Android platforms.
- `CoverContentProvider.openFile`:
  - Rejects non-`r` modes with `SecurityException`
  - Tries Coil's disk cache snapshot first (no I/O beyond a stat) and returns a `ParcelFileDescriptor` against the underlying file
  - On miss, runs a single `imageLoader.execute(...)` inside `runBlocking { withTimeoutOrNull(8.seconds) { ... } }` to populate the cache, then re-snapshots
  - The PFD survives Coil cache eviction because Linux keeps the inode alive while the fd is open
- Manifest registers the provider with `exported="true"`, `grantUriPermissions="true"`, and `<grant-uri-permission android:pathPattern="/.*" />` for Android Auto host compatibility
- `UrlHydrator` is reached cross-process via `ComponentHolder.maybeComponent<CoverContentUserComponent>()`, which returns null safely when the user is logged out — provider then throws `FileNotFoundException` and consumers render placeholders

## Test plan

- [x] `./scripts/ktlint --check`
- [x] `./gradlew :infra:audioplayer:impl:jvmTest` (existing builder tests + new `libraryItemId` assertions)
- [x] `./gradlew :app:android:assembleAlphaRelease` (confirms manifest merge + `Context` plumbing)
- [x] Verified merged manifest contains the provider with the resolved authority `app.campfire.android.alpha.covers`
- [ ] Install alpha on device, play a book, confirm cover art renders on the notification + lockscreen
- [ ] Connect Android Auto (DHU works) and confirm covers render across Home / Series / Authors / Playlists / Collections / Downloads browsable items
- [ ] Force-stop the app, open Auto without launching first — confirm covers eventually load (or fall back to placeholder gracefully) without ANR

🤖 Generated with [Claude Code](https://claude.com/claude-code)