### PR TITLE
Fix #684 - Low volume when playing xhe-aac audio

### DIFF
--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/CampfireRenderersFactory.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/CampfireRenderersFactory.kt
@@ -1,0 +1,43 @@
+package app.campfire.audioplayer.impl
+
+import android.content.Context
+import android.os.Handler
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.audio.AudioRendererEventListener
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+
+@OptIn(UnstableApi::class)
+internal class CampfireRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
+
+  override fun buildAudioRenderers(
+    context: Context,
+    extensionRendererMode: Int,
+    mediaCodecSelector: MediaCodecSelector,
+    enableDecoderFallback: Boolean,
+    audioSink: AudioSink,
+    eventHandler: Handler,
+    eventListener: AudioRendererEventListener,
+    out: ArrayList<Renderer>,
+  ) {
+    out.add(
+      MediaCodecAudioRenderer(
+        context,
+        getCodecAdapterFactory(),
+        mediaCodecSelector,
+        enableDecoderFallback,
+        eventHandler,
+        eventListener,
+        audioSink,
+        // Pass in null to LoudnessCodecController to disable
+        // volume changes when listening to xhe-aac audio
+        // See https://github.com/r0adkll/Campfire/issues/684
+        null,
+      ),
+    )
+  }
+}

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -98,6 +98,7 @@ class ExoPlayerAudioPlayer(
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
   private val exoPlayer = ExoPlayer.Builder(context)
+    .setRenderersFactory(CampfireRenderersFactory(context))
     .setSeekForwardIncrementMs(settings.forwardTimeMs)
     .setSeekBackIncrementMs(settings.backwardTimeMs)
     .setHandleAudioBecomingNoisy(true)


### PR DESCRIPTION
## Summary

Fixes the low volume when playing xhe-aac audio

See the MediaCodecAudioRenderer function [here](https://developer.android.com/reference/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer#MediaCodecAudioRenderer(android.content.Context,androidx.media3.exoplayer.mediacodec.MediaCodecAdapter.Factory,androidx.media3.exoplayer.mediacodec.MediaCodecSelector,boolean,android.os.Handler,androidx.media3.exoplayer.audio.AudioRendererEventListener,androidx.media3.exoplayer.audio.AudioSink,androidx.media3.exoplayer.mediacodec.LoudnessCodecController))


## Related issues

Closes #684

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI / tooling
- [ ] Dependency update

## Platforms affected

- [x] Android
- [ ] iOS
- [ ] Desktop
- [ ] Shared / all platforms

## Screenshots / recordings

n/a

## Test plan

- Run local build
- Play xhe-aac audio while using earbuds
- Compare audio volume from this to official ABS app.