### PR TITLE
Skip APK URL comment on fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
           path: app/android/build/outputs/apk/alpha/release/android-alpha-release.apk
 
       - name: Post Artifact URL to PR
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |


### PR DESCRIPTION
## Summary
- Fork PRs run with a read-only `GITHUB_TOKEN`, so the `Post Artifact URL to PR` step in the `android` job fails when trying to comment on the PR.
- Gate that step on `github.event.pull_request.head.repo.full_name == github.repository`, mirroring the pattern already used by the `code-style` job.
- The APK upload itself still runs on fork PRs — only the PR comment is skipped.

## Test plan
- [ ] Open a PR from a fork and confirm the `android` job no longer fails on the artifact-URL comment step.
- [ ] Open a PR from a same-repo branch and confirm the artifact-URL comment is still posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)