### PR TITLE
Memory tuning

### DIFF
--- a/app/android/src/main/AndroidManifest.xml
+++ b/app/android/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
     android:enableOnBackInvokedCallback="true"
-    android:usesCleartextTraffic="true">
+    android:usesCleartextTraffic="true"
+    android:largeHeap="true">
     <activity
       android:name=".MainActivity"
       android:exported="true"

--- a/app/common/src/commonMain/kotlin/app/campfire/common/image/CoilAppInitializer.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/image/CoilAppInitializer.kt
@@ -5,6 +5,7 @@ import app.campfire.core.di.AppScope
 import app.campfire.network.di.UserClient
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
 import com.r0adkll.kimchi.annotations.ContributesMultibinding
@@ -23,6 +24,11 @@ class CoilAppInitializer(
     SingletonImageLoader.setSafe { context ->
       ImageLoader.Builder(context)
         .crossfade(true)
+        .memoryCache {
+          MemoryCache.Builder()
+            .maxSizePercent(context, 0.08)
+            .build()
+        }
         .components {
           add(
             KtorNetworkFetcherFactory(

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -111,10 +111,10 @@ class ExoPlayerAudioPlayer(
     .setLoadControl(
       DefaultLoadControl.Builder()
         .setBufferDurationsMs(
-          20 * 1000,
-          45 * 1000,
-          5 * 1000,
-          20 * 1000,
+          15 * 1000, // minBuffer
+          30 * 1000, // maxBuffer (was 45s)
+          2 * 1000, // playbackBuffer
+          10 * 1000, // backBuffer (was 20s)
         )
         .build(),
     )

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/di/ExoPlayerAppComponent.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/di/ExoPlayerAppComponent.kt
@@ -9,7 +9,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.cache.CacheDataSource
-import androidx.media3.datasource.cache.NoOpCacheEvictor
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -55,7 +55,7 @@ interface ExoPlayerAppComponent {
     val downloadDirectory = File(application.filesDir, "exoPlayerDownloads")
     return SimpleCache(
       downloadDirectory,
-      NoOpCacheEvictor(),
+      LeastRecentlyUsedCacheEvictor(512 * 1024 * 1024L), // 512 MB disk cap
       databaseProvider,
     )
   }


### PR DESCRIPTION
## Summary

- Update to large heap
- Coil memory cache capped to 8%
- ExoPlayer buffer durations reduced (45s → 30s max)
- NoOpCacheEvictor for images

## Related issues

<!-- Link any related issues. Use "Closes #123" to auto-close on merge. -->

Closes #765

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI / tooling
- [ ] Dependency update

## Platforms affected

- [x] Android
- [ ] iOS
- [ ] Desktop
- [ ] Shared / all platforms

## Screenshots / recordings

na

## Test plan

-Play a large xhe-aac audiobook
-Allow book to move from one chapter to another
-Check log for no OOO errors