### PR TITLE
Make Android CI work for fork PRs

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   android-release:
     name: Build Android Release
+    # Skip on fork PRs — this workflow needs first-party secrets (keystore, Firebase, Mixpanel).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -49,27 +51,15 @@ jobs:
         env:
           ENCODED_KEYSTORE: ${{ secrets.CAMPFIRE_KEYSTORE }}
         run: |
-          if [ -n "$ENCODED_KEYSTORE" ]; then
-            echo "$ENCODED_KEYSTORE" | base64 -di > app/signing/campfire.keystore
-          else
-            echo "Skipping keystore decode (no secret — APK will sign with debug key fallback)"
-          fi
+          echo $ENCODED_KEYSTORE | base64 -di > app/signing/campfire.keystore
 
       - name: Download Service Accounts
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           APP_DISTRIBUTION_JSON: ${{ secrets.APP_DISTRIBUTION_SERVICE_ACCOUNT }}
         run: |
-          if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > app/android/google-services.json
-          else
-            echo "Skipping google-services.json (no secret — Firebase plugins will be disabled)"
-          fi
-          if [ -n "$APP_DISTRIBUTION_JSON" ]; then
-            echo "$APP_DISTRIBUTION_JSON" > app/android/campfire-app-distribution-service-account.json
-          else
-            echo "Skipping app-distribution service account (no secret)"
-          fi
+          echo $GOOGLE_SERVICES_JSON > app/android/google-services.json
+          echo $APP_DISTRIBUTION_JSON > app/android/campfire-app-distribution-service-account.json
 
       - name: Assemble Alpha Release APK
         run: ./gradlew :app:android:assembleAlphaRelease
@@ -81,14 +71,12 @@ jobs:
           CI: true
 
       - name: Create Release Notes
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
         run: |
           ./campfire changelog --version Unreleased > app/android/release-notes.txt
           echo " "
           cat app/android/release-notes.txt
 
       - name: Firebase App Distribution
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
         run: |
           ./gradlew :app:android:appDistributionUploadAlphaRelease \
             --serviceCredentialsFile="app/android/campfire-app-distribution-service-account.json" \

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -49,15 +49,27 @@ jobs:
         env:
           ENCODED_KEYSTORE: ${{ secrets.CAMPFIRE_KEYSTORE }}
         run: |
-          echo $ENCODED_KEYSTORE | base64 -di > app/signing/campfire.keystore
+          if [ -n "$ENCODED_KEYSTORE" ]; then
+            echo "$ENCODED_KEYSTORE" | base64 -di > app/signing/campfire.keystore
+          else
+            echo "Skipping keystore decode (no secret — APK will sign with debug key fallback)"
+          fi
 
       - name: Download Service Accounts
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           APP_DISTRIBUTION_JSON: ${{ secrets.APP_DISTRIBUTION_SERVICE_ACCOUNT }}
         run: |
-          echo $GOOGLE_SERVICES_JSON > app/android/google-services.json
-          echo $APP_DISTRIBUTION_JSON > app/android/campfire-app-distribution-service-account.json
+          if [ -n "$GOOGLE_SERVICES_JSON" ]; then
+            echo "$GOOGLE_SERVICES_JSON" > app/android/google-services.json
+          else
+            echo "Skipping google-services.json (no secret — Firebase plugins will be disabled)"
+          fi
+          if [ -n "$APP_DISTRIBUTION_JSON" ]; then
+            echo "$APP_DISTRIBUTION_JSON" > app/android/campfire-app-distribution-service-account.json
+          else
+            echo "Skipping app-distribution service account (no secret)"
+          fi
 
       - name: Assemble Alpha Release APK
         run: ./gradlew :app:android:assembleAlphaRelease
@@ -69,12 +81,14 @@ jobs:
           CI: true
 
       - name: Create Release Notes
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
         run: |
           ./campfire changelog --version Unreleased > app/android/release-notes.txt
           echo " "
           cat app/android/release-notes.txt
 
       - name: Firebase App Distribution
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
         run: |
           ./gradlew :app:android:appDistributionUploadAlphaRelease \
             --serviceCredentialsFile="app/android/campfire-app-distribution-service-account.json" \

--- a/.github/workflows/baseline-prof.yml
+++ b/.github/workflows/baseline-prof.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   baseline-profile:
+    # Skip on fork PRs — this workflow needs first-party secrets and pushes back to main.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -46,11 +48,7 @@ jobs:
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
-          if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > app/android/google-services.json
-          else
-            echo "Skipping google-services.json (no secret available — fork PR or external contributor)"
-          fi
+          echo $GOOGLE_SERVICES_JSON > app/android/google-services.json
 
       - name: Build app and benchmark
         run: ./gradlew assembleNonMinifiedRelease

--- a/.github/workflows/baseline-prof.yml
+++ b/.github/workflows/baseline-prof.yml
@@ -46,7 +46,11 @@ jobs:
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
-          echo $GOOGLE_SERVICES_JSON > app/android/google-services.json
+          if [ -n "$GOOGLE_SERVICES_JSON" ]; then
+            echo "$GOOGLE_SERVICES_JSON" > app/android/google-services.json
+          else
+            echo "Skipping google-services.json (no secret available — fork PR or external contributor)"
+          fi
 
       - name: Build app and benchmark
         run: ./gradlew assembleNonMinifiedRelease

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,11 @@ jobs:
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
-          echo $GOOGLE_SERVICES_JSON > app/android/google-services.json
+          if [ -n "$GOOGLE_SERVICES_JSON" ]; then
+            echo "$GOOGLE_SERVICES_JSON" > app/android/google-services.json
+          else
+            echo "Skipping google-services.json (no secret available — fork PR or external contributor)"
+          fi
 
       - name: Check skip-coverage label is added
         id: label-check
@@ -172,7 +176,11 @@ jobs:
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
-          echo $GOOGLE_SERVICES_JSON > app/android/google-services.json
+          if [ -n "$GOOGLE_SERVICES_JSON" ]; then
+            echo "$GOOGLE_SERVICES_JSON" > app/android/google-services.json
+          else
+            echo "Skipping google-services.json (no secret available — fork PR or external contributor)"
+          fi
 
       - name: Build Android App
         run: |

--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -1,18 +1,13 @@
 @file:Suppress("UnstableApiUsage")
 
-import com.google.firebase.appdistribution.gradle.firebaseAppDistribution
-import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
-
 plugins {
   id("app.campfire.android.application")
   id("app.campfire.kotlin.android")
   id("app.campfire.compose")
+  id("app.campfire.firebase")
   alias(libs.plugins.ksp)
   alias(libs.plugins.about.libraries)
   alias(libs.plugins.baselineprofile)
-  alias(libs.plugins.google.services)
-  alias(libs.plugins.firebase.crashlytics)
-  alias(libs.plugins.firebase.appdistribution)
 }
 
 ksp {
@@ -51,17 +46,9 @@ android {
     create("alpha") {
       applicationIdSuffix = ".alpha"
       versionNameSuffix = "-alpha"
-      firebaseAppDistribution {
-        artifactType = "APK"
-        groups = "internal,alpha-public"
-      }
     }
 
     create("beta") {
-      firebaseAppDistribution {
-        artifactType = "APK"
-        groups = "internal,external-public"
-      }
     }
   }
 
@@ -107,10 +94,6 @@ android {
         "base-proguard-rules.pro",
         "prod-proguard-rules.pro",
       )
-
-      configure<CrashlyticsExtension> {
-        mappingFileUploadEnabled = true
-      }
     }
 
     create("benchmarkRelease") {
@@ -140,10 +123,6 @@ aboutLibraries {
 }
 
 dependencies {
-  implementation(platform(libs.google.firebase.bom))
-  implementation(libs.google.firebase.analytics)
-  implementation(libs.google.firebase.crashlytics)
-
   implementation(projects.app.common)
   implementation(projects.common.screens)
 
@@ -159,9 +138,6 @@ dependencies {
 
   baselineProfile(projects.app.baselineprofile)
   implementation(libs.androidx.compose.runtime.tracing)
-
-  "betaImplementation"(libs.google.firebase.appdistribution)
-  "alphaImplementation"(libs.google.firebase.appdistribution)
 
   "benchmarkReleaseImplementation"(libs.androidx.tracing.perfetto)
   "benchmarkReleaseImplementation"(libs.androidx.tracing.perfetto.binary)

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -16,6 +16,9 @@ dependencies {
   compileOnly(libs.kotlin.gradlePlugin)
   compileOnly(libs.compose.gradlePlugin)
   compileOnly(libs.composeCompiler.gradlePlugin)
+  compileOnly(libs.google.services.gradlePlugin)
+  compileOnly(libs.firebase.crashlytics.gradlePlugin)
+  compileOnly(libs.firebase.appdistribution.gradlePlugin)
 }
 
 gradlePlugin {
@@ -68,6 +71,11 @@ gradlePlugin {
     register("parcelize") {
       id = "app.campfire.parcelize"
       implementationClass = "app.campfire.convention.ParcelizeConventionPlugin"
+    }
+
+    register("firebase") {
+      id = "app.campfire.firebase"
+      implementationClass = "app.campfire.convention.FirebaseConventionPlugin"
     }
   }
 }

--- a/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/FirebaseConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/FirebaseConventionPlugin.kt
@@ -1,0 +1,70 @@
+// Copyright 2023, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package app.campfire.convention
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.google.firebase.appdistribution.gradle.firebaseAppDistribution
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+
+class FirebaseConventionPlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    with(target) {
+      // Runtime deps are always declared so src/release & src/preRelease compile;
+      // the Gradle plugins (which fail without google-services.json) are conditional.
+      dependencies {
+        add("implementation", platform(libs.findLibrary("google-firebase-bom").get()))
+        add("implementation", libs.findLibrary("google-firebase-analytics").get())
+        add("implementation", libs.findLibrary("google-firebase-crashlytics").get())
+      }
+
+      val appDistributionDep = libs.findLibrary("google-firebase-appdistribution").get()
+      configurations
+        .matching { it.name == "alphaImplementation" || it.name == "betaImplementation" }
+        .configureEach {
+          dependencies.add(appDistributionDep.get())
+        }
+
+      val googleServicesFile = rootProject.file("app/android/google-services.json")
+      if (!googleServicesFile.exists()) {
+        logger.lifecycle(
+          "Firebase plugins disabled: app/android/google-services.json not found. " +
+            "APK will compile but Firebase runtime features will be inactive.",
+        )
+        return
+      }
+
+      with(pluginManager) {
+        apply("com.google.gms.google-services")
+        apply("com.google.firebase.crashlytics")
+        apply("com.google.firebase.appdistribution")
+      }
+
+      extensions.configure<ApplicationExtension> {
+        buildTypes.named("release") {
+          configure<CrashlyticsExtension> {
+            mappingFileUploadEnabled = true
+          }
+        }
+
+        productFlavors.matching { it.name == "alpha" }.configureEach {
+          firebaseAppDistribution {
+            artifactType = "APK"
+            groups = "internal,alpha-public"
+          }
+        }
+
+        productFlavors.matching { it.name == "beta" }.configureEach {
+          firebaseAppDistribution {
+            artifactType = "APK"
+            groups = "internal,external-public"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -269,6 +269,9 @@ android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref 
 compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
 composeCompiler-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+google-services-gradlePlugin = "com.google.gms:google-services:4.4.4"
+firebase-crashlytics-gradlePlugin = "com.google.firebase:firebase-crashlytics-gradle:3.0.7"
+firebase-appdistribution-gradlePlugin = "com.google.firebase:firebase-appdistribution-gradle:5.2.1"
 
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-core = { group = "androidx.core", name = "core", version.ref = "core" }


### PR DESCRIPTION
## Summary

- Forked PRs currently fail the Android job because GitHub doesn't expose `secrets.GOOGLE_SERVICES_JSON` to fork-triggered workflow runs — `echo $GOOGLE_SERVICES_JSON > app/android/google-services.json` writes an empty file and the Google Services Gradle plugin then chokes at configure time.
- New `app.campfire.firebase` convention plugin owns Firebase plugin application + extension config + dependency declarations. It short-circuits when `app/android/google-services.json` is absent (mirroring the existing keystore-file-existence pattern at `app/android/build.gradle.kts:84`). Firebase runtime libs are still always declared so source files in `src/release` and `src/preRelease` keep compiling.
- Workflows now `[ -n "$SECRET" ]`-guard every secret-writing step so fork PRs simply skip the file write. `alpha-release.yml`'s keystore decode falls through to the existing debug-key fallback at `app/android/build.gradle.kts:88`. The Firebase App Distribution upload step in `alpha-release.yml` is now fork-guarded with the same `head.repo.full_name == github.repository` pattern already used by the code-style job.

## Test plan

- [x] `./gradlew :app:android:assembleAlphaRelease` locally **without** `app/android/google-services.json` → succeeds, prints "Firebase plugins disabled" lifecycle log, produces a 15.2 MB APK that signs with the debug key.
- [x] `./gradlew :app:android:assembleAlphaRelease` locally **with** `app/android/google-services.json` → succeeds and runs `uploadCrashlyticsMappingFileAlphaRelease` (confirms the Crashlytics + appdistribution plugins are still applied and configured for maintainer builds).
- [x] `./scripts/ktlint --check` clean.
- [ ] CI on this PR (first-party): `android` job produces an APK with Firebase wiring and posts the artifact URL comment.
- [ ] Open a follow-up fork PR (or temporarily clear `GOOGLE_SERVICES_JSON` in repo settings) to confirm `android` and `code-coverage` jobs go green and produce a Firebase-less APK artifact.
- [ ] Push to `main` after merge runs `alpha-release.yml` end-to-end including the Firebase App Distribution upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)