### PR TITLE
Add podcast episode support to playlists

### DIFF
--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/LibraryItemListItem.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/LibraryItemListItem.kt
@@ -38,6 +38,7 @@ import app.campfire.core.model.preview.libraryItem
 import app.campfire.core.offline.OfflineStatus
 import com.slack.circuit.sharedelements.PreviewSharedElementTransitionLayout
 import com.slack.circuit.sharedelements.SharedElementTransitionScope
+import kotlin.time.Duration
 
 @OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -50,6 +51,11 @@ fun LibraryItemListItem(
   offlineStatus: OfflineStatus = OfflineStatus.None,
   sharedTransitionKey: String = libraryItem.id,
   sharedTransitionZIndex: Float = 0f,
+  // Optional overrides used when the row should display something other than the parent
+  // library item (e.g. a podcast episode within a playlist row).
+  titleOverride: String? = null,
+  subtitleOverride: String? = null,
+  durationOverride: Duration? = null,
   interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) = SharedElementTransitionScope {
   val animationScope = findAnimatedScope(SharedElementTransitionScope.AnimatedScope.Navigation)
@@ -145,14 +151,19 @@ fun LibraryItemListItem(
           .weight(1f),
       ) {
         Text(
-          text = libraryItem.media.metadata.title ?: "Unknown",
+          text = titleOverride ?: libraryItem.media.metadata.title ?: "Unknown",
           style = MaterialTheme.typography.titleMediumEmphasized,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
         )
 
+        // For podcast metadata `authorName` is null (the field is `author`); fall back so
+        // both books and podcasts render a sensible attribution line.
+        val defaultSubtitle = libraryItem.media.metadata.authorName
+          ?: libraryItem.media.metadata.author
+          ?: "--"
         Text(
-          text = libraryItem.media.metadata.authorName ?: "--",
+          text = subtitleOverride ?: defaultSubtitle,
           style = MaterialTheme.typography.bodyMedium,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
@@ -170,7 +181,7 @@ fun LibraryItemListItem(
             modifier = Modifier.size(16.dp),
           )
           Text(
-            text = libraryItem.media.duration.thresholdReadoutFormat(),
+            text = (durationOverride ?: libraryItem.media.duration).thresholdReadoutFormat(),
             style = MaterialTheme.typography.labelSmallEmphasized,
           )
         }

--- a/core/src/commonMain/kotlin/app/campfire/core/model/Playlist.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/model/Playlist.kt
@@ -27,11 +27,10 @@ data class Playlist(
       override val libraryItemId: String,
       override val episodeId: String?,
     ) : Item {
-      constructor(libraryItem: LibraryItem) : this(
+      constructor(libraryItem: LibraryItem, episode: PodcastEpisode? = null) : this(
         index = -1,
         libraryItemId = libraryItem.id,
-        // Add support for Podcasts
-        episodeId = null,
+        episodeId = episode?.id,
       )
     }
 
@@ -40,7 +39,16 @@ data class Playlist(
       override val libraryItemId: String,
       override val episodeId: String?,
       val libraryItem: LibraryItem,
+      val episode: PodcastEpisode? = null,
     ) : Item {
+
+      /**
+       * Stable identity for list rendering / reordering. Books use the bare library item
+       * id; podcast entries combine library item id + episode id so multiple episodes of
+       * the same podcast keep distinct keys.
+       */
+      val key: String
+        get() = if (episodeId != null) "$libraryItemId:$episodeId" else libraryItemId
 
       fun asMinified(): Minified = Minified(index, libraryItemId, episodeId)
     }

--- a/data/db/core/src/commonMain/sqldelight/app/campfire/data/libraryItems.sq
+++ b/data/db/core/src/commonMain/sqldelight/app/campfire/data/libraryItems.sq
@@ -115,14 +115,6 @@ INNER JOIN media ON media.libraryItemId = libraryItem.id
 WHERE collectionsBookJoin.collectionsId = ?
 ORDER BY collectionsBookJoin.itemOrder ASC;
 
-selectForPlaylist:
-SELECT libraryItem.*,media.*,mediaProgress.* FROM libraryItem
-INNER JOIN playlistItemJoin ON playlistItemJoin.libraryItemId = libraryItem.id
-INNER JOIN media ON media.libraryItemId = libraryItem.id
-LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
-WHERE playlistItemJoin.playlistId = ?
-ORDER BY playlistItemJoin.itemOrder ASC;
-
 selectForAuthorName:
 SELECT libraryItem.*,media.* FROM libraryItem
 INNER JOIN media ON media.libraryItemId = libraryItem.id

--- a/data/db/core/src/commonMain/sqldelight/app/campfire/data/playlistItemJoin.sq
+++ b/data/db/core/src/commonMain/sqldelight/app/campfire/data/playlistItemJoin.sq
@@ -3,10 +3,10 @@ import kotlin.Int;
 CREATE TABLE IF NOT EXISTS playlistItemJoin (
   playlistId TEXT NOT NULL,
   libraryItemId TEXT NOT NULL,
-  episodeId TEXT,
+  episodeId TEXT NOT NULL DEFAULT '',
   itemOrder INTEGER AS Int NOT NULL,
 
-  PRIMARY KEY (playlistId, libraryItemId),
+  PRIMARY KEY (playlistId, libraryItemId, episodeId),
   FOREIGN KEY (playlistId) REFERENCES playlists(id) ON UPDATE NO ACTION ON DELETE CASCADE,
   FOREIGN KEY (libraryItemId) REFERENCES libraryItem(id) ON UPDATE NO ACTION ON DELETE NO ACTION
 );
@@ -33,4 +33,5 @@ WHERE playlistId = :playlistId;
 deleteForItem:
 DELETE FROM playlistItemJoin
 WHERE playlistId = :playlistId
-AND libraryItemId = :libraryItemId;
+AND libraryItemId = :libraryItemId
+AND episodeId = :episodeId;

--- a/data/db/core/src/commonMain/sqldelight/migrations/6.sqm
+++ b/data/db/core/src/commonMain/sqldelight/migrations/6.sqm
@@ -227,3 +227,26 @@ FROM sessionQueue;
 
 DROP TABLE sessionQueue;
 ALTER TABLE sessionQueue_new RENAME TO sessionQueue;
+
+-- 9) Make playlistItemJoin per-episode aware so the same podcast can appear multiple
+-- times in a playlist via distinct episodeIds. Same empty-string sentinel convention as
+-- the other tables above; existing book-only rows back-fill to ''.
+CREATE TABLE playlistItemJoin_new (
+  playlistId TEXT NOT NULL,
+  libraryItemId TEXT NOT NULL,
+  episodeId TEXT NOT NULL DEFAULT '',
+  itemOrder INTEGER NOT NULL,
+
+  PRIMARY KEY (playlistId, libraryItemId, episodeId),
+  FOREIGN KEY (playlistId) REFERENCES playlists(id) ON UPDATE NO ACTION ON DELETE CASCADE,
+  FOREIGN KEY (libraryItemId) REFERENCES libraryItem(id) ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+INSERT INTO playlistItemJoin_new
+SELECT playlistId, libraryItemId, COALESCE(episodeId, ''), itemOrder
+FROM playlistItemJoin;
+
+DROP TABLE playlistItemJoin;
+ALTER TABLE playlistItemJoin_new RENAME TO playlistItemJoin;
+
+CREATE INDEX IF NOT EXISTS index_playlist_item_join_libraryItemId ON playlistItemJoin(libraryItemId);

--- a/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/LibraryItemMapping.kt
+++ b/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/LibraryItemMapping.kt
@@ -21,7 +21,6 @@ import app.campfire.data.MediaChapters
 import app.campfire.data.MetadataAuthor
 import app.campfire.data.SelectForAuthorName
 import app.campfire.data.SelectForCollection
-import app.campfire.data.SelectForPlaylist
 import app.campfire.data.SelectForSeries
 import app.campfire.data.mapping.model.LibraryItemProgress
 import app.campfire.data.mapping.model.LibraryItemWithMedia
@@ -475,75 +474,6 @@ suspend fun SelectForCollection.asDomainModel(
 }
 
 suspend fun SelectForAuthorName.asDomainModel(
-  urlHydrator: UrlHydrator,
-): LibraryItem {
-  return LibraryItem(
-    id = id,
-    ino = ino,
-    libraryId = libraryId,
-    oldLibraryId = oldLibraryItemId,
-    folderId = folderId,
-    path = path,
-    relPath = relPath,
-    isFile = isFile,
-    mtimeMs = mtimeMs,
-    ctimeMs = ctimeMs,
-    birthtimeMs = birthtimeMs,
-    isMissing = isMissing,
-    isInvalid = isInvalid,
-    mediaType = mediaType,
-    numFiles = numFiles,
-    sizeInBytes = sizeInBytes,
-    addedAtMillis = addedAt,
-    updatedAtMillis = updatedAt,
-    media = DomainMedia.Book(
-      id = mediaId,
-      metadata = DomainMedia.Metadata.Book(
-        title = metadata_title,
-        titleIgnorePrefix = metadata_titleIgnorePrefix,
-        subtitle = metadata_subtitle,
-        authorName = metadata_authorName,
-        authorNameLastFirst = metadata_authorNameLF,
-        narratorName = metadata_narratorName,
-        seriesName = metadata_seriesName,
-        genres = metadata_genres ?: emptyList(),
-        publishedYear = metadata_publishedYear,
-        publishedDate = metadata_publishedDate,
-        publisher = metadata_publisher,
-        description = metadata_description,
-        ISBN = metadata_isbn,
-        ASIN = metadata_asin,
-        language = metadata_language,
-        isExplicit = metadata_explicit,
-        isAbridged = metadata_abridged,
-        seriesSequence = createIfNotNull(
-          metadata_series_id,
-          metadata_series_name,
-          metadata_series_sequence,
-        ) {
-          SeriesSequence(
-            id = metadata_series_id!!,
-            name = metadata_series_name!!,
-            sequence = metadata_series_sequence!!,
-          )
-        },
-      ),
-      coverImageUrl = urlHydrator.hydrateLibraryItem(id),
-      coverPath = coverPath,
-      tags = tags ?: emptyList(),
-      numTracks = numTracks,
-      numAudioFiles = numAudioFiles,
-      numChapters = numChapters,
-      numMissingParts = numMissingParts,
-      numInvalidAudioFiles = numInvalidAudioFiles,
-      durationInMillis = durationInMillis,
-      sizeInBytes = sizeInBytes,
-      ebookFormat = ebookFormat,
-    ),
-  )
-}
-
-suspend fun SelectForPlaylist.asDomainModel(
   urlHydrator: UrlHydrator,
 ): LibraryItem {
   return LibraryItem(

--- a/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/PlaylistMapping.kt
+++ b/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/PlaylistMapping.kt
@@ -19,11 +19,16 @@ fun NetworkPlaylist.asDomainModel(urlHydrator: UrlHydrator): Playlist {
     lastUpdatedAt = Instant.fromEpochMilliseconds(lastUpdate).toLocalDateTime(TimeZone.currentSystemDefault()),
     createdAt = Instant.fromEpochMilliseconds(createdAt).toLocalDateTime(TimeZone.currentSystemDefault()),
     items = items.mapIndexed { index, item ->
+      val libraryItem = item.libraryItem.asDomainModel(urlHydrator)
+      // The server places the resolved episode at the playlist-item level — the nested
+      // libraryItem.media is the *minified* podcast and never carries episodes here.
+      val episode = item.episode?.asDomainModel(urlHydrator)
       Playlist.Item.Expanded(
         index = index,
         libraryItemId = item.libraryItemId,
         episodeId = item.episodeId,
-        libraryItem = item.libraryItem.asDomainModel(urlHydrator),
+        libraryItem = libraryItem,
+        episode = episode,
       )
     },
   )

--- a/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/dao/LibraryItemDao.kt
+++ b/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/dao/LibraryItemDao.kt
@@ -358,20 +358,26 @@ class SqlDelightLibraryItemDao(
     item: LibraryItem,
     asTransaction: Boolean,
     ignoreOnInsert: Boolean,
+  ) = when (item.media) {
+    is Media.Book -> insertBookDomain(item, asTransaction, ignoreOnInsert)
+    is Media.Podcast -> insertPodcastDomain(item, asTransaction, ignoreOnInsert)
+  }
+
+  private suspend fun insertBookDomain(
+    item: LibraryItem,
+    asTransaction: Boolean,
+    ignoreOnInsert: Boolean,
   ) = withContext(dispatcherProvider.databaseWrite) {
+    val book = item.media as Media.Book
     db.transactionIf(asTransaction) {
-      // Should we attach the serverUrl information to the domain model here? This way we don't have
-      // to pipe it around like this?
       val libraryItem = item.asDbModel(userSession.serverUrl!!)
 
-      // 1) Insert the root library item
       if (ignoreOnInsert) {
         db.libraryItemsQueries.insertOrIgnore(libraryItem)
       } else {
         db.libraryItemsQueries.insert(libraryItem)
       }
 
-      // 2) Insert the media meta
       val media = item.media.asDbModel(libraryItem.id)
       if (ignoreOnInsert) {
         db.mediaQueries.insertOrIgnore(media)
@@ -379,10 +385,7 @@ class SqlDelightLibraryItemDao(
         db.mediaQueries.insert(media)
       }
 
-      // 3) Insert relations
       item.userMediaProgress?.let { progress ->
-        // Match the insert's PK so the freshness check compares against the row that's
-        // about to be replaced (per-episode for podcasts, item-level for books).
         val existing = db.mediaProgressQueries.selectForEpisode(
           userId = progress.userId,
           libraryItemId = libraryItem.id,
@@ -393,31 +396,90 @@ class SqlDelightLibraryItemDao(
         }
       }
 
-      item.media.audioFiles.forEach { audioFile ->
+      book.audioFiles.forEach { audioFile ->
         db.mediaAudioFilesQueries.insert(audioFile.asDbModel(media.mediaId))
       }
 
-      item.media.chapters.forEach { chapter ->
+      book.chapters.forEach { chapter ->
         db.mediaChaptersQueries.insert(chapter.asDbModel(media.mediaId))
       }
 
-      item.media.tracks.forEach { track ->
+      book.tracks.forEach { track ->
         db.mediaAudioTracksQueries.insert(track.asDbModel(media.mediaId))
       }
 
-      item.media.metadata.authors.forEach { authorMeta ->
+      book.metadata.authors.forEach { authorMeta ->
         db.metadataAuthorQueries.insert(authorMeta.asDbModel(media.mediaId))
       }
 
       afterCommit {
         bark("LibraryItemDao", LogPriority.VERBOSE) {
-          "LibraryItemExpanded[${item.id.loggableId}] inserted"
+          "LibraryItem[${item.id.loggableId}] (book) inserted"
+        }
+      }
+      afterRollback {
+        bark("LibraryItemDao", LogPriority.VERBOSE) {
+          "LibraryItem[${item.id.loggableId}] (book) insert failed, rolling back"
+        }
+      }
+    }
+  }
+
+  private suspend fun insertPodcastDomain(
+    item: LibraryItem,
+    asTransaction: Boolean,
+    ignoreOnInsert: Boolean,
+  ) = withContext(dispatcherProvider.databaseWrite) {
+    val podcast = item.media as Media.Podcast
+    db.transactionIf(asTransaction) {
+      val libraryItem = item.asDbModel(userSession.serverUrl!!)
+
+      if (ignoreOnInsert) {
+        db.libraryItemsQueries.insertOrIgnore(libraryItem)
+      } else {
+        db.libraryItemsQueries.insert(libraryItem)
+      }
+
+      val podcastMedia = podcast.asDbModel(libraryItem.id)
+      if (ignoreOnInsert) {
+        db.podcastMediaQueries.insertOrIgnore(podcastMedia)
+      } else {
+        db.podcastMediaQueries.insert(podcastMedia)
+      }
+
+      podcast.episodes.forEach { episode ->
+        val row = episode.asDbModel(podcastMediaId = podcastMedia.mediaId)
+        if (ignoreOnInsert) {
+          db.podcastEpisodeQueries.insertOrIgnore(row)
+        } else {
+          db.podcastEpisodeQueries.insert(row)
+        }
+        episode.audioTrack?.let { track ->
+          db.podcastEpisodeAudioTrackQueries.insert(
+            track.asEpisodeDbModel(episodeId = episode.id),
+          )
         }
       }
 
+      item.userMediaProgress?.let { progress ->
+        val existing = db.mediaProgressQueries.selectForEpisode(
+          userId = progress.userId,
+          libraryItemId = libraryItem.id,
+          episodeId = progress.episodeId.orEmpty(),
+        ).executeAsOneOrNull()
+        if (existing == null || existing.lastUpdate <= progress.lastUpdate) {
+          db.mediaProgressQueries.insert(progress.asDbModel())
+        }
+      }
+
+      afterCommit {
+        bark("LibraryItemDao", LogPriority.VERBOSE) {
+          "LibraryItem[${item.id.loggableId}] (podcast) inserted"
+        }
+      }
       afterRollback {
         bark("LibraryItemDao", LogPriority.VERBOSE) {
-          "LibraryItemExpanded[${item.id.loggableId}] insert failed, rolling back"
+          "LibraryItem[${item.id.loggableId}] (podcast) insert failed, rolling back"
         }
       }
     }

--- a/data/network/api/src/commonMain/kotlin/app/campfire/network/models/Playlist.kt
+++ b/data/network/api/src/commonMain/kotlin/app/campfire/network/models/Playlist.kt
@@ -35,5 +35,10 @@ abstract class PlaylistItem : NetworkModel() {
     override val libraryItemId: String,
     override val episodeId: String? = null,
     val libraryItem: LibraryItemExpanded,
+    // The server returns the resolved podcast episode at the playlist-item level (not
+    // nested inside libraryItem.media). For book entries this is null; for podcast
+    // entries the libraryItem.media is the *minified* podcast (no episodes array) and
+    // the playable unit lives here.
+    val episode: PodcastEpisode? = null,
   ) : PlaylistItem()
 }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeBottomSheet.kt
@@ -22,7 +22,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -49,6 +52,7 @@ import app.campfire.libraries.ui.detail.composables.ExpressiveControlBar
 import app.campfire.libraries.ui.detail.composables.MediaProgressBar
 import app.campfire.libraries.ui.detail.composables.MetadataChip
 import app.campfire.libraries.ui.detail.composables.rememberRichTextState
+import app.campfire.playlists.api.dialog.PlaylistDialogResult
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.TokenClickHandler
 import com.mohamedrejeb.richeditor.ui.material.RichText
@@ -100,6 +104,18 @@ private fun PodcastEpisodeBottomSheet(
   state: PodcastEpisodeUiState,
   modifier: Modifier = Modifier,
 ) {
+  var showAddToPlaylistDialog by remember { mutableStateOf(false) }
+  if (showAddToPlaylistDialog) {
+    state.addToPlaylistDialog.Content(
+      libraryItem = state.libraryItem,
+      episode = state.episode,
+      onDismiss = { _: PlaylistDialogResult ->
+        showAddToPlaylistDialog = false
+      },
+      modifier = Modifier,
+    )
+  }
+
   Column(
     modifier = modifier
       .padding(16.dp)
@@ -170,7 +186,9 @@ private fun PodcastEpisodeBottomSheet(
       onDiscardProgress = { state.eventSink(PodcastEpisodeUiEvent.DiscardProgress) },
       onStopDownloadClick = {},
       onDeleteDownloadClick = {},
-      onAddToPlaylistClick = {},
+      onAddToPlaylistClick = {
+        showAddToPlaylistDialog = true
+      },
       onAddToQueueClick = {
         if (state.isQueued) {
           state.eventSink(PodcastEpisodeUiEvent.RemoveFromQueue)

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
@@ -16,6 +16,7 @@ import app.campfire.audioplayer.history.PlaybackHistoryRepository
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.PodcastEpisode
 import app.campfire.libraries.ui.detail.SessionUiState
+import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import app.campfire.sessions.api.SessionQueue
 import app.campfire.sessions.api.SessionsRepository
 import app.campfire.sessions.api.observeContains
@@ -49,6 +50,7 @@ class PodcastEpisodePresenter(
   private val mediaProgressRepository: MediaProgressRepository,
   private val playbackHistoryRepository: PlaybackHistoryRepository,
   private val audioPlayerHolder: AudioPlayerHolder,
+  private val addToPlaylistDialog: AddToPlaylistDialog,
 ) : Presenter<PodcastEpisodeUiState> {
 
   @Composable
@@ -114,6 +116,7 @@ class PodcastEpisodePresenter(
     }.collectAsState(false)
 
     return PodcastEpisodeUiState(
+      libraryItem = libraryItem,
       episode = episode,
       progress = progress,
       playbackSpeed = playbackSpeed,
@@ -121,6 +124,7 @@ class PodcastEpisodePresenter(
       isQueued = isQueued,
       hasSession = currentSession != null,
       sessionState = episodeSession,
+      addToPlaylistDialog = addToPlaylistDialog,
     ) { event ->
       when (event) {
         PodcastEpisodeUiEvent.PlayClick -> {

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeUiState.kt
@@ -1,12 +1,15 @@
 package app.campfire.libraries.ui.detail.podcast.episode
 
+import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.MediaProgress
 import app.campfire.core.model.PodcastEpisode
 import app.campfire.libraries.ui.detail.SessionUiState
+import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import com.slack.circuit.runtime.CircuitUiState
 import kotlin.time.Duration
 
 data class PodcastEpisodeUiState(
+  val libraryItem: LibraryItem,
   val episode: PodcastEpisode,
   val progress: MediaProgress?,
   val playbackSpeed: Float,
@@ -14,6 +17,7 @@ data class PodcastEpisodeUiState(
   val isQueued: Boolean,
   val hasSession: Boolean,
   val sessionState: SessionUiState,
+  val addToPlaylistDialog: AddToPlaylistDialog,
   val eventSink: (PodcastEpisodeUiEvent) -> Unit,
 ) : CircuitUiState
 

--- a/features/playlists/api/src/commonMain/kotlin/app/campfire/playlists/api/PlaylistsRepository.kt
+++ b/features/playlists/api/src/commonMain/kotlin/app/campfire/playlists/api/PlaylistsRepository.kt
@@ -1,7 +1,6 @@
 package app.campfire.playlists.api
 
 import app.campfire.core.model.CollectionId
-import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Playlist
 import app.campfire.core.model.PlaylistId
 import kotlinx.coroutines.flow.Flow
@@ -26,9 +25,11 @@ interface PlaylistsRepository {
   ): Flow<Playlist>
 
   /**
-   * Observe the list of [LibraryItem] for a given [Playlist]
+   * Observe the items of a playlist as [Playlist.Item.Expanded]. Each entry carries the
+   * resolved [app.campfire.core.model.LibraryItem] and, for podcast entries, the specific
+   * [app.campfire.core.model.PodcastEpisode] referenced by the playlist.
    */
-  fun observePlaylistItems(playlistId: PlaylistId): Flow<List<LibraryItem>>
+  fun observePlaylistItems(playlistId: PlaylistId): Flow<List<Playlist.Item.Expanded>>
 
   /**
    * Create a new playlist

--- a/features/playlists/api/src/commonMain/kotlin/app/campfire/playlists/api/dialog/AddToPlaylistDialog.kt
+++ b/features/playlists/api/src/commonMain/kotlin/app/campfire/playlists/api/dialog/AddToPlaylistDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.PlaylistId
+import app.campfire.core.model.PodcastEpisode
 
 sealed interface PlaylistDialogResult {
   data object None : PlaylistDialogResult
@@ -18,6 +19,7 @@ interface AddToPlaylistDialog {
     libraryItem: LibraryItem,
     onDismiss: (PlaylistDialogResult) -> Unit,
     modifier: Modifier,
+    episode: PodcastEpisode? = null,
   )
 
   companion object NoOp : AddToPlaylistDialog {
@@ -26,6 +28,7 @@ interface AddToPlaylistDialog {
       libraryItem: LibraryItem,
       onDismiss: (PlaylistDialogResult) -> Unit,
       modifier: Modifier,
+      episode: PodcastEpisode?,
     ) {
     }
   }

--- a/features/playlists/impl/src/commonMain/kotlin/app/campfire/playlists/StorePlaylistsRepository.kt
+++ b/features/playlists/impl/src/commonMain/kotlin/app/campfire/playlists/StorePlaylistsRepository.kt
@@ -6,17 +6,17 @@ import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.CollectionId
-import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.Media
 import app.campfire.core.model.Playlist
 import app.campfire.core.model.PlaylistId
 import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.dao.LibraryItemDao
-import app.campfire.data.mapping.model.mapToLibraryItemWithProgress
 import app.campfire.data.mapping.store.debugLogging
 import app.campfire.network.models.PlaylistExpanded
 import app.campfire.playlists.api.PlaylistsRepository
 import app.campfire.playlists.store.PlaylistsStore
 import app.campfire.user.api.UserRepository
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.r0adkll.kimchi.annotations.ContributesBinding
@@ -98,14 +98,41 @@ class StorePlaylistsRepository(
       }
   }
 
-  override fun observePlaylistItems(playlistId: PlaylistId): Flow<List<LibraryItem>> {
-    return db.libraryItemsQueries
-      .selectForPlaylist(playlistId, ::mapToLibraryItemWithProgress)
+  override fun observePlaylistItems(playlistId: PlaylistId): Flow<List<Playlist.Item.Expanded>> {
+    return db.playlistItemJoinQueries
+      .selectForPlaylist(playlistId)
       .asFlow()
       .mapToList(dispatcherProvider.databaseRead)
-      .mapLatest { itemWithProgress ->
-        itemWithProgress.map {
-          libraryItemDao.hydrateItem(it)
+      .mapLatest { junctionEntries ->
+        junctionEntries.mapIndexedNotNull { index, junction ->
+          val libraryItem = libraryItemDao.hydrateById(junction.libraryItemId)
+            ?: return@mapIndexedNotNull null
+          val episodeId = junction.episodeId.takeIf { it.isNotEmpty() }
+          val episode = episodeId?.let { id ->
+            // Prefer the in-memory podcast cache; fall back to a direct DB lookup so we
+            // resolve the episode even when the parent podcast hasn't been fully fetched
+            // (the playlist endpoint returns a *minified* podcast with no episodes array).
+            (libraryItem.media as? Media.Podcast)
+              ?.episodes
+              ?.firstOrNull { it.id == id }
+              ?: db.podcastEpisodeQueries
+                .selectForId(id)
+                .awaitAsOneOrNull()
+                ?.let { row ->
+                  val track = db.podcastEpisodeAudioTrackQueries
+                    .selectForEpisodeId(id)
+                    .awaitAsOneOrNull()
+                    ?.asDomainModel(urlHydrator)
+                  row.asDomainModel(audioTrack = track)
+                }
+          }
+          Playlist.Item.Expanded(
+            index = index,
+            libraryItemId = junction.libraryItemId,
+            episodeId = episodeId,
+            libraryItem = libraryItem,
+            episode = episode,
+          )
         }
       }
   }

--- a/features/playlists/impl/src/commonMain/kotlin/app/campfire/playlists/store/PlaylistsSourceOfTruthFactory.kt
+++ b/features/playlists/impl/src/commonMain/kotlin/app/campfire/playlists/store/PlaylistsSourceOfTruthFactory.kt
@@ -4,6 +4,7 @@ import app.campfire.CampfireDatabase
 import app.campfire.account.api.UrlHydrator
 import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.model.LibraryId
+import app.campfire.core.model.Media
 import app.campfire.core.model.Playlist
 import app.campfire.core.model.PlaylistId
 import app.campfire.core.model.UserId
@@ -12,7 +13,9 @@ import app.campfire.data.PlaylistItemJoin
 import app.campfire.data.Playlists
 import app.campfire.data.mapping.asDbModel
 import app.campfire.data.mapping.asDomainModel
+import app.campfire.data.mapping.asEpisodeDbModel
 import app.campfire.data.mapping.dao.LibraryItemDao
+import app.cash.sqldelight.SuspendingTransactionWithoutReturn
 import app.cash.sqldelight.async.coroutines.awaitAsList
 import app.cash.sqldelight.async.coroutines.awaitAsOne
 import app.cash.sqldelight.coroutines.asFlow
@@ -85,28 +88,29 @@ class PlaylistsSourceOfTruthFactory(
   }
 
   private suspend fun hydratePlaylistItems(playlistId: PlaylistId): List<Playlist.Item.Expanded> {
-    // Get junction entries to access episodeId and ordering
+    // Get junction entries (carries episodeId and ordering). For podcasts the same
+    // libraryItemId can appear multiple times under different episodeIds, so we hydrate
+    // by id directly rather than via a libraryItem-side join (which can only see one
+    // media variant at a time).
     val junctionEntries = db.playlistItemJoinQueries
       .selectForPlaylist(playlistId)
       .awaitAsList()
 
-    // Get the hydrated library items
-    val libraryItems = db.libraryItemsQueries
-      .selectForPlaylist(playlistId)
-      .awaitAsList()
-      .map { it.asDomainModel(urlHydrator) }
-
-    // Map library items by id for efficient lookup
-    val itemsById = libraryItems.associateBy { it.id }
-
-    // Combine junction data with library items
     return junctionEntries.mapIndexedNotNull { index, junction ->
-      val libraryItem = itemsById[junction.libraryItemId] ?: return@mapIndexedNotNull null
+      val libraryItem = libraryItemDao.hydrateById(junction.libraryItemId)
+        ?: return@mapIndexedNotNull null
+      val resolvedEpisodeId = junction.episodeId.takeIf { it.isNotEmpty() }
+      val episode = resolvedEpisodeId?.let { episodeId ->
+        (libraryItem.media as? Media.Podcast)
+          ?.episodes
+          ?.firstOrNull { it.id == episodeId }
+      }
       Playlist.Item.Expanded(
         index = index,
         libraryItemId = junction.libraryItemId,
-        episodeId = junction.episodeId,
+        episodeId = resolvedEpisodeId,
         libraryItem = libraryItem,
+        episode = episode,
       )
     }
   }
@@ -144,22 +148,7 @@ class PlaylistsSourceOfTruthFactory(
 
         // Insert the playlist items
         playlist.items.forEachIndexed { index, item ->
-
-          // These items contain expanded library items, so they should be safe to insert/replace
-          libraryItemDao.insert(
-            item = item.libraryItem,
-            asTransaction = false,
-          )
-
-          // Insert junction entry
-          db.playlistItemJoinQueries.insert(
-            PlaylistItemJoin(
-              playlistId = playlist.id,
-              libraryItemId = item.libraryItemId,
-              episodeId = item.episodeId,
-              itemOrder = index,
-            ),
-          )
+          writePlaylistItem(playlist.id, item, index)
         }
       }
     }
@@ -176,24 +165,54 @@ class PlaylistsSourceOfTruthFactory(
 
       // Insert the playlist items
       playlist.items.forEachIndexed { index, item ->
+        writePlaylistItem(playlist.id, item, index)
+      }
+    }
+  }
 
-        // These items contain expanded library items, so they should be safe to insert/replace
-        libraryItemDao.insert(
-          item = item.libraryItem,
-          asTransaction = false,
-        )
+  /**
+   * Write a single playlist item: the library item row, the junction row, and (for
+   * podcast episode entries) the episode row.
+   *
+   * For podcasts the server returns a *minified* libraryItem (no episodes array) inside
+   * the playlist payload — using INSERT OR REPLACE on the libraryItem would cascade-delete
+   * any episodes previously cached from a podcast detail fetch. We use ignoreOnInsert so
+   * the existing podcast cache is preserved, then write the playlist's specific episode
+   * row separately so it's available even when no full podcast fetch has happened.
+   */
+  private suspend fun SuspendingTransactionWithoutReturn.writePlaylistItem(
+    playlistId: PlaylistId,
+    item: Playlist.Item.Expanded,
+    order: Int,
+  ) {
+    libraryItemDao.insert(
+      item = item.libraryItem,
+      asTransaction = false,
+      ignoreOnInsert = true,
+    )
 
-        // Insert junction entry
-        db.playlistItemJoinQueries.insert(
-          PlaylistItemJoin(
-            playlistId = playlist.id,
-            libraryItemId = item.libraryItemId,
-            episodeId = item.episodeId,
-            itemOrder = index,
-          ),
+    // Persist the resolved episode (if any) so the hydration path can find it.
+    val podcast = item.libraryItem.media as? Media.Podcast
+    val episode = item.episode
+    if (podcast != null && episode != null) {
+      db.podcastEpisodeQueries.insert(
+        episode.asDbModel(podcastMediaId = podcast.id),
+      )
+      episode.audioTrack?.let { track ->
+        db.podcastEpisodeAudioTrackQueries.insert(
+          track.asEpisodeDbModel(episodeId = episode.id),
         )
       }
     }
+
+    db.playlistItemJoinQueries.insert(
+      PlaylistItemJoin(
+        playlistId = playlistId,
+        libraryItemId = item.libraryItemId,
+        episodeId = item.episodeId.orEmpty(),
+        itemOrder = order,
+      ),
+    )
   }
 
   private suspend fun writeCreate(
@@ -219,7 +238,7 @@ class PlaylistsSourceOfTruthFactory(
           PlaylistItemJoin(
             playlistId = mutation.creationId,
             libraryItemId = item.libraryItemId,
-            episodeId = item.episodeId,
+            episodeId = item.episodeId.orEmpty(),
             itemOrder = index,
           ),
         )
@@ -251,7 +270,7 @@ class PlaylistsSourceOfTruthFactory(
           PlaylistItemJoin(
             playlistId = mutation.id,
             libraryItemId = item.libraryItemId,
-            episodeId = item.episodeId,
+            episodeId = item.episodeId.orEmpty(),
             itemOrder = index,
           ),
         )
@@ -271,7 +290,7 @@ class PlaylistsSourceOfTruthFactory(
         PlaylistItemJoin(
           playlistId = mutation.playlistId,
           libraryItemId = mutation.item.libraryItemId,
-          episodeId = mutation.item.episodeId,
+          episodeId = mutation.item.episodeId.orEmpty(),
           itemOrder = playlistCount.toInt(),
         ),
       )
@@ -284,6 +303,7 @@ class PlaylistsSourceOfTruthFactory(
     db.playlistItemJoinQueries.deleteForItem(
       playlistId = mutation.playlistId,
       libraryItemId = mutation.item.libraryItemId,
+      episodeId = mutation.item.episodeId.orEmpty(),
     )
   }
 

--- a/features/playlists/impl/src/commonMain/kotlin/app/campfire/playlists/store/PlaylistsUpdaterFactory.kt
+++ b/features/playlists/impl/src/commonMain/kotlin/app/campfire/playlists/store/PlaylistsUpdaterFactory.kt
@@ -84,7 +84,7 @@ class PlaylistsUpdaterFactory(
         // Copy over the junction entries
         playlist.items.forEachIndexed { index, item ->
           db.playlistItemJoinQueries.insert(
-            PlaylistItemJoin(playlist.id, item.libraryItemId, item.episodeId, index),
+            PlaylistItemJoin(playlist.id, item.libraryItemId, item.episodeId.orEmpty(), index),
           )
         }
 

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailPresenter.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailPresenter.kt
@@ -16,7 +16,6 @@ import app.campfire.audioplayer.PlaybackController
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
-import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Playlist
 import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.playlists.api.PlaylistsRepository
@@ -93,7 +92,7 @@ class PlaylistDetailPresenter(
     val playlistItemsState by remember(playlistId) {
       playlistsRepository.observePlaylistItems(playlistId)
         .map { LoadState.Loaded(it) }
-        .catch<LoadState<out List<LibraryItem>>> { emit(LoadState.Error) }
+        .catch<LoadState<out List<Playlist.Item.Expanded>>> { emit(LoadState.Error) }
     }.collectAsState(LoadState.Loading)
 
     // A local cache of playlist items that we can re-order and then dispatch when finished
@@ -116,10 +115,12 @@ class PlaylistDetailPresenter(
       playlistContentState = playlistItemsState,
       playlistItems = playlistItems,
       offlineStates = offlineStates,
-      reorderSink = { from, to ->
-        val fromIndex = playlistItems.indexOfFirst { it.id == from }
-        val toIndex = playlistItems.indexOfFirst { it.id == to }
-        playlistItems.add(toIndex, playlistItems.removeAt(fromIndex))
+      reorderSink = { fromKey, toKey ->
+        val fromIndex = playlistItems.indexOfFirst { it.key == fromKey }
+        val toIndex = playlistItems.indexOfFirst { it.key == toKey }
+        if (fromIndex >= 0 && toIndex >= 0) {
+          playlistItems.add(toIndex, playlistItems.removeAt(fromIndex))
+        }
       },
     ) { event ->
       when (event) {
@@ -136,21 +137,28 @@ class PlaylistDetailPresenter(
           analytics.send(ContentSelected(ContentType.LibraryItem))
           navigator.goTo(
             LibraryItemScreen(
-              libraryItemId = event.libraryItem.id,
-              sharedTransitionKey = event.libraryItem.id + screen.playlistName,
+              libraryItemId = event.item.libraryItem.id,
+              episodeId = event.item.episodeId,
+              sharedTransitionKey = event.item.key + screen.playlistName,
             ),
           )
         }
 
         is PlaylistDetailUiEvent.PlayClick -> {
           analytics.send(ActionEvent("playlist_item", "play"))
-          playbackController.startSession(event.libraryItem.id)
+          playbackController.startSession(
+            itemId = event.item.libraryItem.id,
+            episodeId = event.item.episodeId,
+          )
         }
 
         is PlaylistDetailUiEvent.RemoveItem -> {
           analytics.send(ActionEvent("playlist_item", "deleted"))
           scope.launch {
-            playlistsRepository.removeFromPlaylist(screen.playlistId, Playlist.Item.Minified(event.libraryItem))
+            playlistsRepository.removeFromPlaylist(
+              playlistId = screen.playlistId,
+              item = event.item.asMinified(),
+            )
           }
         }
 
@@ -160,7 +168,7 @@ class PlaylistDetailPresenter(
               playlistId = screen.playlistId,
               name = playlistName,
               description = playlistDescription,
-              items = playlistItems.map { Playlist.Item.Minified(it) },
+              items = playlistItems.map { it.asMinified() },
             )
           }
         }
@@ -171,10 +179,16 @@ class PlaylistDetailPresenter(
             val firstItem = playlistItems.firstOrNull() ?: return@launch
             val queueItems = playlistItems.drop(1)
 
-            playbackController.startSession(firstItem.id)
+            playbackController.startSession(
+              itemId = firstItem.libraryItem.id,
+              episodeId = firstItem.episodeId,
+            )
             if (queueItems.isNotEmpty()) {
               sessionQueue.clear()
-              sessionQueue.addAll(queueItems)
+              // Per-item add — addAll() is book-only and would drop episodeIds.
+              queueItems.forEach { item ->
+                sessionQueue.add(item.libraryItem, item.episode)
+              }
             }
           }
         }
@@ -182,7 +196,12 @@ class PlaylistDetailPresenter(
         is PlaylistDetailUiEvent.DownloadAll -> {
           analytics.send(ActionEvent("playlist", "download"))
           settings.showConfirmDownload = !event.doNotShowAgain
-          downloadManager.downloadAll(playlistItems)
+          // Offline downloads are item-scoped, not episode-scoped; de-dupe podcast
+          // entries that share a library item.
+          val uniqueLibraryItems = playlistItems
+            .map { it.libraryItem }
+            .distinctBy { it.id }
+          downloadManager.downloadAll(uniqueLibraryItems)
         }
       }
     }

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUi.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUi.kt
@@ -53,8 +53,8 @@ import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.dialog.ConfirmDownloadDialog
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
-import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.Playlist
 import app.campfire.core.offline.OfflineStatus
 import app.campfire.playlists.api.screen.PlaylistDetailScreen
 import app.campfire.playlists.ui.detail.composables.PlaylistFloatingToolbar
@@ -110,8 +110,11 @@ fun PlaylistDetail(
   }
 
   if (showConfirmDownloadDialog) {
+    val downloadConfirmItems = remember(state.playlistItems) {
+      state.playlistItems.map { it.libraryItem }.distinctBy { it.id }
+    }
     ConfirmDownloadDialog(
-      state.playlistItems,
+      downloadConfirmItems,
       onConfirm = { doNotShowAgain ->
         if (postNotificationPermissionState is PermissionState.Granted) {
           state.eventSink(PlaylistDetailUiEvent.DownloadAll(doNotShowAgain))
@@ -205,7 +208,12 @@ fun PlaylistDetail(
           state.eventSink(PlaylistDetailUiEvent.ReorderStopped)
         },
         offlineStateSelector = { itemId -> state.offlineStates[itemId].asWidgetStatus() },
-        isPlayingSelector = { itemId -> state.currentSession?.libraryItem?.id == itemId },
+        isPlayingSelector = { item ->
+          val session = state.currentSession
+          session != null &&
+            session.libraryItem.id == item.libraryItemId &&
+            session.episodeId == item.episodeId
+        },
         contentPadding = paddingValues + PaddingValues(
           // 2 x 16dp (padding) + 56dp (toolbar)
           bottom = 104.dp,
@@ -246,15 +254,15 @@ private fun PlaylistTopBar(
 private fun LoadedContent(
   name: String,
   description: String?,
-  items: List<LibraryItem>,
+  items: List<Playlist.Item.Expanded>,
   isReordering: Boolean,
-  onItemClick: (LibraryItem) -> Unit,
-  onPlayClick: (LibraryItem) -> Unit,
-  onRemove: (LibraryItem) -> Unit,
-  onReorderItem: suspend (from: LibraryItemId, to: LibraryItemId) -> Unit,
+  onItemClick: (Playlist.Item.Expanded) -> Unit,
+  onPlayClick: (Playlist.Item.Expanded) -> Unit,
+  onRemove: (Playlist.Item.Expanded) -> Unit,
+  onReorderItem: suspend (fromKey: String, toKey: String) -> Unit,
   onReorderStopped: () -> Unit,
   offlineStateSelector: (LibraryItemId) -> OfflineStatus,
-  isPlayingSelector: (LibraryItemId) -> Boolean,
+  isPlayingSelector: (Playlist.Item.Expanded) -> Boolean,
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = PaddingValues(),
   state: LazyListState = rememberLazyListState(),
@@ -262,7 +270,7 @@ private fun LoadedContent(
   val haptics = LocalHapticFeedback.current
   val reorderableLazyListState = rememberReorderableLazyListState(state) { from, to ->
     haptics.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
-    onReorderItem(from.key as LibraryItemId, to.key as LibraryItemId)
+    onReorderItem(from.key as String, to.key as String)
   }
   LazyColumn(
     state = state,
@@ -279,16 +287,16 @@ private fun LoadedContent(
 
     itemsIndexed(
       items = items,
-      key = { _, item -> item.id },
+      key = { _, item -> item.key },
     ) { index, item ->
-      ReorderableItem(reorderableLazyListState, key = item.id) { isDragging ->
+      ReorderableItem(reorderableLazyListState, key = item.key) { isDragging ->
         val interactionSource = remember { MutableInteractionSource() }
         PlaylistListItem(
           item = item,
-          sharedTransitionKey = item.id + name,
+          sharedTransitionKey = item.key + name,
           sharedTransitionZIndex = (items.size - index) + 1f,
-          offlineStatus = offlineStateSelector(item.id),
-          isPlaying = isPlayingSelector(item.id),
+          offlineStatus = offlineStateSelector(item.libraryItem.id),
+          isPlaying = isPlayingSelector(item),
           onClick = {
             onItemClick(item)
           },

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUiState.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUiState.kt
@@ -3,7 +3,6 @@ package app.campfire.playlists.ui.detail
 import androidx.compose.runtime.Stable
 import app.campfire.audioplayer.offline.OfflineDownload
 import app.campfire.core.coroutines.LoadState
-import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.Playlist
 import app.campfire.core.model.Session
@@ -17,19 +16,19 @@ data class PlaylistDetailUiState(
   val currentSession: Session?,
   val showConfirmDownloadDialog: Boolean,
   val playlistState: LoadState<out Playlist>,
-  val playlistContentState: LoadState<out List<LibraryItem>>,
-  val playlistItems: List<LibraryItem>,
+  val playlistContentState: LoadState<out List<Playlist.Item.Expanded>>,
+  val playlistItems: List<Playlist.Item.Expanded>,
   val offlineStates: Map<LibraryItemId, OfflineDownload>,
-  val reorderSink: suspend (from: LibraryItemId, to: LibraryItemId) -> Unit,
+  val reorderSink: suspend (fromKey: String, toKey: String) -> Unit,
   val eventSink: (PlaylistDetailUiEvent) -> Unit,
 ) : CircuitUiState
 
 sealed interface PlaylistDetailUiEvent : CircuitUiEvent {
   data object Back : PlaylistDetailUiEvent
   data object Delete : PlaylistDetailUiEvent
-  data class ItemClick(val libraryItem: LibraryItem) : PlaylistDetailUiEvent
-  data class PlayClick(val libraryItem: LibraryItem) : PlaylistDetailUiEvent
-  data class RemoveItem(val libraryItem: LibraryItem) : PlaylistDetailUiEvent
+  data class ItemClick(val item: Playlist.Item.Expanded) : PlaylistDetailUiEvent
+  data class PlayClick(val item: Playlist.Item.Expanded) : PlaylistDetailUiEvent
+  data class RemoveItem(val item: Playlist.Item.Expanded) : PlaylistDetailUiEvent
   data class DownloadAll(val doNotShowAgain: Boolean = true) : PlaylistDetailUiEvent
 
   data object PlayAll : PlaylistDetailUiEvent

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/composables/PlaylistHeader.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/composables/PlaylistHeader.kt
@@ -19,14 +19,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.extensions.thresholdReadoutFormat
-import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.Playlist
 import kotlin.time.Duration
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun PlaylistHeader(
   description: String?,
-  items: List<LibraryItem>,
+  items: List<Playlist.Item.Expanded>,
   modifier: Modifier = Modifier,
 ) {
   Column(
@@ -51,8 +51,9 @@ internal fun PlaylistHeader(
         ),
       verticalAlignment = Alignment.CenterVertically,
     ) {
+      val itemLabel = if (items.size == 1) "Item" else "Items"
       Text(
-        text = "${items.size} Books",
+        text = "${items.size} $itemLabel",
         style = MaterialTheme.typography.labelLarge,
         fontWeight = FontWeight.SemiBold,
       )
@@ -66,7 +67,12 @@ internal fun PlaylistHeader(
       )
       Spacer(Modifier.width(4.dp))
       Text(
-        text = items.fold(Duration.ZERO) { acc, item -> item.media.duration + acc }.thresholdReadoutFormat(),
+        text = items.fold(Duration.ZERO) { acc, item ->
+          // Podcast entries reflect the chosen episode's duration; book entries reflect
+          // the whole library item.
+          val itemDuration = item.episode?.duration ?: item.libraryItem.media.duration
+          acc + itemDuration
+        }.thresholdReadoutFormat(),
         style = MaterialTheme.typography.labelLarge,
         fontWeight = FontWeight.SemiBold,
       )

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/composables/PlaylistListItem.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/composables/PlaylistListItem.kt
@@ -37,7 +37,7 @@ import app.campfire.common.compose.widgets.swipetodismiss.AnimatedRemoveBackgrou
 import app.campfire.common.compose.widgets.swipetodismiss.SwipeToDismissBox
 import app.campfire.common.compose.widgets.swipetodismiss.SwipeToDismissBoxValue
 import app.campfire.common.compose.widgets.swipetodismiss.rememberSwipeToDismissBoxState
-import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.Playlist
 import app.campfire.core.model.preview.libraryItem
 import app.campfire.core.offline.OfflineStatus
 import com.slack.circuit.sharedelements.PreviewSharedElementTransitionLayout
@@ -45,13 +45,13 @@ import com.slack.circuit.sharedelements.PreviewSharedElementTransitionLayout
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun PlaylistListItem(
-  item: LibraryItem,
+  item: Playlist.Item.Expanded,
   onClick: () -> Unit,
   onPlayClick: () -> Unit,
   onRemove: () -> Unit,
   modifier: Modifier = Modifier,
   handleModifier: Modifier = Modifier,
-  sharedTransitionKey: String = item.id,
+  sharedTransitionKey: String = item.key,
   sharedTransitionZIndex: Float = 0f,
   offlineStatus: OfflineStatus = OfflineStatus.None,
   isPlaying: Boolean = false,
@@ -96,13 +96,19 @@ internal fun PlaylistListItem(
       }
     }
 
+    val episode = item.episode
     LibraryItemListItem(
-      libraryItem = item,
+      libraryItem = item.libraryItem,
       onClick = onClick,
       offlineStatus = offlineStatus,
       interactionSource = interactionSource,
       sharedTransitionKey = sharedTransitionKey,
       sharedTransitionZIndex = sharedTransitionZIndex,
+      // For podcast episodes, surface the episode in place of the parent podcast so the
+      // playlist row identifies the actual playable unit.
+      titleOverride = episode?.title,
+      subtitleOverride = episode?.let { item.libraryItem.media.metadata.title },
+      durationOverride = episode?.duration,
       modifier = Modifier.weight(1f),
       trailingContent = {
         FilledTonalIconButton(
@@ -145,13 +151,13 @@ fun PlaylistItemPreview() {
         Surface(Modifier.fillMaxSize()) {
           Column {
             PlaylistListItem(
-              item = libraryItem("item_1"),
+              item = previewExpandedItem("item_1", index = 0),
               onClick = {},
               onRemove = {},
               onPlayClick = {},
             )
             PlaylistListItem(
-              item = libraryItem("item_2"),
+              item = previewExpandedItem("item_2", index = 1),
               onClick = {},
               onRemove = {},
               onPlayClick = {},
@@ -160,7 +166,7 @@ fun PlaylistItemPreview() {
               offlineStatus = OfflineStatus.Downloading(0.4f),
             )
             PlaylistListItem(
-              item = libraryItem("item_3"),
+              item = previewExpandedItem("item_3", index = 2),
               onClick = {},
               onRemove = {},
               onPlayClick = {},
@@ -173,4 +179,14 @@ fun PlaylistItemPreview() {
       }
     }
   }
+}
+
+private fun previewExpandedItem(id: String, index: Int): Playlist.Item.Expanded {
+  val item = libraryItem(id)
+  return Playlist.Item.Expanded(
+    index = index,
+    libraryItemId = item.id,
+    episodeId = null,
+    libraryItem = item,
+  )
 }

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/dialog/AddToPlaylistDialogImpl.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/dialog/AddToPlaylistDialogImpl.kt
@@ -65,6 +65,7 @@ import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Playlist
+import app.campfire.core.model.PodcastEpisode
 import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import app.campfire.playlists.api.dialog.PlaylistDialogResult
 import campfire.features.playlists.ui.generated.resources.Res
@@ -82,7 +83,7 @@ import org.jetbrains.compose.resources.stringResource
 @ContributesBinding(UserScope::class)
 @Inject
 class AddToPlaylistDialogImpl(
-  private val presenterFactory: (LibraryItem, OnDismissListener) -> AddToPlaylistDialogPresenter,
+  private val presenterFactory: (LibraryItem, PodcastEpisode?, OnDismissListener) -> AddToPlaylistDialogPresenter,
 ) : AddToPlaylistDialog {
 
   @Composable
@@ -90,19 +91,22 @@ class AddToPlaylistDialogImpl(
     libraryItem: LibraryItem,
     onDismiss: (PlaylistDialogResult) -> Unit,
     modifier: Modifier,
+    episode: PodcastEpisode?,
   ) {
     Impression {
       ScreenViewEvent("AddToPlaylist", ScreenType.Dialog)
     }
 
-    val presenter = remember(libraryItem, onDismiss) {
-      presenterFactory(libraryItem, onDismiss)
+    val presenter = remember(libraryItem, episode, onDismiss) {
+      presenterFactory(libraryItem, episode, onDismiss)
     }
 
     val viewState = presenter.present()
     Content(
       viewState = viewState,
-      item = libraryItem,
+      // Surface the episode title for podcast entries so the user understands which unit
+      // they're adding; falls back to the library item title for books.
+      itemTitle = episode?.title ?: libraryItem.media.metadata.title.orEmpty(),
       onDismiss = { onDismiss(PlaylistDialogResult.None) },
       modifier = modifier,
     )
@@ -111,7 +115,7 @@ class AddToPlaylistDialogImpl(
   @Composable
   private fun Content(
     viewState: AddToPlaylistViewState,
-    item: LibraryItem,
+    itemTitle: String,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     properties: DialogProperties = DialogProperties(
@@ -144,7 +148,7 @@ class AddToPlaylistDialogImpl(
             buildAnnotatedString {
               append(stringResource(Res.string.dialog_add_playlist_text))
               withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                append("\"${item.media.metadata.title}\"")
+                append("\"$itemTitle\"")
               }
             },
           )

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/dialog/AddToPlaylistDialogPresenter.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/dialog/AddToPlaylistDialogPresenter.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Playlist
+import app.campfire.core.model.PodcastEpisode
 import app.campfire.playlists.api.PlaylistsRepository
 import app.campfire.playlists.api.dialog.PlaylistDialogResult
 import com.slack.circuit.runtime.presenter.Presenter
@@ -24,6 +25,7 @@ typealias OnDismissListener = (PlaylistDialogResult) -> Unit
 @Inject
 class AddToPlaylistDialogPresenter(
   @Assisted private val libraryItem: LibraryItem,
+  @Assisted private val episode: PodcastEpisode?,
   @Assisted private val onDismiss: OnDismissListener,
   private val playlistsRepository: PlaylistsRepository,
 ) : Presenter<AddToPlaylistViewState> {
@@ -52,7 +54,7 @@ class AddToPlaylistDialogPresenter(
             scope.launch {
               playlistsRepository.addToPlaylist(
                 playlistId = event.playlist.id,
-                item = Playlist.Item.Minified(libraryItem),
+                item = Playlist.Item.Minified(libraryItem, episode),
               ).onSuccess {
                 onDismiss(
                   PlaylistDialogResult.Existing(
@@ -70,7 +72,7 @@ class AddToPlaylistDialogPresenter(
             scope.launch {
               val newPlaylistId = playlistsRepository.createPlaylist(
                 name = event.playlistName,
-                items = listOf(Playlist.Item.Minified(libraryItem)),
+                items = listOf(Playlist.Item.Minified(libraryItem, episode)),
               ).onSuccess { newPlaylistId ->
                 onDismiss(PlaylistDialogResult.New(newPlaylistId))
               }.onFailure {

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
@@ -206,8 +206,10 @@ class MediaTree(
       .firstOrNull()
       ?: return emptyList()
 
+    // Browse currently surfaces the parent library item; podcast episodes within a
+    // playlist still resolve to the parent podcast for Android Auto navigation.
     return items.map { item ->
-      item.asBrowsableMediaItem()
+      item.libraryItem.asBrowsableMediaItem()
     }
   }
 


### PR DESCRIPTION
## Summary
- Playlists now hold podcast episodes alongside books; the same podcast can appear multiple times under distinct episode IDs.
- Per-row playback, play-all and the queue all honor the chosen episode; the episode bottom sheet's "Add to playlist" action now actually works.
- Migration 6 grows the `playlistItemJoin` PK to include `episodeId` (empty-string sentinel matching the other tables); the book-only `selectForPlaylist` join is dropped in favor of junction-driven hydration via `LibraryItemDao.hydrateById`.
- Network DTO grows a top-level `episode` field on `PlaylistItem.Expanded` — the ABS playlist endpoint returns the resolved episode there, and the nested `libraryItem.media` is the *minified* podcast (no episodes array). The SoT persists that episode separately and switches its libraryItem write to `ignoreOnInsert` so an existing fully-fetched podcast's episode cache isn't cascade-deleted.

## Related issues

Closes #791

## Screenshots / recordings
_To add._

## Test plan
- [ ] Open a podcast, tap an episode → "Add to playlist" → pick a playlist; confirm the episode title (not the podcast title) renders on the playlist row.
- [ ] Add multiple episodes from the same podcast to one playlist; verify each is a distinct row, drag-reorder works, and removing one leaves the others.
- [ ] Tap the per-row play button on an episode → playback starts on that episode.
- [ ] "Play all" on a mixed book/podcast playlist → first item plays, the rest queue with the correct episode IDs.
- [ ] Sync a playlist from another client (web/iOS) and confirm episode rows hydrate correctly without re-fetching the podcast detail first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)