### PR TITLE
Podcast Queue Support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,44 +2,19 @@
 Thanks for contributing to Campfire! Please fill out the sections below.
 Feel free to delete sections that don't apply.
 -->
-
 ## Summary
-
 <!-- What does this PR do and why? Keep it short — 1-3 bullets. -->
 
--
 
 ## Related issues
-
 <!-- Link any related issues. Use "Closes #123" to auto-close on merge. -->
 
 Closes #
 
-## Type of change
-
-<!-- Check all that apply. -->
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Refactor / cleanup
-- [ ] Documentation
-- [ ] Build / CI / tooling
-- [ ] Dependency update
-
-## Platforms affected
-
-- [ ] Android
-- [ ] iOS
-- [ ] Desktop
-- [ ] Shared / all platforms
-
 ## Screenshots / recordings
-
 <!-- For UI changes, include before/after screenshots or a short recording. -->
 
 ## Test plan
-
 <!-- How did you verify this works? What should reviewers check? -->
 
 - [ ]
-[ ]

--- a/core/src/commonMain/kotlin/app/campfire/core/model/Media.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/model/Media.kt
@@ -132,9 +132,7 @@ sealed interface Media {
       override val publishedDate: String?,
       override val publisher: String?,
       override val description: String?,
-      @Suppress("PropertyName")
       override val ISBN: String?,
-      @Suppress("PropertyName")
       override val ASIN: String?,
       override val language: String?,
       override val isExplicit: Boolean,

--- a/data/db/core/src/commonMain/sqldelight/app/campfire/data/sessionQueue.sq
+++ b/data/db/core/src/commonMain/sqldelight/app/campfire/data/sessionQueue.sq
@@ -3,9 +3,10 @@ import kotlin.Int;
 CREATE TABLE sessionQueue (
   userId TEXT NOT NULL,
   libraryItemId TEXT NOT NULL,
+  episodeId TEXT NOT NULL DEFAULT '',
   queueIndex INTEGER AS Int NOT NULL,
 
-  PRIMARY KEY (userId, libraryItemId),
+  PRIMARY KEY (userId, libraryItemId, episodeId),
   FOREIGN KEY (userId) REFERENCES user(id) ON DELETE CASCADE
 );
 
@@ -19,12 +20,14 @@ updateIndex:
 UPDATE sessionQueue
 SET queueIndex = ?
 WHERE userId = ?
-  AND libraryItemId = ?;
+  AND libraryItemId = ?
+  AND episodeId = ?;
 
 delete:
 DELETE FROM sessionQueue
 WHERE userId = ?
-  AND libraryItemId = ?;
+  AND libraryItemId = ?
+  AND episodeId = ?;
 
 deleteAll:
 DELETE FROM sessionQueue
@@ -38,11 +41,3 @@ selectAll:
 SELECT * FROM sessionQueue
 WHERE userId = ?
 ORDER BY queueIndex ASC;
-
-selectForUser:
-SELECT libraryItem.*, media.*, mediaProgress.* FROM libraryItem
-INNER JOIN sessionQueue ON sessionQueue.libraryItemId = libraryItem.id
-INNER JOIN media ON media.libraryItemId = libraryItem.id
-LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
-WHERE sessionQueue.userId = ?
-ORDER BY sessionQueue.queueIndex ASC;

--- a/data/db/core/src/commonMain/sqldelight/migrations/6.sqm
+++ b/data/db/core/src/commonMain/sqldelight/migrations/6.sqm
@@ -3,6 +3,8 @@ import app.campfire.core.model.MediaType;
 import app.campfire.core.model.PlayMethod;
 import kotlin.Boolean;
 import kotlin.Int;
+import kotlin.String;
+import kotlin.collections.List;
 import kotlin.time.Duration;
 import kotlin.uuid.Uuid;
 import kotlinx.datetime.LocalDateTime;
@@ -205,3 +207,23 @@ ALTER TABLE playbackAction ADD COLUMN episodeId TEXT NOT NULL DEFAULT '';
 
 CREATE INDEX IF NOT EXISTS idx_playbackAction_episode
   ON playbackAction(userId, libraryItemId, episodeId);
+
+-- 8) Make sessionQueue per-episode aware. SQLite can't ALTER PRIMARY KEY in place,
+-- so rebuild the table; existing rows are book queue entries and back-fill to the
+-- empty-string sentinel that matches mediaProgress / session / shelfJoin.
+CREATE TABLE sessionQueue_new (
+  userId TEXT NOT NULL,
+  libraryItemId TEXT NOT NULL,
+  episodeId TEXT NOT NULL DEFAULT '',
+  queueIndex INTEGER NOT NULL,
+
+  PRIMARY KEY (userId, libraryItemId, episodeId),
+  FOREIGN KEY (userId) REFERENCES user(id) ON DELETE CASCADE
+);
+
+INSERT INTO sessionQueue_new
+SELECT userId, libraryItemId, '', queueIndex
+FROM sessionQueue;
+
+DROP TABLE sessionQueue;
+ALTER TABLE sessionQueue_new RENAME TO sessionQueue;

--- a/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/dao/LibraryItemDao.kt
+++ b/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/dao/LibraryItemDao.kt
@@ -29,6 +29,7 @@ import app.cash.sqldelight.SuspendingTransacter
 import app.cash.sqldelight.SuspendingTransactionWithoutReturn
 import app.cash.sqldelight.async.coroutines.awaitAsList
 import app.cash.sqldelight.async.coroutines.awaitAsOne
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
@@ -60,6 +61,13 @@ interface LibraryItemDao {
    * source so a single page query can mix book and podcast items.
    */
   suspend fun hydratePagedItem(item: DbLibraryItem): LibraryItem
+
+  /**
+   * Hydrate by library item id alone — looks up the media type and dispatches to the
+   * matching hydrate path. Returns null if no item exists for the id. Used where we
+   * carry only an id (e.g. queue rows, server-resolved sessions).
+   */
+  suspend fun hydrateById(id: app.campfire.core.model.LibraryItemId): LibraryItem?
 
   /**
    * Insert an expanded library item and all of its relations in a transaction
@@ -160,6 +168,32 @@ class SqlDelightLibraryItemDao(
           .awaitAsOne()
       }
       hydratePodcastItem(full)
+    }
+  }
+
+  override suspend fun hydrateById(
+    id: app.campfire.core.model.LibraryItemId,
+  ): LibraryItem? {
+    val mediaType = withContext(dispatcherProvider.databaseRead) {
+      db.libraryItemsQueries.selectMediaTypeForId(id).awaitAsOneOrNull()
+    } ?: return null
+    return when (mediaType) {
+      MediaType.Book -> {
+        val full = withContext(dispatcherProvider.databaseRead) {
+          db.libraryItemsQueries
+            .selectForIdFull(id, ::mapToLibraryItemWithProgress)
+            .awaitAsOneOrNull()
+        } ?: return null
+        hydrateItem(full)
+      }
+      MediaType.Podcast -> {
+        val full = withContext(dispatcherProvider.databaseRead) {
+          db.libraryItemsQueries
+            .selectForPodcastIdFull(id, ::mapToPodcastLibraryItemWithProgress)
+            .awaitAsOneOrNull()
+        } ?: return null
+        hydratePodcastItem(full)
+      }
     }
   }
 

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/book/BookPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/book/BookPresenter.kt
@@ -211,7 +211,7 @@ class BookPresenter(
 
         LibraryItemUiEvent.RemoveFromQueue -> {
           scope.launch {
-            sessionQueue.remove(libraryItem)
+            sessionQueue.remove(libraryItem.id)
           }
         }
 

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/PodcastPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/PodcastPresenter.kt
@@ -63,7 +63,7 @@ class PodcastPresenter(
       val podcastEpisode = podcastMedia.episodes.find { it.id == screen.episodeId }
       if (podcastEpisode != null && !hasShownEpisode) {
         hasShownEpisode = true
-        overlayHost.showPodcastEpisodeBottomSheet(podcastEpisode)
+        overlayHost.showPodcastEpisodeBottomSheet(libraryItem, podcastEpisode)
       }
     }
 
@@ -73,7 +73,7 @@ class PodcastPresenter(
         when (event) {
           is LibraryItemUiEvent.OpenEpisode -> {
             scope.launch {
-              overlayHost.showPodcastEpisodeBottomSheet(event.episode)
+              overlayHost.showPodcastEpisodeBottomSheet(libraryItem, event.episode)
             }
           }
 

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeBottomSheet.kt
@@ -164,7 +164,13 @@ private fun PodcastEpisodeBottomSheet(
       onStopDownloadClick = {},
       onDeleteDownloadClick = {},
       onAddToPlaylistClick = {},
-      onAddToQueueClick = {},
+      onAddToQueueClick = {
+        if (state.isQueued) {
+          state.eventSink(PodcastEpisodeUiEvent.RemoveFromQueue)
+        } else {
+          state.eventSink(PodcastEpisodeUiEvent.AddToQueue)
+        }
+      },
     )
 
     Spacer(Modifier.height(16.dp))

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeBottomSheet.kt
@@ -42,6 +42,7 @@ import app.campfire.core.di.ComponentHolder
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.asDate
 import app.campfire.core.extensions.asReadableBytes
+import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.PodcastEpisode
 import app.campfire.libraries.ui.detail.SessionUiState
 import app.campfire.libraries.ui.detail.composables.ExpressiveControlBar
@@ -61,20 +62,26 @@ interface PodcastEpisodeBottomSheetComponent {
   val podcastEpisodePresenterFactory: PodcastEpisodePresenterFactory
 }
 
+private data class PodcastEpisodeSheetModel(
+  val libraryItem: LibraryItem,
+  val episode: PodcastEpisode,
+)
+
 suspend fun OverlayHost.showPodcastEpisodeBottomSheet(
+  item: LibraryItem,
   episode: PodcastEpisode,
 ) {
   show(
     BottomSheetOverlay(
-      model = episode,
+      model = PodcastEpisodeSheetModel(item, episode),
       onDismiss = { Unit },
-    ) { podcastEpisode, navigator ->
+    ) { (libraryItem, podcastEpisode), navigator ->
       CompositionLocalProvider(
         LocalContentLayout provides ContentLayout.Root,
       ) {
         val presenter = remember {
           ComponentHolder.component<PodcastEpisodeBottomSheetComponent>()
-            .podcastEpisodePresenterFactory(podcastEpisode, navigator)
+            .podcastEpisodePresenterFactory(libraryItem, podcastEpisode, navigator)
         }
 
         val state = presenter.present()

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
@@ -13,9 +13,8 @@ import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.audioplayer.PlaybackController
 import app.campfire.audioplayer.history.PlaybackHistoryRepository
+import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.PodcastEpisode
-import app.campfire.core.model.preview.libraryItem
-import app.campfire.libraries.api.LibraryItemRepository
 import app.campfire.libraries.ui.detail.SessionUiState
 import app.campfire.sessions.api.SessionQueue
 import app.campfire.sessions.api.SessionsRepository
@@ -34,11 +33,13 @@ import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
-typealias PodcastEpisodePresenterFactory = (PodcastEpisode, OverlayNavigator<Unit>) -> PodcastEpisodePresenter
+typealias PodcastEpisodePresenterFactory =
+    (LibraryItem, PodcastEpisode, OverlayNavigator<Unit>) -> PodcastEpisodePresenter
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Inject
 class PodcastEpisodePresenter(
+  @Assisted private val libraryItem: LibraryItem,
   @Assisted private val episode: PodcastEpisode,
   @Assisted private val navigator: OverlayNavigator<Unit>,
   private val analytics: Analytics,
@@ -48,7 +49,6 @@ class PodcastEpisodePresenter(
   private val mediaProgressRepository: MediaProgressRepository,
   private val playbackHistoryRepository: PlaybackHistoryRepository,
   private val audioPlayerHolder: AudioPlayerHolder,
-  private val libraryItemRepository: LibraryItemRepository,
 ) : Presenter<PodcastEpisodeUiState> {
 
   @Composable
@@ -212,8 +212,7 @@ class PodcastEpisodePresenter(
         PodcastEpisodeUiEvent.AddToQueue -> {
           analytics.send(ActionEvent("add_to_queue", Click))
           scope.launch {
-            val parent = libraryItemRepository.getLibraryItem(episode.libraryItemId)
-            sessionQueue.add(parent, episode)
+            sessionQueue.add(libraryItem, episode)
           }
         }
 

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
@@ -15,6 +15,7 @@ import app.campfire.audioplayer.PlaybackController
 import app.campfire.audioplayer.history.PlaybackHistoryRepository
 import app.campfire.core.model.PodcastEpisode
 import app.campfire.core.model.preview.libraryItem
+import app.campfire.libraries.api.LibraryItemRepository
 import app.campfire.libraries.ui.detail.SessionUiState
 import app.campfire.sessions.api.SessionQueue
 import app.campfire.sessions.api.SessionsRepository
@@ -47,6 +48,7 @@ class PodcastEpisodePresenter(
   private val mediaProgressRepository: MediaProgressRepository,
   private val playbackHistoryRepository: PlaybackHistoryRepository,
   private val audioPlayerHolder: AudioPlayerHolder,
+  private val libraryItemRepository: LibraryItemRepository,
 ) : Presenter<PodcastEpisodeUiState> {
 
   @Composable
@@ -204,6 +206,21 @@ class PodcastEpisodePresenter(
             sessionsRepository.markDeleted(episode.libraryItemId, episode.id)
             mediaProgressRepository.deleteProgress(episode.libraryItemId, episode.id)
             playbackHistoryRepository.clear(episode.libraryItemId, episode.id)
+          }
+        }
+
+        PodcastEpisodeUiEvent.AddToQueue -> {
+          analytics.send(ActionEvent("add_to_queue", Click))
+          scope.launch {
+            val parent = libraryItemRepository.getLibraryItem(episode.libraryItemId)
+            sessionQueue.add(parent, episode)
+          }
+        }
+
+        PodcastEpisodeUiEvent.RemoveFromQueue -> {
+          analytics.send(ActionEvent("remove_from_queue", Click))
+          scope.launch {
+            sessionQueue.remove(episode.libraryItemId, episode.id)
           }
         }
       }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
@@ -34,7 +34,7 @@ import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
 
 typealias PodcastEpisodePresenterFactory =
-    (LibraryItem, PodcastEpisode, OverlayNavigator<Unit>) -> PodcastEpisodePresenter
+  (LibraryItem, PodcastEpisode, OverlayNavigator<Unit>) -> PodcastEpisodePresenter
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Inject

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeUiState.kt
@@ -23,4 +23,6 @@ sealed interface PodcastEpisodeUiEvent {
   data object MarkNotFinished : PodcastEpisodeUiEvent
   data object DiscardProgress : PodcastEpisodeUiEvent
   data class Seek(val position: Duration) : PodcastEpisodeUiEvent
+  data object AddToQueue : PodcastEpisodeUiEvent
+  data object RemoveFromQueue : PodcastEpisodeUiEvent
 }

--- a/features/sessions/api/src/commonMain/kotlin/app/campfire/sessions/api/QueuedEntry.kt
+++ b/features/sessions/api/src/commonMain/kotlin/app/campfire/sessions/api/QueuedEntry.kt
@@ -1,0 +1,29 @@
+package app.campfire.sessions.api
+
+import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
+
+/**
+ * A single entry in the session queue. For books, [episode] is null. For podcast queue
+ * entries, [episode] carries the playable episode and [libraryItem] is its parent podcast.
+ */
+data class QueuedEntry(
+  val libraryItem: LibraryItem,
+  val episode: PodcastEpisode? = null,
+) {
+  val libraryItemId: LibraryItemId
+    get() = libraryItem.id
+
+  val episodeId: PodcastEpisodeId?
+    get() = episode?.id
+
+  /**
+   * Stable identity for queue rendering / reordering. Books use the bare library item id;
+   * podcast entries combine library item id + episode id so multiple episodes of the same
+   * podcast keep distinct keys.
+   */
+  val key: String
+    get() = if (episode != null) "${libraryItem.id}:${episode.id}" else libraryItem.id
+}

--- a/features/sessions/api/src/commonMain/kotlin/app/campfire/sessions/api/SessionQueue.kt
+++ b/features/sessions/api/src/commonMain/kotlin/app/campfire/sessions/api/SessionQueue.kt
@@ -2,6 +2,7 @@ package app.campfire.sessions.api
 
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
 import app.campfire.core.model.PodcastEpisodeId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -9,15 +10,14 @@ import kotlinx.coroutines.flow.mapLatest
 
 interface SessionQueue {
 
-  suspend fun add(libraryItem: LibraryItem)
+  suspend fun add(libraryItem: LibraryItem, episode: PodcastEpisode? = null)
   suspend fun addAll(libraryItems: List<LibraryItem>)
-  suspend fun remove(libraryItem: LibraryItem)
-  suspend fun pop(): LibraryItem?
-  suspend fun reorder(fromItemId: LibraryItemId, toItemId: LibraryItemId)
-  suspend fun reorder(libraryItems: List<LibraryItem>)
+  suspend fun remove(libraryItemId: LibraryItemId, episodeId: PodcastEpisodeId? = null)
+  suspend fun pop(): QueuedEntry?
+  suspend fun reorder(entries: List<QueuedEntry>)
   suspend fun clear()
 
-  fun observeAll(): Flow<List<LibraryItem>>
+  fun observeAll(): Flow<List<QueuedEntry>>
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -26,5 +26,7 @@ fun SessionQueue.observeContains(
   episodeId: PodcastEpisodeId? = null,
 ): Flow<Boolean> {
   return observeAll()
-    .mapLatest { it.any { item -> item.id == libraryItemId } }
+    .mapLatest { list ->
+      list.any { it.libraryItemId == libraryItemId && it.episodeId == episodeId }
+    }
 }

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DiskSessionQueue.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DiskSessionQueue.kt
@@ -5,12 +5,15 @@ import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
 import app.campfire.core.session.UserSession
 import app.campfire.core.session.requiredUserId
 import app.campfire.core.session.userId
 import app.campfire.data.SessionQueue as DbSessionQueue
+import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.dao.LibraryItemDao
-import app.campfire.data.mapping.model.mapToLibraryItemWithProgress
+import app.campfire.sessions.api.QueuedEntry
 import app.campfire.sessions.api.SessionQueue
 import app.cash.sqldelight.async.coroutines.awaitAsList
 import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
@@ -34,7 +37,7 @@ class DiskSessionQueue(
   private val dispatcherProvider: DispatcherProvider,
 ) : SessionQueue {
 
-  override suspend fun add(libraryItem: LibraryItem) {
+  override suspend fun add(libraryItem: LibraryItem, episode: PodcastEpisode?) {
     val newIndex = read {
       db.sessionQueueQueries
         .getHighestIndex()
@@ -48,6 +51,7 @@ class DiskSessionQueue(
         DbSessionQueue(
           userId = userSession.requiredUserId,
           libraryItemId = libraryItem.id,
+          episodeId = episode?.id.orEmpty(),
           queueIndex = newIndex,
         ),
       )
@@ -70,6 +74,7 @@ class DiskSessionQueue(
             DbSessionQueue(
               userId = userSession.requiredUserId,
               libraryItemId = item.id,
+              episodeId = "",
               queueIndex = newIndex + index,
             ),
           )
@@ -78,99 +83,67 @@ class DiskSessionQueue(
     }
   }
 
-  override suspend fun remove(libraryItem: LibraryItem) {
-    val queue = read {
+  override suspend fun remove(libraryItemId: LibraryItemId, episodeId: PodcastEpisodeId?) {
+    val targetEpisodeId = episodeId.orEmpty()
+    val remaining = read {
       db.sessionQueueQueries
         .selectAll(userSession.requiredUserId)
         .awaitAsList()
         .sortedBy { it.queueIndex }
-        .map { it.libraryItemId }
-        .filter { it != libraryItem.id }
+        .filterNot { it.libraryItemId == libraryItemId && it.episodeId == targetEpisodeId }
+        .map { QueueKey(it.libraryItemId, it.episodeId) }
     }
 
     db.sessionQueueQueries.transaction {
       val success = db.sessionQueueQueries.delete(
         userId = userSession.requiredUserId,
-        libraryItemId = libraryItem.id,
+        libraryItemId = libraryItemId,
+        episodeId = targetEpisodeId,
       ) > 0
 
-      // Now re-index queue, if successful
-      if (success) reindexQueue(queue)
+      if (success) reindexQueue(remaining)
     }
   }
 
-  override suspend fun pop(): LibraryItem? {
+  override suspend fun pop(): QueuedEntry? {
+    val queue = read {
+      db.sessionQueueQueries
+        .selectAll(userSession.requiredUserId)
+        .awaitAsList()
+        .sortedBy { it.queueIndex }
+    }
+
+    val first = queue.firstOrNull() ?: return null
+
+    write {
+      db.sessionQueueQueries.delete(
+        userId = userSession.requiredUserId,
+        libraryItemId = first.libraryItemId,
+        episodeId = first.episodeId,
+      )
+
+      val remaining = queue.drop(1)
+      if (remaining.isNotEmpty()) {
+        reindexQueue(remaining.map { QueueKey(it.libraryItemId, it.episodeId) })
+      }
+    }
+
+    return hydrate(first.libraryItemId, first.episodeId.takeIf { it.isNotEmpty() })
+  }
+
+  override suspend fun reorder(entries: List<QueuedEntry>) {
     val queue = read {
       db.sessionQueueQueries
         .selectAll(userSession.requiredUserId)
         .awaitAsList()
     }
 
-    val first = queue.firstOrNull()
-
-    if (first != null) {
-      write {
-        db.sessionQueueQueries.delete(
-          userId = userSession.requiredUserId,
-          libraryItemId = first.libraryItemId,
-        )
-
-        val remaining = queue.drop(1)
-        if (remaining.isNotEmpty()) {
-          reindexQueue(remaining.map { it.libraryItemId })
-        }
-      }
-
-      val libraryItem = read {
-        db.libraryItemsQueries
-          .selectForIdFull(
-            first.libraryItemId,
-            ::mapToLibraryItemWithProgress,
-          )
-          .awaitAsOneOrNull()
-      }
-
-      return libraryItem?.let {
-        libraryItemDao.hydrateItem(it)
-      }
-    }
-
-    return null
-  }
-
-  override suspend fun reorder(fromItemId: LibraryItemId, toItemId: LibraryItemId) {
-    val queue = read {
-      db.sessionQueueQueries
-        .selectAll(userSession.requiredUserId)
-        .awaitAsList()
-    }
-
-    val fromIndex = queue.indexOfFirst { it.libraryItemId == fromItemId }
-    val toIndex = queue.indexOfFirst { it.libraryItemId == toItemId }
-
-    val mutableQueue = queue.toMutableList()
-    mutableQueue.add(toIndex, mutableQueue.removeAt(fromIndex))
+    if (queue.size != entries.size) return
 
     write {
       db.sessionQueueQueries.transaction {
-        reindexQueue(mutableQueue.map { it.libraryItemId })
+        reindexQueue(entries.map { QueueKey(it.libraryItemId, it.episodeId.orEmpty()) })
       }
-    }
-  }
-
-  override suspend fun reorder(libraryItems: List<LibraryItem>) {
-    val queue = read {
-      db.sessionQueueQueries
-        .selectAll(userSession.requiredUserId)
-        .awaitAsList()
-    }
-
-    // No-op if we have a difference
-    if (queue.size != libraryItems.size) return
-
-    // Re-index the current queue
-    write {
-      reindexQueue(libraryItems.map { it.id })
     }
   }
 
@@ -181,27 +154,41 @@ class DiskSessionQueue(
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  override fun observeAll(): Flow<List<LibraryItem>> {
+  override fun observeAll(): Flow<List<QueuedEntry>> {
     if (userSession.userId == null) return emptyFlow()
     return db.sessionQueueQueries
-      .selectForUser(userSession.requiredUserId, ::mapToLibraryItemWithProgress)
+      .selectAll(userSession.requiredUserId)
       .asFlow()
       .mapToList(dispatcherProvider.databaseRead)
-      .mapLatest { entities ->
-        entities.map {
-          libraryItemDao.hydrateItem(it)
-        }
+      .mapLatest { rows ->
+        rows
+          .sortedBy { it.queueIndex }
+          .mapNotNull { row ->
+            hydrate(row.libraryItemId, row.episodeId.takeIf { it.isNotEmpty() })
+          }
       }
   }
 
-  private suspend fun reindexQueue(
-    queue: List<LibraryItemId>,
-  ) {
-    queue.forEachIndexed { index, item ->
+  private suspend fun hydrate(
+    libraryItemId: LibraryItemId,
+    episodeId: PodcastEpisodeId?,
+  ): QueuedEntry? {
+    val libraryItem = libraryItemDao.hydrateById(libraryItemId) ?: return null
+    val episode = episodeId?.let {
+      read {
+        db.podcastEpisodeQueries.selectForId(it).awaitAsOneOrNull()
+      }?.asDomainModel()
+    }
+    return QueuedEntry(libraryItem = libraryItem, episode = episode)
+  }
+
+  private suspend fun reindexQueue(queue: List<QueueKey>) {
+    queue.forEachIndexed { index, key ->
       db.sessionQueueQueries.updateIndex(
         queueIndex = index,
         userId = userSession.requiredUserId,
-        libraryItemId = item,
+        libraryItemId = key.libraryItemId,
+        episodeId = key.episodeId,
       )
     }
   }
@@ -218,5 +205,10 @@ class DiskSessionQueue(
   ): T = withContext(
     dispatcherProvider.databaseWrite,
     block = block,
+  )
+
+  private data class QueueKey(
+    val libraryItemId: String,
+    val episodeId: String,
   )
 }

--- a/features/sessions/test/src/commonMain/kotlin/app/campfire/sessions/test/FakeSessionQueue.kt
+++ b/features/sessions/test/src/commonMain/kotlin/app/campfire/sessions/test/FakeSessionQueue.kt
@@ -2,49 +2,42 @@ package app.campfire.sessions.test
 
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
+import app.campfire.sessions.api.QueuedEntry
 import app.campfire.sessions.api.SessionQueue
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.onSubscription
 
 class FakeSessionQueue : SessionQueue {
-  val queue = ArrayDeque<LibraryItem>()
-  private val queueFlow = MutableSharedFlow<List<LibraryItem>>()
+  val queue = ArrayDeque<QueuedEntry>()
+  private val queueFlow = MutableSharedFlow<List<QueuedEntry>>()
 
-  override suspend fun add(libraryItem: LibraryItem) {
-    queue.addLast(libraryItem)
+  override suspend fun add(libraryItem: LibraryItem, episode: PodcastEpisode?) {
+    queue.addLast(QueuedEntry(libraryItem, episode))
     emit()
   }
 
   override suspend fun addAll(libraryItems: List<LibraryItem>) {
-    queue.addAll(libraryItems)
+    queue.addAll(libraryItems.map { QueuedEntry(it) })
     emit()
   }
 
-  override suspend fun remove(libraryItem: LibraryItem) {
-    queue.remove(libraryItem)
+  override suspend fun remove(libraryItemId: LibraryItemId, episodeId: PodcastEpisodeId?) {
+    queue.removeAll { it.libraryItemId == libraryItemId && it.episodeId == episodeId }
     emit()
   }
 
-  override suspend fun pop(): LibraryItem? {
+  override suspend fun pop(): QueuedEntry? {
     return queue.removeFirstOrNull().also {
       emit()
     }
   }
 
-  override suspend fun reorder(
-    fromItemId: LibraryItemId,
-    toItemId: LibraryItemId,
-  ) {
-    val fromIndex = queue.indexOfFirst { it.id == fromItemId }
-    val toIndex = queue.indexOfFirst { it.id == toItemId }
-    queue.add(toIndex, queue.removeAt(fromIndex))
-    emit()
-  }
-
-  override suspend fun reorder(libraryItems: List<LibraryItem>) {
+  override suspend fun reorder(entries: List<QueuedEntry>) {
     queue.clear()
-    queue.addAll(libraryItems)
+    queue.addAll(entries)
     emit()
   }
 
@@ -53,7 +46,7 @@ class FakeSessionQueue : SessionQueue {
     emit()
   }
 
-  override fun observeAll(): Flow<List<LibraryItem>> {
+  override fun observeAll(): Flow<List<QueuedEntry>> {
     return queueFlow
       .onSubscription {
         emit(queue)

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackPresenter.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackPresenter.kt
@@ -298,8 +298,8 @@ class PlaybackPresenter(
     ) { event ->
       when (event) {
         is QueueUiEvent.ReorderItem -> {
-          val fromIndex = localQueue.indexOfFirst { it.id == event.fromItemId }
-          val toIndex = localQueue.indexOfFirst { it.id == event.toItemId }
+          val fromIndex = localQueue.indexOfFirst { it.key == event.fromKey }
+          val toIndex = localQueue.indexOfFirst { it.key == event.toKey }
           localQueue.add(toIndex, localQueue.removeAt(fromIndex))
         }
 
@@ -312,14 +312,17 @@ class PlaybackPresenter(
         }
 
         is QueueUiEvent.QueueItemClick -> {
-          playbackController.startSession(event.item.id)
+          playbackController.startSession(
+            itemId = event.entry.libraryItemId,
+            episodeId = event.entry.episodeId,
+          )
           scope.launch {
-            sessionQueue.remove(event.item)
+            sessionQueue.remove(event.entry.libraryItemId, event.entry.episodeId)
           }
         }
 
         is QueueUiEvent.RemoveQueueItem -> scope.launch {
-          sessionQueue.remove(event.item)
+          sessionQueue.remove(event.entry.libraryItemId, event.entry.episodeId)
         }
       }
     }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackUiState.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackUiState.kt
@@ -9,11 +9,11 @@ import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.core.model.AudioTrack
 import app.campfire.core.model.Bookmark
 import app.campfire.core.model.Chapter
-import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.MediaProgress
 import app.campfire.core.model.Session
 import app.campfire.libraries.api.LibraryItemValidation
+import app.campfire.sessions.api.QueuedEntry
 import com.r0adkll.swatchbuckler.compose.Theme
 import kotlin.time.Duration
 
@@ -43,7 +43,7 @@ data class PlayerUiState(
 
 @Immutable
 data class QueueUiState(
-  val queue: List<LibraryItem>,
+  val queue: List<QueuedEntry>,
   val eventSink: (QueueUiEvent) -> Unit,
 )
 
@@ -98,13 +98,13 @@ sealed interface PlayerUiEvent {
 @Stable
 sealed interface QueueUiEvent {
   data class ReorderItem(
-    val fromItemId: LibraryItemId,
-    val toItemId: LibraryItemId,
+    val fromKey: String,
+    val toKey: String,
   ) : QueueUiEvent
   data object ReorderStopped : QueueUiEvent
 
-  data class QueueItemClick(val item: LibraryItem) : QueueUiEvent
-  data class RemoveQueueItem(val item: LibraryItem) : QueueUiEvent
+  data class QueueItemClick(val entry: QueuedEntry) : QueueUiEvent
+  data class RemoveQueueItem(val entry: QueuedEntry) : QueueUiEvent
   data object ClearQueue : QueueUiEvent
 }
 

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
@@ -302,15 +302,15 @@ internal fun ExpandedPlaybackBar(
         if (queue) {
           QueueContent(
             queue = queueState.queue,
-            onItemClick = { item ->
-              queueState.eventSink(QueueUiEvent.QueueItemClick(item))
+            onItemClick = { entry ->
+              queueState.eventSink(QueueUiEvent.QueueItemClick(entry))
               showQueue = false
             },
-            onRemoveItem = { item ->
-              queueState.eventSink(QueueUiEvent.RemoveQueueItem(item))
+            onRemoveItem = { entry ->
+              queueState.eventSink(QueueUiEvent.RemoveQueueItem(entry))
             },
-            onReorderItem = { from, to ->
-              queueState.eventSink(QueueUiEvent.ReorderItem(from, to))
+            onReorderItem = { fromKey, toKey ->
+              queueState.eventSink(QueueUiEvent.ReorderItem(fromKey, toKey))
             },
             onReorderStopped = {
               queueState.eventSink(QueueUiEvent.ReorderStopped)

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/QueueContent.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/QueueContent.kt
@@ -13,8 +13,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.widgets.MetadataHeader
-import app.campfire.core.model.LibraryItem
-import app.campfire.core.model.LibraryItemId
+import app.campfire.sessions.api.QueuedEntry
 import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.queue_header_queue
 import campfire.features.sessions.ui.generated.resources.queue_header_up_next
@@ -26,17 +25,17 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 
 @Composable
 internal fun QueueContent(
-  queue: List<LibraryItem>,
-  onItemClick: (LibraryItem) -> Unit,
-  onRemoveItem: (LibraryItem) -> Unit,
-  onReorderItem: suspend (from: LibraryItemId, to: LibraryItemId) -> Unit,
+  queue: List<QueuedEntry>,
+  onItemClick: (QueuedEntry) -> Unit,
+  onRemoveItem: (QueuedEntry) -> Unit,
+  onReorderItem: suspend (fromKey: String, toKey: String) -> Unit,
   onReorderStopped: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val haptics = LocalHapticFeedback.current
   val lazyListState = rememberLazyListState()
   val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
-    onReorderItem(from.key as LibraryItemId, to.key as LibraryItemId)
+    onReorderItem(from.key as String, to.key as String)
     haptics.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
   }
   LazyColumn(
@@ -47,7 +46,7 @@ internal fun QueueContent(
       horizontal = 16.dp,
     ),
   ) {
-    queue.groupBy { queue.indexOf(it) == 0 }.forEach { (isFirst, items) ->
+    queue.groupBy { queue.indexOf(it) == 0 }.forEach { (isFirst, entries) ->
       if (isFirst) {
         item {
           MetadataHeader(
@@ -63,15 +62,15 @@ internal fun QueueContent(
       }
 
       items(
-        items = items,
-        key = { it.id },
-      ) { item ->
-        ReorderableItem(reorderableLazyListState, key = item.id) {
+        items = entries,
+        key = { it.key },
+      ) { entry ->
+        ReorderableItem(reorderableLazyListState, key = entry.key) {
           val interactionSource = remember { MutableInteractionSource() }
           QueueItem(
-            item = item,
-            onClick = { onItemClick(item) },
-            onRemove = { onRemoveItem(item) },
+            entry = entry,
+            onClick = { onItemClick(entry) },
+            onRemove = { onRemoveItem(entry) },
             interactionSource = interactionSource,
             modifier = Modifier
               .animateItem()

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/QueueItem.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/QueueItem.kt
@@ -16,9 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,14 +29,14 @@ import app.campfire.common.compose.widgets.swipetodismiss.AnimatedRemoveBackgrou
 import app.campfire.common.compose.widgets.swipetodismiss.SwipeToDismissBox
 import app.campfire.common.compose.widgets.swipetodismiss.SwipeToDismissBoxValue
 import app.campfire.common.compose.widgets.swipetodismiss.rememberSwipeToDismissBoxState
-import app.campfire.core.model.LibraryItem
+import app.campfire.sessions.api.QueuedEntry
 
 private val ThumbnailSize = 88.dp
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun QueueItem(
-  item: LibraryItem,
+  entry: QueuedEntry,
   onClick: () -> Unit,
   onRemove: () -> Unit,
   modifier: Modifier = Modifier,
@@ -60,7 +58,7 @@ internal fun QueueItem(
     modifier = modifier,
   ) {
     QueueItemContent(
-      item = item,
+      entry = entry,
       onClick = onClick,
       interactionSource = interactionSource,
     )
@@ -70,11 +68,18 @@ internal fun QueueItem(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun QueueItemContent(
-  item: LibraryItem,
+  entry: QueuedEntry,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
   interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
+  // For podcast entries the playable unit is the episode — surface its title and duration
+  // while the cover/author still come from the parent podcast.
+  val title = entry.episode?.title ?: entry.libraryItem.media.metadata.title ?: "Unknown"
+  val subtitle = entry.libraryItem.media.metadata.title?.takeIf { entry.episode != null }
+    ?: entry.libraryItem.media.metadata.authorName ?: "--"
+  val duration = entry.episode?.duration ?: entry.libraryItem.media.duration
+
   val shape = MaterialTheme.shapes.large
   ElevatedCard(
     onClick = onClick,
@@ -92,7 +97,7 @@ private fun QueueItemContent(
       verticalAlignment = Alignment.CenterVertically,
     ) {
       ItemImage(
-        imageUrl = item.media.coverImageUrl,
+        imageUrl = entry.libraryItem.media.coverImageUrl,
         contentDescription = null,
         contentScale = ContentScale.Crop,
         modifier = Modifier
@@ -107,14 +112,14 @@ private fun QueueItemContent(
           .weight(1f),
       ) {
         Text(
-          text = item.media.metadata.title ?: "Unknown",
+          text = title,
           style = MaterialTheme.typography.titleMediumEmphasized,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
         )
 
         Text(
-          text = item.media.metadata.authorName ?: "--",
+          text = subtitle,
           style = MaterialTheme.typography.bodyMedium,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
@@ -132,7 +137,7 @@ private fun QueueItemContent(
             modifier = Modifier.size(16.dp),
           )
           Text(
-            text = item.media.duration.thresholdReadoutFormat(),
+            text = duration.thresholdReadoutFormat(),
             style = MaterialTheme.typography.labelSmallEmphasized,
           )
         }

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/session/DefaultPlaybackSessionManager.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/session/DefaultPlaybackSessionManager.kt
@@ -41,8 +41,9 @@ class DefaultPlaybackSessionManager(
       val player = audioPlayerHolder.currentPlayer.value
         ?: throw IllegalStateException("There isn't a media player available, unable to prepare session")
 
-      // Remove this item from the queue, if exists.
-      sessionQueue.remove(session.libraryItem)
+      // Remove this item from the queue, if exists. Scope to the same episode for podcasts
+      // so other queued episodes of the same podcast aren't clobbered.
+      sessionQueue.remove(session.libraryItem.id, session.episodeId)
 
       player.prepare(session, playImmediately, chapterId) { libraryItemId ->
         // For podcast sessions, scope all the finishing operations to the playing episode
@@ -54,7 +55,11 @@ class DefaultPlaybackSessionManager(
         val nextItem = sessionQueue.pop()
         if (nextItem != null) {
           // Kick off the next item by calling this very function.
-          startSession(nextItem.id, playImmediately = true)
+          startSession(
+            libraryItemId = nextItem.libraryItemId,
+            playImmediately = true,
+            episodeId = nextItem.episodeId,
+          )
         } else {
           // If we don't have a next-of-queue, Mark the session as finished which maxes out its current time
           // and marks it as inactive so it can be sync'd and then deleted
@@ -83,7 +88,11 @@ class DefaultPlaybackSessionManager(
       if (isCurrent) {
         val nextItem = sessionQueue.pop()
         if (nextItem != null) {
-          startSession(nextItem.id, playImmediately = true)
+          startSession(
+            libraryItemId = nextItem.libraryItemId,
+            playImmediately = true,
+            episodeId = nextItem.episodeId,
+          )
         } else {
           sessionsRepository.stopSession(libraryItemId, episodeId)
         }

--- a/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/ActiveWidgetContent.kt
+++ b/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/ActiveWidgetContent.kt
@@ -6,7 +6,7 @@ import androidx.glance.action.Action
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.core.model.Chapter
-import app.campfire.core.model.LibraryItem
+import app.campfire.sessions.api.QueuedEntry
 import kotlin.time.Duration
 
 @Composable
@@ -22,7 +22,7 @@ internal fun ActiveWidgetContent(
   runningTimer: RunningTimer?,
   prevChapter: Chapter?,
   nextChapter: Chapter?,
-  queue: List<LibraryItem>?,
+  queue: List<QueuedEntry>?,
   onClick: Action,
   widgetSizeClass: WidgetSizeClass,
   modifier: GlanceModifier = GlanceModifier,

--- a/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/PlaybackContent.kt
+++ b/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/PlaybackContent.kt
@@ -39,7 +39,7 @@ import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.common.compose.extensions.readoutFormat
 import app.campfire.core.extensions.readableHundredths
 import app.campfire.core.model.Chapter
-import app.campfire.core.model.LibraryItem
+import app.campfire.sessions.api.QueuedEntry
 import app.campfire.widgets.R
 import app.campfire.widgets.callbacks.CycleSpeedActionCallback
 import app.campfire.widgets.callbacks.SkipNextActionCallback
@@ -312,7 +312,7 @@ internal fun ExpandedPlaybackContent(
   playbackSpeed: Float,
   sleepTimerDuration: Duration,
   runningTimer: RunningTimer?,
-  queue: List<LibraryItem>?,
+  queue: List<QueuedEntry>?,
   sizeClass: WidgetSizeClass,
   modifier: GlanceModifier = GlanceModifier,
   defaultBackground: ImageProvider = ImageProvider(R.drawable.default_background),
@@ -452,7 +452,7 @@ internal fun ExpandedPlaybackContent(
 
 @Composable
 private fun QueueItem(
-  queue: List<LibraryItem>,
+  queue: List<QueuedEntry>,
   modifier: GlanceModifier = GlanceModifier,
 ) {
   Column(
@@ -470,7 +470,10 @@ private fun QueueItem(
         ),
     )
 
-    val nextItem = queue.first()
+    val nextEntry = queue.first()
+    val title = nextEntry.episode?.title ?: nextEntry.libraryItem.media.metadata.title ?: "--"
+    val duration = nextEntry.episode?.duration ?: nextEntry.libraryItem.media.duration
+
     Row(
       modifier = GlanceModifier.fillMaxWidth(),
       verticalAlignment = Alignment.CenterVertically,
@@ -478,7 +481,7 @@ private fun QueueItem(
       // Thumbnail
       val thumbSize = 64.dp
       GlanceImage(
-        url = nextItem.media.coverImageUrl,
+        url = nextEntry.libraryItem.media.coverImageUrl,
         modifier = GlanceModifier
           .size(thumbSize)
           .cornerRadius(16.dp),
@@ -492,7 +495,7 @@ private fun QueueItem(
           .defaultWeight(),
       ) {
         Text(
-          text = nextItem.media.metadata.title ?: "--",
+          text = title,
           style = TextStyle(
             fontSize = 18.sp,
             fontWeight = FontWeight.Medium,
@@ -501,7 +504,7 @@ private fun QueueItem(
         )
 
         Text(
-          text = nextItem.media.metadata.authorName ?: "--",
+          text = nextEntry.libraryItem.media.metadata.authorName ?: "--",
           style = TextStyle(
             fontSize = 14.sp,
             fontWeight = FontWeight.Normal,
@@ -510,7 +513,7 @@ private fun QueueItem(
         )
 
         Text(
-          text = nextItem.media.duration.readoutFormat(),
+          text = duration.readoutFormat(),
           style = TextStyle(
             fontSize = 12.sp,
             fontWeight = FontWeight.Normal,


### PR DESCRIPTION
## Summary
Add the ability to queue podcast episodes for playback. Can be mixed with book content.

## Related issues
<!-- Link any related issues. Use "Closes #123" to auto-close on merge. -->

Closes #790
