### PR TITLE
Wrap all IconButtons with IconButtonTooltip for a11y

### DIFF
--- a/common/compose/src/commonMain/composeResources/values/common_compose_strings.xml
+++ b/common/compose/src/commonMain/composeResources/values/common_compose_strings.xml
@@ -24,6 +24,10 @@
   <string name="action_show_less">Show less</string>
   <string name="action_show_more">Show more</string>
   <string name="action_remove">REMOVE</string>
+  <string name="action_clear_search">Clear search</string>
+  <string name="action_filter">Filter</string>
+  <string name="action_sort">Sort</string>
+  <string name="action_open_menu">Open menu</string>
 
   <string name="dialog_download_message_prefix">This will download</string>
   <string name="dialog_download_message_suffix">onto your devices internal storage.</string>

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/DropdownIconButton.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/DropdownIconButton.kt
@@ -21,6 +21,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.extensions.alpha
+import campfire.common.compose.generated.resources.Res
+import campfire.common.compose.generated.resources.action_open_menu
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun <T> DropdownIconButton(
@@ -35,11 +38,14 @@ fun <T> DropdownIconButton(
   optionIcon: (@Composable (T) -> Unit)? = null,
 ) {
   var isExpanded by remember { mutableStateOf(false) }
+  val menuLabel = stringResource(Res.string.action_open_menu)
   Box(modifier) {
-    IconButton(
-      onClick = { isExpanded = true },
-      content = icon,
-    )
+    IconButtonTooltip(text = menuLabel) {
+      IconButton(
+        onClick = { isExpanded = true },
+        content = icon,
+      )
+    }
 
     DropdownMenu(
       expanded = isExpanded,
@@ -92,11 +98,14 @@ fun <T> DropdownIconButton(
   optionIcon: (@Composable (T) -> Unit)? = null,
 ) {
   var isExpanded by remember { mutableStateOf(false) }
+  val menuLabel = stringResource(Res.string.action_open_menu)
   Box(modifier) {
-    IconButton(
-      onClick = { isExpanded = true },
-      content = icon,
-    )
+    IconButtonTooltip(text = menuLabel) {
+      IconButton(
+        onClick = { isExpanded = true },
+        content = icon,
+      )
+    }
 
     DropdownMenu(
       expanded = isExpanded,

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/FilterBar.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/FilterBar.kt
@@ -37,6 +37,10 @@ import app.campfire.core.settings.ContentSortMode
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SortDirection
 import app.campfire.core.settings.SortDisplayMode
+import campfire.common.compose.generated.resources.Res
+import campfire.common.compose.generated.resources.action_filter
+import campfire.common.compose.generated.resources.action_sort
+import org.jetbrains.compose.resources.stringResource
 
 private val FilterBarHeight = 56.dp
 
@@ -100,15 +104,20 @@ fun FilterBar(
       )
 
       if (onFilterClick != null) {
-        IconButton(
-          onClick = onFilterClick,
+        val filterLabel = stringResource(Res.string.action_filter)
+        IconButtonTooltip(
+          text = filterLabel,
           modifier = Modifier.offset(x = 12.dp),
         ) {
-          Icon(
-            if (isFiltered) Icons.Rounded.FilterAlt else Icons.Rounded.FilterAltOff,
-            contentDescription = null,
-            tint = if (isFiltered) MaterialTheme.colorScheme.primary else LocalContentColor.current,
-          )
+          IconButton(
+            onClick = onFilterClick,
+          ) {
+            Icon(
+              if (isFiltered) Icons.Rounded.FilterAlt else Icons.Rounded.FilterAltOff,
+              contentDescription = filterLabel,
+              tint = if (isFiltered) MaterialTheme.colorScheme.primary else LocalContentColor.current,
+            )
+          }
         }
       }
     }
@@ -125,14 +134,19 @@ private fun SortIconButton(
   val sortIcon = SortIcon.forMode(sortMode)
   val icon = sortIcon.forDirection(sortDirection)
 
-  IconButton(
-    onClick = onClick,
+  val sortLabel = stringResource(Res.string.action_sort)
+  IconButtonTooltip(
+    text = sortLabel,
     modifier = modifier,
   ) {
-    Icon(
-      icon,
-      contentDescription = null,
-    )
+    IconButton(
+      onClick = onClick,
+    ) {
+      Icon(
+        icon,
+        contentDescription = sortLabel,
+      )
+    }
   }
 }
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/SearchBar.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/SearchBar.kt
@@ -26,6 +26,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import campfire.common.compose.generated.resources.Res
+import campfire.common.compose.generated.resources.action_clear_search
+import org.jetbrains.compose.resources.stringResource
 
 val SearchBarHeight = 56.dp
 val SearchBarElevation = 6.dp
@@ -88,13 +91,16 @@ fun SearchBar(
         )
 
         if (!query.isNullOrEmpty()) {
-          IconButton(
-            onClick = {
-              query = null
-              onQueryCleared()
-            },
-          ) {
-            Icon(Icons.Rounded.Close, contentDescription = null)
+          val clearSearchLabel = stringResource(Res.string.action_clear_search)
+          IconButtonTooltip(text = clearSearchLabel) {
+            IconButton(
+              onClick = {
+                query = null
+                onQueryCleared()
+              },
+            ) {
+              Icon(Icons.Rounded.Close, contentDescription = clearSearchLabel)
+            }
           }
         }
       }

--- a/data/account/ui/src/commonMain/composeResources/values/account_ui_strings.xml
+++ b/data/account/ui/src/commonMain/composeResources/values/account_ui_strings.xml
@@ -12,4 +12,6 @@
   <string name="account_picker_logout_action_dismiss">Cancel</string>
 
   <string name="libraries_error_message">Uh-oh! Something went wrong trying to load your libraries.</string>
+
+  <string name="action_switch_account">Switch account</string>
 </resources>

--- a/data/account/ui/src/commonMain/kotlin/app/campfire/account/ui/switcher/AccountSwitcher.kt
+++ b/data/account/ui/src/commonMain/kotlin/app/campfire/account/ui/switcher/AccountSwitcher.kt
@@ -50,11 +50,13 @@ import app.campfire.common.compose.icons.asComposeIcon
 import app.campfire.common.compose.icons.rounded.AccountSwitch
 import app.campfire.common.compose.icons.theme.rememberWallVectorPainter
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.Library
 import app.campfire.ui.theming.api.AppTheme
 import campfire.data.account.ui.generated.resources.Res
+import campfire.data.account.ui.generated.resources.action_switch_account
 import campfire.data.account.ui.generated.resources.libraries_error_message
 import campfire.data.account.ui.generated.resources.server_name_error
 import campfire.data.account.ui.generated.resources.server_name_loading
@@ -202,13 +204,16 @@ private fun AccountSwitcher(
 
       Spacer(Modifier.width(16.dp))
 
-      IconButton(
-        onClick = onClick,
-      ) {
-        Icon(
-          CampfireIcons.Rounded.AccountSwitch,
-          contentDescription = null,
-        )
+      val switchAccountLabel = stringResource(Res.string.action_switch_account)
+      IconButtonTooltip(text = switchAccountLabel) {
+        IconButton(
+          onClick = onClick,
+        ) {
+          Icon(
+            CampfireIcons.Rounded.AccountSwitch,
+            contentDescription = switchAccountLabel,
+          )
+        }
       }
     }
 

--- a/features/auth/ui/src/commonMain/composeResources/values/auth_ui_strings.xml
+++ b/features/auth/ui/src/commonMain/composeResources/values/auth_ui_strings.xml
@@ -22,4 +22,11 @@
   <string name="login_add_account_title">Add campsite</string>
   <string name="login_reauth_account_title">Reauthenticate</string>
   <string name="action_finish_analytics_consent">Finish</string>
+
+  <string name="action_back">Back</string>
+  <string name="action_clear_server_url">Clear server address</string>
+  <string name="action_show_password">Show password</string>
+  <string name="action_hide_password">Hide password</string>
+  <string name="action_add_header">Add extra header</string>
+  <string name="action_delete_header">Delete extra header</string>
 </resources>

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUi.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUi.kt
@@ -57,11 +57,13 @@ import app.campfire.common.compose.layout.ContentLayout
 import app.campfire.common.compose.layout.LocalContentLayout
 import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.screens.LoginScreen
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.Tent
 import campfire.features.auth.ui.generated.resources.Res
 import campfire.features.auth.ui.generated.resources.action_add_campsite
+import campfire.features.auth.ui.generated.resources.action_back
 import campfire.features.auth.ui.generated.resources.action_login_openid
 import campfire.features.auth.ui.generated.resources.label_authenticating_loading_message
 import campfire.features.auth.ui.generated.resources.login_add_account_title
@@ -111,10 +113,13 @@ private fun LoginContent(
           },
           navigationIcon = {
             if (screen is LoginScreen.Additional) {
-              IconButton(
-                onClick = { state.eventSink(LoginUiEvent.NavigateBack) },
-              ) {
-                Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+              val backLabel = stringResource(Res.string.action_back)
+              IconButtonTooltip(text = backLabel) {
+                IconButton(
+                  onClick = { state.eventSink(LoginUiEvent.NavigateBack) },
+                ) {
+                  Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+                }
               }
             }
           },

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/composables/ServerCard.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/composables/ServerCard.kt
@@ -81,9 +81,13 @@ import app.campfire.common.compose.icons.rounded.Connected
 import app.campfire.common.compose.icons.rounded.Disconnected
 import app.campfire.common.compose.icons.rounded.Settings
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.model.NetworkSettings
 import app.campfire.core.model.Tent
 import campfire.features.auth.ui.generated.resources.Res
+import campfire.features.auth.ui.generated.resources.action_clear_server_url
+import campfire.features.auth.ui.generated.resources.action_hide_password
+import campfire.features.auth.ui.generated.resources.action_show_password
 import campfire.features.auth.ui.generated.resources.invalid_server_url
 import campfire.features.auth.ui.generated.resources.label_login_error_auth
 import campfire.features.auth.ui.generated.resources.label_login_error_network
@@ -207,13 +211,16 @@ internal fun ServerCard(
       },
       trailingIcon = if (serverUrl.isNotBlank()) {
         {
-          IconButton(
-            onClick = {
-              onServerUrlChange("")
-              serverUrlFocus.requestFocus()
-            },
-          ) {
-            Icon(Icons.Rounded.Cancel, contentDescription = null)
+          val clearLabel = stringResource(Res.string.action_clear_server_url)
+          IconButtonTooltip(text = clearLabel) {
+            IconButton(
+              onClick = {
+                onServerUrlChange("")
+                serverUrlFocus.requestFocus()
+              },
+            ) {
+              Icon(Icons.Rounded.Cancel, contentDescription = clearLabel)
+            }
           }
         }
       } else {
@@ -324,13 +331,18 @@ internal fun ServerCard(
             label = { Text(stringResource(Res.string.label_password)) },
             leadingIcon = { Icon(Icons.Rounded.Password, contentDescription = null) },
             trailingIcon = {
-              IconButton(
-                onClick = { showPassword = !showPassword },
-              ) {
-                Icon(
-                  if (showPassword) Icons.Rounded.Visibility else Icons.Rounded.VisibilityOff,
-                  contentDescription = null,
-                )
+              val showPasswordLabel = stringResource(
+                if (showPassword) Res.string.action_hide_password else Res.string.action_show_password,
+              )
+              IconButtonTooltip(text = showPasswordLabel) {
+                IconButton(
+                  onClick = { showPassword = !showPassword },
+                ) {
+                  Icon(
+                    if (showPassword) Icons.Rounded.Visibility else Icons.Rounded.VisibilityOff,
+                    contentDescription = showPasswordLabel,
+                  )
+                }
               }
             },
             visualTransformation = if (showPassword) VisualTransformation.None else PasswordVisualTransformation(),

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/settings/NetworkSettingsBottomSheet.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/settings/NetworkSettingsBottomSheet.kt
@@ -40,9 +40,14 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.model.NetworkSettings
+import campfire.features.auth.ui.generated.resources.Res
+import campfire.features.auth.ui.generated.resources.action_add_header
+import campfire.features.auth.ui.generated.resources.action_delete_header
 import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuitx.overlays.BottomSheetOverlay
+import org.jetbrains.compose.resources.stringResource
 
 data class NetworkSettingsModel(val settings: NetworkSettings?)
 
@@ -170,21 +175,26 @@ private fun NetworkSettingsBottomSheet(
 
       Spacer(Modifier.size(8.dp))
 
-      FilledIconButton(
-        shapes = IconButtonDefaults.shapes(),
-        enabled = newHeaderName.text.isNotBlank() &&
-          newHeaderValue.text.isNotBlank(),
-        onClick = {
-          headers[newHeaderName.text.toString()] = newHeaderValue.text.toString()
-          newHeaderName.clearText()
-          newHeaderValue.clearText()
-        },
+      val addHeaderLabel = stringResource(Res.string.action_add_header)
+      IconButtonTooltip(
+        text = addHeaderLabel,
         modifier = Modifier.padding(top = 8.dp),
       ) {
-        Icon(
-          Icons.Rounded.Add,
-          contentDescription = "Add Extra Header",
-        )
+        FilledIconButton(
+          shapes = IconButtonDefaults.shapes(),
+          enabled = newHeaderName.text.isNotBlank() &&
+            newHeaderValue.text.isNotBlank(),
+          onClick = {
+            headers[newHeaderName.text.toString()] = newHeaderValue.text.toString()
+            newHeaderName.clearText()
+            newHeaderValue.clearText()
+          },
+        ) {
+          Icon(
+            Icons.Rounded.Add,
+            contentDescription = addHeaderLabel,
+          )
+        }
       }
 
       Spacer(Modifier.size(8.dp))
@@ -263,14 +273,17 @@ private fun HeaderValue(
       overflow = TextOverflow.MiddleEllipsis,
     )
 
-    IconButton(
-      onClick = onDeleteClick,
-    ) {
-      Icon(
-        Icons.Rounded.Delete,
-        contentDescription = "Delete Extra Header",
-        tint = MaterialTheme.colorScheme.error,
-      )
+    val deleteHeaderLabel = stringResource(Res.string.action_delete_header)
+    IconButtonTooltip(text = deleteHeaderLabel) {
+      IconButton(
+        onClick = onDeleteClick,
+      ) {
+        Icon(
+          Icons.Rounded.Delete,
+          contentDescription = deleteHeaderLabel,
+          tint = MaterialTheme.colorScheme.error,
+        )
+      }
     }
   }
 }

--- a/features/author/ui/src/commonMain/composeResources/values/authors_ui_strings.xml
+++ b/features/author/ui/src/commonMain/composeResources/values/authors_ui_strings.xml
@@ -24,4 +24,6 @@
   <string name="sort_mode_num_books">Number of Books</string>
   <string name="sort_mode_added_at">Added at</string>
   <string name="sort_mode_updated_at">Updated at</string>
+
+  <string name="action_back">Back</string>
 </resources>

--- a/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailUi.kt
+++ b/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailUi.kt
@@ -33,6 +33,7 @@ import app.campfire.common.compose.extensions.plus
 import app.campfire.common.compose.widgets.AuthorSharedTransitionKey
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LibraryItemCard
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.screens.AuthorDetailScreen
@@ -43,6 +44,7 @@ import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.offline.OfflineStatus
 import campfire.features.author.ui.generated.resources.Res
+import campfire.features.author.ui.generated.resources.action_back
 import campfire.features.author.ui.generated.resources.author_books_empty_message
 import campfire.features.author.ui.generated.resources.author_books_header
 import campfire.features.author.ui.generated.resources.error_author_message
@@ -65,10 +67,13 @@ fun AuthorDetail(
         title = { Text(screen.authorName) },
         scrollBehavior = scrollBehavior,
         navigationIcon = {
-          IconButton(
-            onClick = { state.eventSink(AuthorDetailUiEvent.Back) },
-          ) {
-            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+          val backLabel = stringResource(Res.string.action_back)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(
+              onClick = { state.eventSink(AuthorDetailUiEvent.Back) },
+            ) {
+              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+            }
           }
         },
       )

--- a/features/collections/ui/src/commonMain/composeResources/values/collection_ui_strings.xml
+++ b/features/collections/ui/src/commonMain/composeResources/values/collection_ui_strings.xml
@@ -7,6 +7,10 @@
 
   <string name="action_add_new_collection">Create new</string>
   <string name="action_edit_collection">Edit</string>
+  <string name="action_back">Back</string>
+  <string name="action_close">Close</string>
+  <string name="action_delete_collection">Delete collection</string>
+  <string name="action_delete_selected_items">Delete selected items</string>
 
   <string name="dialog_confirm_delete_title">Delete collection</string>
   <string name="dialog_confirm_delete_message">Are you sure you want to delete</string>

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/CollectionDetailUi.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/CollectionDetailUi.kt
@@ -57,6 +57,7 @@ import app.campfire.collections.ui.detail.composables.EditingTopAppBar
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.extensions.plus
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemCollectionSharedTransitionKey
 import app.campfire.common.compose.widgets.LibraryItemCard
 import app.campfire.common.compose.widgets.LoadingListState
@@ -67,6 +68,7 @@ import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.offline.OfflineStatus
 import campfire.features.collections.ui.generated.resources.Res
+import campfire.features.collections.ui.generated.resources.action_delete_selected_items
 import campfire.features.collections.ui.generated.resources.action_edit_collection
 import campfire.features.collections.ui.generated.resources.dialog_confirm_delete_action_cancel
 import campfire.features.collections.ui.generated.resources.dialog_confirm_delete_action_delete
@@ -127,18 +129,21 @@ fun CollectionDetail(
               )
             },
             actions = {
-              IconButton(
-                onClick = {
-                  state.eventSink(CollectionDetailUiEvent.DeleteItems(selectedItems.toList()))
-                  isItemEditing = false
-                  selectedItems.clear()
-                },
-              ) {
-                Icon(
-                  Icons.Rounded.Delete,
-                  contentDescription = null,
-                  tint = MaterialTheme.colorScheme.error,
-                )
+              val deleteSelectedLabel = stringResource(Res.string.action_delete_selected_items)
+              IconButtonTooltip(text = deleteSelectedLabel) {
+                IconButton(
+                  onClick = {
+                    state.eventSink(CollectionDetailUiEvent.DeleteItems(selectedItems.toList()))
+                    isItemEditing = false
+                    selectedItems.clear()
+                  },
+                ) {
+                  Icon(
+                    Icons.Rounded.Delete,
+                    contentDescription = deleteSelectedLabel,
+                    tint = MaterialTheme.colorScheme.error,
+                  )
+                }
               }
             },
             onDismiss = {

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/composables/CollectionDetailTopAppBar.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/composables/CollectionDetailTopAppBar.kt
@@ -11,6 +11,11 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import campfire.features.collections.ui.generated.resources.Res
+import campfire.features.collections.ui.generated.resources.action_back
+import campfire.features.collections.ui.generated.resources.action_delete_collection
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun CollectionDetailTopAppBar(
@@ -26,22 +31,28 @@ fun CollectionDetailTopAppBar(
     title = { Text(name) },
     scrollBehavior = scrollBehavior,
     navigationIcon = {
-      IconButton(
-        onClick = onBack,
-      ) {
-        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+      val backLabel = stringResource(Res.string.action_back)
+      IconButtonTooltip(text = backLabel) {
+        IconButton(
+          onClick = onBack,
+        ) {
+          Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+        }
       }
     },
     actions = {
       if (canEdit) {
-        IconButton(
-          onClick = onDelete,
-        ) {
-          Icon(
-            Icons.Rounded.Delete,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.error,
-          )
+        val deleteLabel = stringResource(Res.string.action_delete_collection)
+        IconButtonTooltip(text = deleteLabel) {
+          IconButton(
+            onClick = onDelete,
+          ) {
+            Icon(
+              Icons.Rounded.Delete,
+              contentDescription = deleteLabel,
+              tint = MaterialTheme.colorScheme.error,
+            )
+          }
         }
       }
     },

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/composables/EditingTopAppBar.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/composables/EditingTopAppBar.kt
@@ -13,6 +13,10 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import campfire.features.collections.ui.generated.resources.Res
+import campfire.features.collections.ui.generated.resources.action_close
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun EditingTopAppBar(
@@ -42,10 +46,13 @@ fun EditingTopAppBar(
       navigationIconContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
     ),
     navigationIcon = {
-      IconButton(
-        onClick = onDismiss,
-      ) {
-        Icon(Icons.Rounded.Close, contentDescription = null)
+      val closeLabel = stringResource(Res.string.action_close)
+      IconButtonTooltip(text = closeLabel) {
+        IconButton(
+          onClick = onDismiss,
+        ) {
+          Icon(Icons.Rounded.Close, contentDescription = closeLabel)
+        }
       }
     },
     actions = actions,

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUi.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUi.kt
@@ -27,6 +27,7 @@ import app.campfire.common.compose.layout.LazyCampfireGrid
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemCollectionCard
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.screens.CollectionsScreen
@@ -34,6 +35,7 @@ import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.Collection
 import campfire.features.collections.ui.generated.resources.Res
+import campfire.features.collections.ui.generated.resources.action_back
 import campfire.features.collections.ui.generated.resources.collections_title
 import campfire.features.collections.ui.generated.resources.empty_collection_items_message
 import campfire.features.collections.ui.generated.resources.error_collection_items_message
@@ -55,10 +57,13 @@ fun Collections(
         title = { Text(stringResource(Res.string.collections_title)) },
         scrollBehavior = scrollBehavior,
         navigationIcon = {
-          IconButton(
-            onClick = { state.eventSink(CollectionsUiEvent.Back) },
-          ) {
-            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+          val backLabel = stringResource(Res.string.action_back)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(
+              onClick = { state.eventSink(CollectionsUiEvent.Back) },
+            ) {
+              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+            }
           }
         },
       )

--- a/features/filters/ui/src/commonMain/composeResources/values/filters_ui_strings.xml
+++ b/features/filters/ui/src/commonMain/composeResources/values/filters_ui_strings.xml
@@ -59,4 +59,6 @@
 
   <string name="filter_value_tracks_single">Single-track</string>
   <string name="filter_value_tracks_multi">Multi-track</string>
+
+  <string name="action_back">Back</string>
 </resources>

--- a/features/filters/ui/src/commonMain/kotlin/app/campfire/filters/ui/filters/ContentFilterBottomSheet.kt
+++ b/features/filters/ui/src/commonMain/kotlin/app/campfire/filters/ui/filters/ContentFilterBottomSheet.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import app.campfire.analytics.events.ScreenType
 import app.campfire.analytics.events.ScreenViewEvent
 import app.campfire.common.compose.analytics.Impression
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.bottomSheetShape
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.fluentIf
@@ -54,6 +55,7 @@ import app.campfire.filters.AllowedFilterCategories
 import app.campfire.filters.ContentFilterResult
 import app.campfire.filters.ContentFilterUi
 import campfire.features.filters.ui.generated.resources.Res
+import campfire.features.filters.ui.generated.resources.action_back
 import campfire.features.filters.ui.generated.resources.filter_category_author
 import campfire.features.filters.ui.generated.resources.filter_category_genre
 import campfire.features.filters.ui.generated.resources.filter_category_language
@@ -329,10 +331,13 @@ private fun <T : Any> FilterGroupOptionList(
   ) {
     TopAppBar(
       navigationIcon = {
-        IconButton(
-          onClick = onBackClick,
-        ) {
-          Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+        val backLabel = stringResource(Res.string.action_back)
+        IconButtonTooltip(text = backLabel) {
+          IconButton(
+            onClick = onBackClick,
+          ) {
+            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+          }
         }
       },
       title = {

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -95,4 +95,18 @@
 
   <string name="cd_back_arrow">Back</string>
   <string name="cd_add_to_collection">Add to collection</string>
+  <string name="action_theme_swatch">Pick theme color</string>
+  <string name="action_close_swatch">Close color picker</string>
+  <string name="action_play_episode">Play episode</string>
+  <string name="action_episode_options">Episode options</string>
+  <string name="action_open_episode_filter">Filter episodes</string>
+  <string name="action_search_button">Search</string>
+  <string name="action_play_book">Play book</string>
+  <string name="action_pause_playback">Pause</string>
+  <string name="action_add_episode_to_playlist">Add episode to playlist</string>
+  <string name="action_mark_episode_finished">Mark episode finished</string>
+  <string name="action_mark_episode_not_finished">Mark episode as not finished</string>
+  <string name="action_find_episodes">Find episodes</string>
+  <string name="action_retry_download">Retry download</string>
+  <string name="action_delete_download">Delete download</string>
 </resources>

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
@@ -56,6 +56,7 @@ import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.theme.colorScheme
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LibraryItemSharedTransitionKey
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.core.coroutines.LoadState
@@ -145,15 +146,18 @@ fun LibraryItemContent(
         title = {},
         scrollBehavior = scrollBehavior,
         navigationIcon = {
-          IconButton(
-            onClick = {
-              state.eventSink(LibraryItemUiEvent.OnBack)
-            },
-          ) {
-            Icon(
-              Icons.AutoMirrored.Rounded.ArrowBack,
-              contentDescription = stringResource(Res.string.cd_back_arrow),
-            )
+          val backLabel = stringResource(Res.string.cd_back_arrow)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(
+              onClick = {
+                state.eventSink(LibraryItemUiEvent.OnBack)
+              },
+            ) {
+              Icon(
+                Icons.AutoMirrored.Rounded.ArrowBack,
+                contentDescription = backLabel,
+              )
+            }
           }
         },
         actions = {
@@ -172,16 +176,19 @@ fun LibraryItemContent(
           }
 
           if (state.user.canEditCollections) {
-            IconButton(
-              onClick = {
-                Analytics.send(ActionEvent("add_to_collection", Click))
-                showAddToCollectionDialog = true
-              },
-            ) {
-              Icon(
-                Icons.Rounded.LibraryAdd,
-                contentDescription = stringResource(Res.string.cd_add_to_collection),
-              )
+            val addToCollectionLabel = stringResource(Res.string.cd_add_to_collection)
+            IconButtonTooltip(text = addToCollectionLabel) {
+              IconButton(
+                onClick = {
+                  Analytics.send(ActionEvent("add_to_collection", Click))
+                  showAddToCollectionDialog = true
+                },
+              ) {
+                Icon(
+                  Icons.Rounded.LibraryAdd,
+                  contentDescription = addToCollectionLabel,
+                )
+              }
             }
           }
         },

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ExpressiveControlBar.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ExpressiveControlBar.kt
@@ -75,6 +75,7 @@ import app.campfire.common.compose.icons.rounded.QueuePlayNext
 import app.campfire.common.compose.layout.ContentLayout
 import app.campfire.common.compose.layout.LocalContentLayout
 import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.extensions.asReadableBytes
 import app.campfire.core.model.MediaProgress
 import app.campfire.core.model.Tent
@@ -88,9 +89,11 @@ import campfire.features.libraries.ui.generated.resources.action_add_to_enqueue
 import campfire.features.libraries.ui.generated.resources.action_add_to_playlist_long
 import campfire.features.libraries.ui.generated.resources.action_add_to_playlist_short
 import campfire.features.libraries.ui.generated.resources.action_currently_playing
+import campfire.features.libraries.ui.generated.resources.action_delete_download
 import campfire.features.libraries.ui.generated.resources.action_delete_offline
 import campfire.features.libraries.ui.generated.resources.action_play
 import campfire.features.libraries.ui.generated.resources.action_resume_listening
+import campfire.features.libraries.ui.generated.resources.action_retry_download
 import campfire.features.libraries.ui.generated.resources.action_stop_downloading
 import campfire.features.libraries.ui.generated.resources.menu_item_discard_progress
 import campfire.features.libraries.ui.generated.resources.menu_item_discard_progress_short
@@ -217,20 +220,23 @@ private fun OfflineStatus(
           targetState = offlineDownload.isActive,
         ) { isActive ->
           if (isActive) {
-            FilledIconButton(
-              onClick = onStopClick,
-              shapes = IconButtonDefaults.shapes(),
-              modifier = Modifier.size(IconButtonDefaults.extraSmallContainerSize()),
-              colors = IconButtonDefaults.filledIconButtonColors(
-                containerColor = MaterialTheme.colorScheme.errorContainer,
-                contentColor = MaterialTheme.colorScheme.onErrorContainer,
-              ),
-            ) {
-              Icon(
-                Icons.Rounded.Stop,
-                contentDescription = stringResource(Res.string.action_stop_downloading),
-                modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
-              )
+            val stopLabel = stringResource(Res.string.action_stop_downloading)
+            IconButtonTooltip(text = stopLabel) {
+              FilledIconButton(
+                onClick = onStopClick,
+                shapes = IconButtonDefaults.shapes(),
+                modifier = Modifier.size(IconButtonDefaults.extraSmallContainerSize()),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                  containerColor = MaterialTheme.colorScheme.errorContainer,
+                  contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+              ) {
+                Icon(
+                  Icons.Rounded.Stop,
+                  contentDescription = stopLabel,
+                  modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
+                )
+              }
             }
           } else {
             Row(
@@ -240,34 +246,40 @@ private fun OfflineStatus(
                 offlineDownload.state == OfflineDownload.State.Failed ||
                 offlineDownload.state == OfflineDownload.State.Stopped
               ) {
-                IconButton(
-                  onClick = onRetryClick,
-                  shapes = IconButtonDefaults.shapes(),
-                  modifier = Modifier.size(IconButtonDefaults.extraSmallContainerSize()),
-                ) {
-                  Icon(
-                    Icons.Rounded.Replay,
-                    contentDescription = "Retry download",
-                    modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
-                  )
+                val retryLabel = stringResource(Res.string.action_retry_download)
+                IconButtonTooltip(text = retryLabel) {
+                  IconButton(
+                    onClick = onRetryClick,
+                    shapes = IconButtonDefaults.shapes(),
+                    modifier = Modifier.size(IconButtonDefaults.extraSmallContainerSize()),
+                  ) {
+                    Icon(
+                      Icons.Rounded.Replay,
+                      contentDescription = retryLabel,
+                      modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
+                    )
+                  }
                 }
 
                 Spacer(Modifier.size(8.dp))
 
-                FilledIconButton(
-                  onClick = onDeleteClick,
-                  shapes = IconButtonDefaults.shapes(),
-                  colors = IconButtonDefaults.filledIconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.error,
-                    contentColor = MaterialTheme.colorScheme.onError,
-                  ),
-                  modifier = Modifier.size(IconButtonDefaults.extraSmallContainerSize()),
-                ) {
-                  Icon(
-                    Icons.Rounded.Delete,
-                    contentDescription = "Delete download",
-                    modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
-                  )
+                val deleteDownloadLabel = stringResource(Res.string.action_delete_download)
+                IconButtonTooltip(text = deleteDownloadLabel) {
+                  FilledIconButton(
+                    onClick = onDeleteClick,
+                    shapes = IconButtonDefaults.shapes(),
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                      containerColor = MaterialTheme.colorScheme.error,
+                      contentColor = MaterialTheme.colorScheme.onError,
+                    ),
+                    modifier = Modifier.size(IconButtonDefaults.extraSmallContainerSize()),
+                  ) {
+                    Icon(
+                      Icons.Rounded.Delete,
+                      contentDescription = deleteDownloadLabel,
+                      modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
+                    )
+                  }
                 }
               } else {
                 val size = ButtonDefaults.ExtraSmallContainerHeight

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/SwatchToolbar.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/SwatchToolbar.kt
@@ -41,7 +41,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.action_close_swatch
+import campfire.features.libraries.ui.generated.resources.action_theme_swatch
 import com.r0adkll.swatchbuckler.compose.Swatch
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -110,22 +115,27 @@ internal fun SwatchToolbar(
       }
     }
 
-    IconToggleButton(
-      checked = expanded,
-      onCheckedChange = { expanded = it },
-      shapes = IconToggleButtonShapes(
-        shape = CircleShape,
-        pressedShape = MaterialTheme.shapes.medium,
-      ),
-      colors = IconButtonDefaults.iconToggleButtonColors(
-        checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-      ),
-    ) {
-      Icon(
-        if (expanded) Icons.Rounded.Close else Icons.Rounded.Palette,
-        contentDescription = null,
-      )
+    val toggleLabel = stringResource(
+      if (expanded) Res.string.action_close_swatch else Res.string.action_theme_swatch,
+    )
+    IconButtonTooltip(text = toggleLabel) {
+      IconToggleButton(
+        checked = expanded,
+        onCheckedChange = { expanded = it },
+        shapes = IconToggleButtonShapes(
+          shape = CircleShape,
+          pressedShape = MaterialTheme.shapes.medium,
+        ),
+        colors = IconButtonDefaults.iconToggleButtonColors(
+          checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+          checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        ),
+      ) {
+        Icon(
+          if (expanded) Icons.Rounded.Close else Icons.Rounded.Palette,
+          contentDescription = toggleLabel,
+        )
+      }
     }
   }
 }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/EpisodeHeaderSlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/EpisodeHeaderSlot.kt
@@ -18,9 +18,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.MetadataHeader
 import app.campfire.libraries.ui.detail.LibraryItemUiEvent
 import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.action_find_episodes
 import campfire.features.libraries.ui.generated.resources.header_episodes
 import org.jetbrains.compose.resources.stringResource
 
@@ -47,14 +49,17 @@ class EpisodeHeaderSlot : ContentSlot {
           textStyle = MaterialTheme.typography.titleLarge,
           textColor = MaterialTheme.colorScheme.contentColorFor(ChapterContainerColor),
           trailingContent = {
-            IconButton(
-              onClick = {
-              },
-            ) {
-              Icon(
-                Icons.Rounded.Search,
-                contentDescription = "Find episodes",
-              )
+            val findEpisodesLabel = stringResource(Res.string.action_find_episodes)
+            IconButtonTooltip(text = findEpisodesLabel) {
+              IconButton(
+                onClick = {
+                },
+              ) {
+                Icon(
+                  Icons.Rounded.Search,
+                  contentDescription = findEpisodesLabel,
+                )
+              }
             }
           },
           modifier = Modifier

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/EpisodeSlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/EpisodeSlot.kt
@@ -22,6 +22,7 @@ import app.campfire.common.compose.icons.filled.MarkFinished
 import app.campfire.common.compose.icons.rounded.MarkFinished
 import app.campfire.common.compose.widgets.EpisodeListItem
 import app.campfire.common.compose.widgets.EpisodeListItemDefaults
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Media
 import app.campfire.core.model.MediaProgress
@@ -29,6 +30,11 @@ import app.campfire.core.model.PodcastEpisode
 import app.campfire.libraries.ui.detail.LibraryItemUiEvent
 import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import app.campfire.playlists.api.dialog.PlaylistDialogResult
+import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.action_add_episode_to_playlist
+import campfire.features.libraries.ui.generated.resources.action_mark_episode_finished
+import campfire.features.libraries.ui.generated.resources.action_mark_episode_not_finished
+import org.jetbrains.compose.resources.stringResource
 
 class EpisodeSlot(
   private val libraryItem: LibraryItem,
@@ -91,48 +97,60 @@ class EpisodeSlot(
           EpisodeListItemDefaults.singleItemShape()
         },
         actions = {
-          IconButton(
-            onClick = { showAddToPlaylistDialog = true },
-            modifier = Modifier
-              .size(
-                IconButtonDefaults.extraSmallContainerSize(
-                  IconButtonDefaults.IconButtonWidthOption.Uniform,
+          val addToPlaylistLabel = stringResource(Res.string.action_add_episode_to_playlist)
+          IconButtonTooltip(text = addToPlaylistLabel) {
+            IconButton(
+              onClick = { showAddToPlaylistDialog = true },
+              modifier = Modifier
+                .size(
+                  IconButtonDefaults.extraSmallContainerSize(
+                    IconButtonDefaults.IconButtonWidthOption.Uniform,
+                  ),
                 ),
-              ),
-            shape = IconButtonDefaults.extraSmallSquareShape,
-          ) {
-            Icon(
-              Icons.AutoMirrored.Rounded.PlaylistAdd,
-              contentDescription = null,
-              modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
-            )
+              shape = IconButtonDefaults.extraSmallSquareShape,
+            ) {
+              Icon(
+                Icons.AutoMirrored.Rounded.PlaylistAdd,
+                contentDescription = addToPlaylistLabel,
+                modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
+              )
+            }
           }
 
-          IconButton(
-            onClick = {
-              if (isFinished) {
-                eventSink(LibraryItemUiEvent.MarkEpisodeNotFinished(episode))
-              } else {
-                eventSink(LibraryItemUiEvent.MarkEpisodeFinished(episode))
-              }
+          val finishedLabel = stringResource(
+            if (isFinished) {
+              Res.string.action_mark_episode_not_finished
+            } else {
+              Res.string.action_mark_episode_finished
             },
-            modifier = Modifier
-              .size(
-                IconButtonDefaults.extraSmallContainerSize(
-                  IconButtonDefaults.IconButtonWidthOption.Uniform,
-                ),
-              ),
-            shape = IconButtonDefaults.extraSmallSquareShape,
-          ) {
-            Icon(
-              if (isFinished) {
-                Icons.Filled.MarkFinished
-              } else {
-                Icons.Rounded.MarkFinished
+          )
+          IconButtonTooltip(text = finishedLabel) {
+            IconButton(
+              onClick = {
+                if (isFinished) {
+                  eventSink(LibraryItemUiEvent.MarkEpisodeNotFinished(episode))
+                } else {
+                  eventSink(LibraryItemUiEvent.MarkEpisodeFinished(episode))
+                }
               },
-              contentDescription = null,
-              modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
-            )
+              modifier = Modifier
+                .size(
+                  IconButtonDefaults.extraSmallContainerSize(
+                    IconButtonDefaults.IconButtonWidthOption.Uniform,
+                  ),
+                ),
+              shape = IconButtonDefaults.extraSmallSquareShape,
+            ) {
+              Icon(
+                if (isFinished) {
+                  Icons.Filled.MarkFinished
+                } else {
+                  Icons.Rounded.MarkFinished
+                },
+                contentDescription = finishedLabel,
+                modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
+              )
+            }
           }
         },
         modifier = Modifier

--- a/features/playlists/ui/src/commonMain/composeResources/values/playlists_ui_strings.xml
+++ b/features/playlists/ui/src/commonMain/composeResources/values/playlists_ui_strings.xml
@@ -25,4 +25,13 @@
   <string name="dialog_add_playlist_title">Add to a playlist</string>
   <string name="dialog_add_playlist_text">Choose an existing playlist or create a new one to add </string>
   <string name="dialog_add_playlist_error_message">Something went wrong when trying to load your playlists</string>
+
+  <string name="action_back">Back</string>
+  <string name="action_play_item">Play item</string>
+  <string name="action_currently_playing">Currently playing</string>
+  <string name="action_edit_playlist">Edit playlist</string>
+  <string name="action_delete_playlist">Delete playlist</string>
+  <string name="action_download_playlist">Download playlist</string>
+  <string name="action_reorder_playlist">Toggle reorder</string>
+  <string name="action_play_all">Play all</string>
 </resources>

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUi.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUi.kt
@@ -48,6 +48,7 @@ import app.campfire.common.compose.permission.rememberPostNotificationPermission
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemCollectionSharedTransitionKey
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.dialog.ConfirmDownloadDialog
@@ -63,6 +64,7 @@ import app.campfire.playlists.ui.detail.composables.PlaylistListItem
 import app.campfire.playlists.ui.sheets.EditPlaylistModel
 import app.campfire.playlists.ui.sheets.showEditPlaylistBottomSheet
 import campfire.features.playlists.ui.generated.resources.Res
+import campfire.features.playlists.ui.generated.resources.action_back
 import campfire.features.playlists.ui.generated.resources.dialog_confirm_delete_action_cancel
 import campfire.features.playlists.ui.generated.resources.dialog_confirm_delete_action_delete
 import campfire.features.playlists.ui.generated.resources.dialog_confirm_delete_message
@@ -238,13 +240,16 @@ private fun PlaylistTopBar(
     title = { Text(name) },
     scrollBehavior = scrollBehavior,
     navigationIcon = {
-      IconButton(
-        onClick = onBack,
-      ) {
-        Icon(
-          Icons.AutoMirrored.Rounded.ArrowBack,
-          contentDescription = null,
-        )
+      val backLabel = stringResource(Res.string.action_back)
+      IconButtonTooltip(text = backLabel) {
+        IconButton(
+          onClick = onBack,
+        ) {
+          Icon(
+            Icons.AutoMirrored.Rounded.ArrowBack,
+            contentDescription = backLabel,
+          )
+        }
       }
     },
   )

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/composables/PlaylistFloatingToolbar.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/composables/PlaylistFloatingToolbar.kt
@@ -1,6 +1,5 @@
 package app.campfire.playlists.ui.detail.composables
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
 import androidx.compose.material.icons.rounded.Delete
@@ -15,21 +14,21 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PlainTooltip
-import androidx.compose.material3.Text
-import androidx.compose.material3.TooltipAnchorPosition
-import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.TooltipScope
-import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.SwapCalls
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import campfire.features.playlists.ui.generated.resources.Res
+import campfire.features.playlists.ui.generated.resources.action_delete_playlist
+import campfire.features.playlists.ui.generated.resources.action_download_playlist
+import campfire.features.playlists.ui.generated.resources.action_edit_playlist
+import campfire.features.playlists.ui.generated.resources.action_play_all
+import campfire.features.playlists.ui.generated.resources.action_reorder_playlist
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -46,51 +45,44 @@ internal fun PlaylistFloatingToolbar(
   HorizontalFloatingToolbar(
     expanded = true,
     floatingActionButton = {
-      TooltipBox(
-        positionProvider =
-        TooltipDefaults.rememberTooltipPositionProvider(
-          TooltipAnchorPosition.Above,
-        ),
-        tooltip = { CampfireTooltip("Play all items in the playlist") },
-        state = rememberTooltipState(),
-      ) {
+      val playAllLabel = stringResource(Res.string.action_play_all)
+      IconButtonTooltip(text = playAllLabel) {
         FloatingToolbarDefaults.StandardFloatingActionButton(
           onClick = onPlayAllClick,
           containerColor = MaterialTheme.colorScheme.secondaryContainer,
           contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
         ) {
-          Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, contentDescription = null)
+          Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, contentDescription = playAllLabel)
         }
       }
     },
     floatingActionButtonPosition = FloatingToolbarHorizontalFabPosition.Start,
-//        colors = FloatingToolbarDefaults.vibrantFloatingToolbarColors(),
     modifier = modifier,
   ) {
     ToolbarButton(
       Icons.Rounded.Download,
       onClick = onDownloadClick,
       expanded = expanded,
-      contentDescription = "Download playlist",
+      contentDescription = stringResource(Res.string.action_download_playlist),
     )
     ToolbarButton(
       Icons.Rounded.Edit,
       onClick = onEditClick,
       expanded = expanded,
-      contentDescription = "Edit playlist name and description",
+      contentDescription = stringResource(Res.string.action_edit_playlist),
     )
     ToggleToolbarButton(
       checked = isReordering,
       onCheckedChange = onReorderChange,
       icon = CampfireIcons.Rounded.SwapCalls,
       expanded = expanded,
-      contentDescription = "Re-order playlist items",
+      contentDescription = stringResource(Res.string.action_reorder_playlist),
     )
     ToolbarButton(
       Icons.Rounded.Delete,
       onClick = onDeleteClick,
       expanded = expanded,
-      contentDescription = "Delete playlist",
+      contentDescription = stringResource(Res.string.action_delete_playlist),
       tint = MaterialTheme.colorScheme.error,
     )
   }
@@ -105,13 +97,8 @@ internal fun ToolbarButton(
   expanded: Boolean = false,
   tint: Color = LocalContentColor.current,
 ) {
-  TooltipBox(
-    positionProvider =
-    TooltipDefaults.rememberTooltipPositionProvider(
-      TooltipAnchorPosition.Above,
-    ),
-    tooltip = { CampfireTooltip(contentDescription) },
-    state = rememberTooltipState(),
+  IconButtonTooltip(
+    text = contentDescription,
     modifier = modifier,
   ) {
     IconButton(
@@ -136,13 +123,8 @@ internal fun ToggleToolbarButton(
   modifier: Modifier = Modifier,
   expanded: Boolean = false,
 ) {
-  TooltipBox(
-    positionProvider =
-    TooltipDefaults.rememberTooltipPositionProvider(
-      TooltipAnchorPosition.Above,
-    ),
-    tooltip = { CampfireTooltip(contentDescription) },
-    state = rememberTooltipState(),
+  IconButtonTooltip(
+    text = contentDescription,
     modifier = modifier,
   ) {
     IconToggleButton(
@@ -152,25 +134,5 @@ internal fun ToggleToolbarButton(
     ) {
       Icon(icon, contentDescription = contentDescription)
     }
-  }
-}
-
-@Composable
-private fun TooltipScope.CampfireTooltip(
-  text: String,
-  modifier: Modifier = Modifier,
-) {
-  PlainTooltip(
-    caretShape = TooltipDefaults.caretShape(),
-    shape = MaterialTheme.shapes.small,
-    modifier = modifier,
-  ) {
-    Text(
-      text = text,
-      modifier = Modifier.padding(
-        horizontal = 4.dp,
-        vertical = 2.dp,
-      ),
-    )
   }
 }

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/composables/PlaylistListItem.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/composables/PlaylistListItem.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.MotionPlay
 import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LibraryItemListItem
 import app.campfire.common.compose.widgets.swipetodismiss.AnimatedRemoveBackgroundContent
 import app.campfire.common.compose.widgets.swipetodismiss.SwipeToDismissBox
@@ -40,7 +41,11 @@ import app.campfire.common.compose.widgets.swipetodismiss.rememberSwipeToDismiss
 import app.campfire.core.model.Playlist
 import app.campfire.core.model.preview.libraryItem
 import app.campfire.core.offline.OfflineStatus
+import campfire.features.playlists.ui.generated.resources.Res
+import campfire.features.playlists.ui.generated.resources.action_currently_playing
+import campfire.features.playlists.ui.generated.resources.action_play_item
 import com.slack.circuit.sharedelements.PreviewSharedElementTransitionLayout
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -111,25 +116,30 @@ internal fun PlaylistListItem(
       durationOverride = episode?.duration,
       modifier = Modifier.weight(1f),
       trailingContent = {
-        FilledTonalIconButton(
-          enabled = !isPlaying,
-          onClick = onPlayClick,
-          shapes = IconButtonDefaults.shapes(
-            shape = MaterialTheme.shapes.small,
-            pressedShape = CircleShape,
-          ),
-        ) {
-          AnimatedContent(
-            isPlaying,
-          ) { playing ->
-            Icon(
-              if (!playing) {
-                Icons.Rounded.PlayArrow
-              } else {
-                CampfireIcons.Rounded.MotionPlay
-              },
-              contentDescription = null,
-            )
+        val playLabel = stringResource(
+          if (isPlaying) Res.string.action_currently_playing else Res.string.action_play_item,
+        )
+        IconButtonTooltip(text = playLabel) {
+          FilledTonalIconButton(
+            enabled = !isPlaying,
+            onClick = onPlayClick,
+            shapes = IconButtonDefaults.shapes(
+              shape = MaterialTheme.shapes.small,
+              pressedShape = CircleShape,
+            ),
+          ) {
+            AnimatedContent(
+              isPlaying,
+            ) { playing ->
+              Icon(
+                if (!playing) {
+                  Icons.Rounded.PlayArrow
+                } else {
+                  CampfireIcons.Rounded.MotionPlay
+                },
+                contentDescription = playLabel,
+              )
+            }
           }
         }
       },

--- a/features/podcasts/ui/src/commonMain/composeResources/values/podcasts_ui_strings.xml
+++ b/features/podcasts/ui/src/commonMain/composeResources/values/podcasts_ui_strings.xml
@@ -3,4 +3,8 @@
   <string name="latest_episodes_empty">All caught up! No new episodes to play.</string>
   <string name="latest_episodes_play_episode">Play episode</string>
   <string name="latest_episodes_image_content_description">%1$s cover</string>
+
+  <string name="action_add_episode_to_playlist">Add episode to playlist</string>
+  <string name="action_mark_episode_finished">Mark episode finished</string>
+  <string name="action_mark_episode_not_finished">Mark episode as not finished</string>
 </resources>

--- a/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/latest/LatestEpisodesUi.kt
+++ b/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/latest/LatestEpisodesUi.kt
@@ -40,6 +40,7 @@ import app.campfire.common.compose.icons.rounded.MarkFinished
 import app.campfire.common.compose.widgets.ContentPagingScaffold
 import app.campfire.common.compose.widgets.EpisodeListItem
 import app.campfire.common.compose.widgets.EpisodeListItemDefaults
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemImage
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.asDate
@@ -54,6 +55,9 @@ import app.campfire.ui.appbar.CampfireAppBar
 import app.campfire.ui.navigation.bar.AttachScrollBehaviorToLocalNavigationBar
 import app.campfire.user.api.MediaProgressKey
 import campfire.features.podcasts.ui.generated.resources.Res
+import campfire.features.podcasts.ui.generated.resources.action_add_episode_to_playlist
+import campfire.features.podcasts.ui.generated.resources.action_mark_episode_finished
+import campfire.features.podcasts.ui.generated.resources.action_mark_episode_not_finished
 import campfire.features.podcasts.ui.generated.resources.latest_episodes_empty
 import campfire.features.podcasts.ui.generated.resources.latest_episodes_image_content_description
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
@@ -213,50 +217,62 @@ private fun LatestEpisodesList(
               }
             },
             actions = {
-              IconButton(
-                onClick = {
-                  onAddToPlaylistClick(item)
-                },
-                modifier = Modifier
-                  .size(
-                    IconButtonDefaults.extraSmallContainerSize(
-                      IconButtonDefaults.IconButtonWidthOption.Uniform,
+              val addToPlaylistLabel = stringResource(Res.string.action_add_episode_to_playlist)
+              IconButtonTooltip(text = addToPlaylistLabel) {
+                IconButton(
+                  onClick = {
+                    onAddToPlaylistClick(item)
+                  },
+                  modifier = Modifier
+                    .size(
+                      IconButtonDefaults.extraSmallContainerSize(
+                        IconButtonDefaults.IconButtonWidthOption.Uniform,
+                      ),
                     ),
-                  ),
-                shape = IconButtonDefaults.extraSmallSquareShape,
-              ) {
-                Icon(
-                  Icons.AutoMirrored.Rounded.PlaylistAdd,
-                  contentDescription = null,
-                  modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
-                )
+                  shape = IconButtonDefaults.extraSmallSquareShape,
+                ) {
+                  Icon(
+                    Icons.AutoMirrored.Rounded.PlaylistAdd,
+                    contentDescription = addToPlaylistLabel,
+                    modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
+                  )
+                }
               }
 
-              IconButton(
-                onClick = {
-                  if (isFinished) {
-                    onMarkNotFinishedClick(item)
-                  } else {
-                    onMarkFinishedClick(item)
-                  }
+              val finishedLabel = stringResource(
+                if (isFinished) {
+                  Res.string.action_mark_episode_not_finished
+                } else {
+                  Res.string.action_mark_episode_finished
                 },
-                modifier = Modifier
-                  .size(
-                    IconButtonDefaults.extraSmallContainerSize(
-                      IconButtonDefaults.IconButtonWidthOption.Uniform,
-                    ),
-                  ),
-                shape = IconButtonDefaults.extraSmallSquareShape,
-              ) {
-                Icon(
-                  if (isFinished) {
-                    Icons.Filled.MarkFinished
-                  } else {
-                    Icons.Rounded.MarkFinished
+              )
+              IconButtonTooltip(text = finishedLabel) {
+                IconButton(
+                  onClick = {
+                    if (isFinished) {
+                      onMarkNotFinishedClick(item)
+                    } else {
+                      onMarkFinishedClick(item)
+                    }
                   },
-                  contentDescription = null,
-                  modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
-                )
+                  modifier = Modifier
+                    .size(
+                      IconButtonDefaults.extraSmallContainerSize(
+                        IconButtonDefaults.IconButtonWidthOption.Uniform,
+                      ),
+                    ),
+                  shape = IconButtonDefaults.extraSmallSquareShape,
+                ) {
+                  Icon(
+                    if (isFinished) {
+                      Icons.Filled.MarkFinished
+                    } else {
+                      Icons.Rounded.MarkFinished
+                    },
+                    contentDescription = finishedLabel,
+                    modifier = Modifier.size(IconButtonDefaults.extraSmallIconSize),
+                  )
+                }
               }
             },
             shape = if (isFirst && !isLast) {

--- a/features/series/ui/src/commonMain/composeResources/values/series_ui_strings.xml
+++ b/features/series/ui/src/commonMain/composeResources/values/series_ui_strings.xml
@@ -7,4 +7,6 @@
     <item quantity="one">%1$d Series</item>
     <item quantity="other">%1$d Series</item>
   </plurals>
+
+  <string name="action_back">Back</string>
 </resources>

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUi.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUi.kt
@@ -25,6 +25,7 @@ import app.campfire.audioplayer.offline.asWidgetStatus
 import app.campfire.common.compose.extensions.plus
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemCollectionSharedTransitionKey
 import app.campfire.common.compose.widgets.LibraryItemCard
 import app.campfire.common.compose.widgets.LoadingListState
@@ -36,6 +37,7 @@ import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.offline.OfflineStatus
 import campfire.features.series.ui.generated.resources.Res
+import campfire.features.series.ui.generated.resources.action_back
 import campfire.features.series.ui.generated.resources.error_series_detail_message
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.sharedelements.SharedElementTransitionScope
@@ -56,10 +58,13 @@ fun SeriesDetail(
         title = { Text(screen.seriesName) },
         scrollBehavior = scrollBehavior,
         navigationIcon = {
-          IconButton(
-            onClick = { state.eventSink(SeriesDetailUiEvent.Back) },
-          ) {
-            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+          val backLabel = stringResource(Res.string.action_back)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(
+              onClick = { state.eventSink(SeriesDetailUiEvent.Back) },
+            ) {
+              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+            }
           }
         },
       )

--- a/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
+++ b/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
@@ -36,10 +36,26 @@
 
   <string name="action_set_timer">Set timer</string>
   <string name="action_clear_timer">Clear timer</string>
+  <string name="action_playback_speed">Playback speed</string>
+  <string name="action_sleep_timer">Sleep timer</string>
+  <string name="action_skip_previous">Skip previous</string>
+  <string name="action_skip_next">Skip next</string>
+  <string name="action_rewind">Rewind</string>
+  <string name="action_forward">Forward</string>
+  <string name="action_add_bookmark">Add bookmark</string>
+  <string name="action_chapters">Chapters</string>
+  <string name="action_audio_tracks">Audio tracks</string>
+  <string name="action_more_options">More options</string>
+  <string name="action_delete_bookmark">Delete bookmark</string>
+  <string name="action_play_from_bookmark">Play from bookmark</string>
+  <string name="action_create_bookmark">Create bookmark</string>
 
   <string name="action_queue">Queue</string>
   <string name="action_remove">REMOVE</string>
   <string name="action_clear_queue">Clear queue?</string>
+  <string name="action_clear_queue_short">Clear queue</string>
+  <string name="action_cancel_clear_queue">Cancel queue clear</string>
+  <string name="action_confirm_clear_queue">Confirm clear queue</string>
   <string name="queue_header_up_next">Up next</string>
   <string name="queue_header_queue">Queue</string>
 
@@ -48,6 +64,15 @@
 
   <string name="history_bottomsheet_title">Playback History</string>
   <string name="history_empty_message">No playback history yet</string>
+  <string name="action_clear_history">Clear history</string>
+  <string name="action_sync_progress">Sync progress</string>
+  <string name="action_play">Play</string>
+  <string name="action_pause">Pause</string>
+  <string name="action_close">Close</string>
+  <string name="action_play_pause">Play or pause</string>
+  <string name="action_bookmarks">Bookmarks</string>
+  <string name="action_description">Description</string>
+  <string name="action_history">Playback history</string>
   <string name="history_context_play">Played</string>
   <string name="history_context_pause">Paused</string>
   <string name="history_context_seek">Seeked</string>

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
@@ -73,6 +73,7 @@ import app.campfire.common.compose.icons.rounded.Bookmarks
 import app.campfire.common.compose.icons.rounded.EditAudio
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.widgets.CoverImage
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.extensions.fluentIf
 import app.campfire.core.model.AudioTrack
 import app.campfire.core.model.Bookmark
@@ -92,6 +93,13 @@ import app.campfire.sessions.ui.sheets.speed.showPlaybackSpeedBottomSheet
 import app.campfire.sessions.ui.sheets.tracks.AudioTrackResult
 import app.campfire.sessions.ui.sheets.tracks.showAudioTrackBottomSheet
 import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_add_bookmark
+import campfire.features.sessions.ui.generated.resources.action_chapters
+import campfire.features.sessions.ui.generated.resources.action_forward
+import campfire.features.sessions.ui.generated.resources.action_rewind
+import campfire.features.sessions.ui.generated.resources.action_skip_next
+import campfire.features.sessions.ui.generated.resources.action_skip_previous
+import campfire.features.sessions.ui.generated.resources.action_sleep_timer
 import campfire.features.sessions.ui.generated.resources.label_end_of_chapter_short
 import com.slack.circuit.overlay.LocalOverlayHost
 import ir.mahozad.multiplatform.wavyslider.WaveDirection
@@ -372,22 +380,28 @@ private fun PlaybackActions(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
   ) {
-    IconButton(
-      onClick = onSkipPreviousClick,
-    ) {
-      Icon(
-        Icons.Rounded.SkipPrevious,
-        modifier = Modifier.size(actionSize),
-        contentDescription = null,
-      )
+    val skipPreviousLabel = stringResource(Res.string.action_skip_previous)
+    IconButtonTooltip(text = skipPreviousLabel) {
+      IconButton(
+        onClick = onSkipPreviousClick,
+      ) {
+        Icon(
+          Icons.Rounded.SkipPrevious,
+          modifier = Modifier.size(actionSize),
+          contentDescription = skipPreviousLabel,
+        )
+      }
     }
 
-    IconButton(
-      onClick = onRewindClick,
-    ) {
-      RewindIcon(
-        modifier = Modifier.size(actionSize),
-      )
+    val rewindLabel = stringResource(Res.string.action_rewind)
+    IconButtonTooltip(text = rewindLabel) {
+      IconButton(
+        onClick = onRewindClick,
+      ) {
+        RewindIcon(
+          modifier = Modifier.size(actionSize),
+        )
+      }
     }
 
     val isPlayPauseEnabled = state != AudioPlayer.State.Finished &&
@@ -436,22 +450,28 @@ private fun PlaybackActions(
       }
     }
 
-    IconButton(
-      onClick = onForwardClick,
-    ) {
-      ForwardIcon(
-        modifier = Modifier.size(actionSize),
-      )
+    val forwardLabel = stringResource(Res.string.action_forward)
+    IconButtonTooltip(text = forwardLabel) {
+      IconButton(
+        onClick = onForwardClick,
+      ) {
+        ForwardIcon(
+          modifier = Modifier.size(actionSize),
+        )
+      }
     }
 
-    IconButton(
-      onClick = onSkipNextClick,
-    ) {
-      Icon(
-        Icons.Rounded.SkipNext,
-        modifier = Modifier.size(actionSize),
-        contentDescription = null,
-      )
+    val skipNextLabel = stringResource(Res.string.action_skip_next)
+    IconButtonTooltip(text = skipNextLabel) {
+      IconButton(
+        onClick = onSkipNextClick,
+      ) {
+        Icon(
+          Icons.Rounded.SkipNext,
+          modifier = Modifier.size(actionSize),
+          contentDescription = skipNextLabel,
+        )
+      }
     }
   }
 }
@@ -583,10 +603,13 @@ private fun ActionRow(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
   ) {
-    IconButton(
-      onClick = onBookmarkAddClick,
-    ) {
-      Icon(Icons.Rounded.Bookmarks, contentDescription = null)
+    val bookmarkLabel = stringResource(Res.string.action_add_bookmark)
+    IconButtonTooltip(text = bookmarkLabel) {
+      IconButton(
+        onClick = onBookmarkAddClick,
+      ) {
+        Icon(Icons.Rounded.Bookmarks, contentDescription = bookmarkLabel)
+      }
     }
 
     speedContent()
@@ -607,10 +630,13 @@ private fun ActionRow(
       contentAlignment = Alignment.CenterStart,
     ) { timer ->
       if (timer == null) {
-        IconButton(
-          onClick = onTimerClick,
-        ) {
-          Icon(Icons.Outlined.Timer, contentDescription = null)
+        val timerLabel = stringResource(Res.string.action_sleep_timer)
+        IconButtonTooltip(text = timerLabel) {
+          IconButton(
+            onClick = onTimerClick,
+          ) {
+            Icon(Icons.Outlined.Timer, contentDescription = timerLabel)
+          }
         }
       } else {
         Row(
@@ -650,10 +676,13 @@ private fun ActionRow(
       }
     }
 
-    IconButton(
-      onClick = onChapterListClick,
-    ) {
-      Icon(Icons.AutoMirrored.Rounded.List, contentDescription = null)
+    val chaptersLabel = stringResource(Res.string.action_chapters)
+    IconButtonTooltip(text = chaptersLabel) {
+      IconButton(
+        onClick = onChapterListClick,
+      ) {
+        Icon(Icons.AutoMirrored.Rounded.List, contentDescription = chaptersLabel)
+      }
     }
   }
 }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/composables/PlaybackSpeedAction.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/composables/PlaybackSpeedAction.kt
@@ -17,7 +17,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.sessions.ui.sheets.speed.readableHundredths
+import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_playback_speed
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun PlaybackSpeedAction(
@@ -26,11 +30,16 @@ fun PlaybackSpeedAction(
   modifier: Modifier = Modifier,
 ) {
   if (playbackSpeed == 1f) {
-    IconButton(
-      onClick = onClick,
+    val label = stringResource(Res.string.action_playback_speed)
+    IconButtonTooltip(
+      text = label,
       modifier = modifier,
     ) {
-      Icon(Icons.Rounded.Speed, contentDescription = null)
+      IconButton(
+        onClick = onClick,
+      ) {
+        Icon(Icons.Rounded.Speed, contentDescription = label)
+      }
     }
   } else {
     Box(

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/composables/RunningTimerAction.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/composables/RunningTimerAction.kt
@@ -21,7 +21,11 @@ import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.common.compose.extensions.thresholdReadoutFormat
 import app.campfire.common.compose.icons.animated.AnimatedTimerPainter
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_sleep_timer
 import kotlin.time.Duration
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun RunningTimerAction(
@@ -33,20 +37,25 @@ fun RunningTimerAction(
   modifier: Modifier = Modifier,
 ) {
   if (runningTimer?.timer !is PlaybackTimer.EndOfChapter) {
-    IconButton(
-      onClick = onClick,
+    val label = stringResource(Res.string.action_sleep_timer)
+    IconButtonTooltip(
+      text = label,
       modifier = modifier,
     ) {
-      if (runningTimer != null) {
-        Icon(
-          AnimatedTimerPainter,
-          contentDescription = null,
-        )
-      } else {
-        Icon(
-          Icons.Outlined.Timer,
-          contentDescription = null,
-        )
+      IconButton(
+        onClick = onClick,
+      ) {
+        if (runningTimer != null) {
+          Icon(
+            AnimatedTimerPainter,
+            contentDescription = label,
+          )
+        } else {
+          Icon(
+            Icons.Outlined.Timer,
+            contentDescription = label,
+          )
+        }
       }
     }
   } else {

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/collapsed/CollapsedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/collapsed/CollapsedPlaybackBar.kt
@@ -74,6 +74,7 @@ import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Sync
 import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.extensions.fluentIf
 import app.campfire.core.extensions.progressOver
 import app.campfire.core.model.Session
@@ -91,6 +92,10 @@ import app.campfire.sessions.ui.playback.collapsed.ActionState.None
 import app.campfire.sessions.ui.playback.collapsed.ActionState.Open
 import app.campfire.sessions.ui.playback.collapsed.composables.PlaybackThumbnail
 import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_pause
+import campfire.features.sessions.ui.generated.resources.action_play
+import campfire.features.sessions.ui.generated.resources.action_rewind
+import campfire.features.sessions.ui.generated.resources.action_sync_progress
 import campfire.features.sessions.ui.generated.resources.clear_session_subtitle
 import campfire.features.sessions.ui.generated.resources.clear_session_title
 import campfire.features.sessions.ui.generated.resources.sync_available
@@ -294,23 +299,29 @@ private fun CollapsedPlaybackBarContent(
       AnimatedVisibility(
         visible = dragState.actionState != Dispose && availableSync == null,
       ) {
-        IconButton(
-          onClick = onRewindClick,
-        ) {
-          RewindIcon()
+        val rewindLabel = stringResource(Res.string.action_rewind)
+        IconButtonTooltip(text = rewindLabel) {
+          IconButton(
+            onClick = onRewindClick,
+          ) {
+            RewindIcon()
+          }
         }
       }
 
       AnimatedVisibility(
         visible = dragState.actionState != Dispose && availableSync != null,
       ) {
-        IconButton(
-          onClick = onSync,
-        ) {
-          Icon(
-            CampfireIcons.Rounded.Sync,
-            contentDescription = "Sync progress",
-          )
+        val syncLabel = stringResource(Res.string.action_sync_progress)
+        IconButtonTooltip(text = syncLabel) {
+          IconButton(
+            onClick = onSync,
+          ) {
+            Icon(
+              CampfireIcons.Rounded.Sync,
+              contentDescription = syncLabel,
+            )
+          }
         }
       }
 
@@ -318,17 +329,23 @@ private fun CollapsedPlaybackBarContent(
         visible = dragState.actionState != Dispose,
       ) {
         Box {
-          IconButton(
-            onClick = onPlayPauseClick,
-          ) {
-            Icon(
-              if (state == AudioPlayer.State.Playing) {
-                Icons.Rounded.Pause
-              } else {
-                Icons.Rounded.PlayArrow
-              },
-              contentDescription = null,
-            )
+          val isPlaying = state == AudioPlayer.State.Playing
+          val playPauseLabel = stringResource(
+            if (isPlaying) Res.string.action_pause else Res.string.action_play,
+          )
+          IconButtonTooltip(text = playPauseLabel) {
+            IconButton(
+              onClick = onPlayPauseClick,
+            ) {
+              Icon(
+                if (isPlaying) {
+                  Icons.Rounded.Pause
+                } else {
+                  Icons.Rounded.PlayArrow
+                },
+                contentDescription = playPauseLabel,
+              )
+            }
           }
 
           if (state == AudioPlayer.State.Buffering) {

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
@@ -64,6 +64,7 @@ import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.layout.isSupportingPaneEnabled
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.widgets.CoverImageSize
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.extensions.fluentIf
 import app.campfire.core.model.Session
 import app.campfire.libraries.api.LibraryItemValidation
@@ -104,6 +105,7 @@ import app.campfire.sessions.ui.sheets.speed.showPlaybackSpeedBottomSheet
 import app.campfire.sessions.ui.sheets.tracks.AudioTrackResult
 import app.campfire.sessions.ui.sheets.tracks.showAudioTrackBottomSheet
 import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_close
 import campfire.features.sessions.ui.generated.resources.misaligned_chapters_error_message
 import campfire.features.sessions.ui.generated.resources.playback_error_message
 import com.slack.circuit.overlay.ContentWithOverlays
@@ -256,10 +258,13 @@ internal fun ExpandedPlaybackBar(
           }
         },
         navigationIcon = {
-          IconButton(
-            onClick = onClose,
-          ) {
-            Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = null)
+          val closeLabel = stringResource(Res.string.action_close)
+          IconButtonTooltip(text = closeLabel) {
+            IconButton(
+              onClick = onClose,
+            ) {
+              Icon(Icons.Rounded.KeyboardArrowDown, contentDescription = closeLabel)
+            }
           }
         },
         actions = {

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ActionRow.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ActionRow.kt
@@ -18,6 +18,13 @@ import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Bookmarks
 import app.campfire.common.compose.icons.rounded.Description
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_bookmarks
+import campfire.features.sessions.ui.generated.resources.action_chapters
+import campfire.features.sessions.ui.generated.resources.action_description
+import campfire.features.sessions.ui.generated.resources.action_history
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun ActionRow(
@@ -44,10 +51,13 @@ internal fun ActionRow(
       modifier = Modifier.weight(1f),
       contentAlignment = Alignment.Center,
     ) {
-      IconButton(
-        onClick = onBookmarksClick,
-      ) {
-        Icon(Icons.Rounded.Bookmarks, contentDescription = null)
+      val bookmarksLabel = stringResource(Res.string.action_bookmarks)
+      IconButtonTooltip(text = bookmarksLabel) {
+        IconButton(
+          onClick = onBookmarksClick,
+        ) {
+          Icon(Icons.Rounded.Bookmarks, contentDescription = bookmarksLabel)
+        }
       }
     }
 
@@ -70,10 +80,13 @@ internal fun ActionRow(
         modifier = Modifier.weight(1f),
         contentAlignment = Alignment.Center,
       ) {
-        IconButton(
-          onClick = onChapterListClick,
-        ) {
-          Icon(Icons.AutoMirrored.Rounded.List, contentDescription = null)
+        val chaptersLabel = stringResource(Res.string.action_chapters)
+        IconButtonTooltip(text = chaptersLabel) {
+          IconButton(
+            onClick = onChapterListClick,
+          ) {
+            Icon(Icons.AutoMirrored.Rounded.List, contentDescription = chaptersLabel)
+          }
         }
       }
     }
@@ -83,10 +96,13 @@ internal fun ActionRow(
         modifier = Modifier.weight(1f),
         contentAlignment = Alignment.Center,
       ) {
-        IconButton(
-          onClick = onDescriptionClick,
-        ) {
-          Icon(CampfireIcons.Rounded.Description, contentDescription = null)
+        val descriptionLabel = stringResource(Res.string.action_description)
+        IconButtonTooltip(text = descriptionLabel) {
+          IconButton(
+            onClick = onDescriptionClick,
+          ) {
+            Icon(CampfireIcons.Rounded.Description, contentDescription = descriptionLabel)
+          }
         }
       }
     }
@@ -96,10 +112,13 @@ internal fun ActionRow(
         modifier = Modifier.weight(1f),
         contentAlignment = Alignment.Center,
       ) {
-        IconButton(
-          onClick = onHistoryClick,
-        ) {
-          Icon(Icons.Rounded.History, contentDescription = null)
+        val historyLabel = stringResource(Res.string.action_history)
+        IconButtonTooltip(text = historyLabel) {
+          IconButton(
+            onClick = onHistoryClick,
+          ) {
+            Icon(Icons.Rounded.History, contentDescription = historyLabel)
+          }
         }
       }
     }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ClearQueueButton.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ClearQueueButton.kt
@@ -38,8 +38,12 @@ import app.campfire.common.compose.icons.rounded.Check
 import app.campfire.common.compose.icons.rounded.Close
 import app.campfire.common.compose.icons.rounded.DeleteSweep
 import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_cancel_clear_queue
 import campfire.features.sessions.ui.generated.resources.action_clear_queue
+import campfire.features.sessions.ui.generated.resources.action_clear_queue_short
+import campfire.features.sessions.ui.generated.resources.action_confirm_clear_queue
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -81,13 +85,16 @@ fun ClearQueueButton(
           onCancelClick = { showConfirmation = false },
         )
       } else {
-        IconButton(
-          onClick = { showConfirmation = true },
-        ) {
-          Icon(
-            CampfireIcons.Rounded.DeleteSweep,
-            contentDescription = "Clear queue",
-          )
+        val clearQueueLabel = stringResource(Res.string.action_clear_queue_short)
+        IconButtonTooltip(text = clearQueueLabel) {
+          IconButton(
+            onClick = { showConfirmation = true },
+          ) {
+            Icon(
+              CampfireIcons.Rounded.DeleteSweep,
+              contentDescription = clearQueueLabel,
+            )
+          }
         }
       }
     }
@@ -107,14 +114,17 @@ private fun AnimatedContentScope.ConfirmClearQueueContent(
     verticalAlignment = Alignment.CenterVertically,
   ) {
     // Cancel Button
-    IconButton(
-      onClick = onCancelClick,
-    ) {
-      Icon(
-        CampfireIcons.Rounded.Close,
-        contentDescription = "Cancel queue clear",
-        tint = MaterialTheme.colorScheme.onErrorContainer,
-      )
+    val cancelLabel = stringResource(Res.string.action_cancel_clear_queue)
+    IconButtonTooltip(text = cancelLabel) {
+      IconButton(
+        onClick = onCancelClick,
+      ) {
+        Icon(
+          CampfireIcons.Rounded.Close,
+          contentDescription = cancelLabel,
+          tint = MaterialTheme.colorScheme.onErrorContainer,
+        )
+      }
     }
 
     // Text
@@ -126,12 +136,9 @@ private fun AnimatedContentScope.ConfirmClearQueueContent(
     )
 
     // Confirm Button
-    FilledIconButton(
-      onClick = onConfirmClick,
-      colors = IconButtonDefaults.filledIconButtonColors(
-        containerColor = CampfireTheme.colorScheme.success,
-        contentColor = CampfireTheme.colorScheme.onSuccess,
-      ),
+    val confirmLabel = stringResource(Res.string.action_confirm_clear_queue)
+    IconButtonTooltip(
+      text = confirmLabel,
       modifier = Modifier
         .animateEnterExit(
           enter = expandIn(
@@ -141,10 +148,18 @@ private fun AnimatedContentScope.ConfirmClearQueueContent(
           exit = shrinkOut() + fadeOut(),
         ),
     ) {
-      Icon(
-        CampfireIcons.Rounded.Check,
-        contentDescription = "Clear queue",
-      )
+      FilledIconButton(
+        onClick = onConfirmClick,
+        colors = IconButtonDefaults.filledIconButtonColors(
+          containerColor = CampfireTheme.colorScheme.success,
+          contentColor = CampfireTheme.colorScheme.onSuccess,
+        ),
+      ) {
+        Icon(
+          CampfireIcons.Rounded.Check,
+          contentDescription = confirmLabel,
+        )
+      }
     }
   }
 }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/PlaybackActions.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/PlaybackActions.kt
@@ -33,8 +33,16 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.common.compose.icons.rounded.EditAudio
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.sessions.ui.composables.ForwardIcon
 import app.campfire.sessions.ui.composables.RewindIcon
+import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_forward
+import campfire.features.sessions.ui.generated.resources.action_play_pause
+import campfire.features.sessions.ui.generated.resources.action_rewind
+import campfire.features.sessions.ui.generated.resources.action_skip_next
+import campfire.features.sessions.ui.generated.resources.action_skip_previous
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -68,34 +76,38 @@ internal fun PlaybackActions(
       @Composable
       fun AccessoryButton(
         onClick: () -> Unit,
+        label: String,
         modifier: Modifier = Modifier,
         content: @Composable (iconSize: Dp) -> Unit,
       ) {
         val accessoryButtonSize = ButtonDefaults.LargeContainerHeight
         val accessoryButtonIconSize = ButtonDefaults.LargeIconSize
-        FilledIconButton(
-          onClick = onClick,
-          shapes = IconButtonDefaults.shapes(
-            shape = buttonShape,
-            pressedShape = ButtonDefaults.shape,
-          ),
-          colors = IconButtonDefaults.filledIconButtonColors(
-            containerColor = accessoryButtonContainerColor,
-            contentColor = accessoryButtonContentColor,
-          ),
-          modifier = modifier
-            .sizeIn(
-              minWidth = accessoryButtonSize,
-              minHeight = accessoryButtonSize,
+        IconButtonTooltip(text = label, modifier = modifier) {
+          FilledIconButton(
+            onClick = onClick,
+            shapes = IconButtonDefaults.shapes(
+              shape = buttonShape,
+              pressedShape = ButtonDefaults.shape,
             ),
-          content = {
-            content(accessoryButtonIconSize)
-          },
-        )
+            colors = IconButtonDefaults.filledIconButtonColors(
+              containerColor = accessoryButtonContainerColor,
+              contentColor = accessoryButtonContentColor,
+            ),
+            modifier = Modifier
+              .sizeIn(
+                minWidth = accessoryButtonSize,
+                minHeight = accessoryButtonSize,
+              ),
+            content = {
+              content(accessoryButtonIconSize)
+            },
+          )
+        }
       }
 
       AccessoryButton(
         onClick = onRewindClick,
+        label = stringResource(Res.string.action_rewind),
       ) { iconSize ->
         RewindIcon(
           modifier = Modifier.size(iconSize),
@@ -107,53 +119,57 @@ internal fun PlaybackActions(
         !isInteracting
 
       val playButtonIconSize = ButtonDefaults.ExtraLargeIconSize
-      FilledIconButton(
-        onClick = onPlayPauseClick,
-        enabled = isPlayPauseEnabled,
-        shapes = IconButtonDefaults.shapes(
-          shape = buttonShape,
-          pressedShape = ButtonDefaults.shape,
-        ),
-        modifier = Modifier
-          .sizeIn(
-            minWidth = playButtonSize + playButtonExtraWidth,
-            minHeight = playButtonSize,
+      val playPauseLabel = stringResource(Res.string.action_play_pause)
+      IconButtonTooltip(text = playPauseLabel) {
+        FilledIconButton(
+          onClick = onPlayPauseClick,
+          enabled = isPlayPauseEnabled,
+          shapes = IconButtonDefaults.shapes(
+            shape = buttonShape,
+            pressedShape = ButtonDefaults.shape,
           ),
-      ) {
-        AnimatedContent(
-          targetState = when {
-            state == AudioPlayer.State.Buffering -> PlayButtonState.Buffering
-            isInteracting -> PlayButtonState.Interacting
-            state == AudioPlayer.State.Playing -> PlayButtonState.Playing
-            else -> PlayButtonState.Paused
-          },
-          transitionSpec = {
-            (fadeIn(initialAlpha = 0.4f) + expandIn(expandFrom = Alignment.Center)) togetherWith
-              (fadeOut(targetAlpha = 0.4f) + shrinkOut(shrinkTowards = Alignment.Center))
-          },
-          contentAlignment = Alignment.Center,
-        ) { state ->
-          if (state == PlayButtonState.Buffering) {
-            CircularProgressIndicator(
-              modifier = Modifier.size(playButtonIconSize),
-              strokeWidth = 4.dp,
-            )
-          } else {
-            Icon(
-              when (state) {
-                PlayButtonState.Interacting -> Icons.Rounded.EditAudio
-                PlayButtonState.Playing -> Icons.Rounded.Pause
-                else -> Icons.Rounded.PlayArrow
-              },
-              modifier = Modifier.size(playButtonIconSize),
-              contentDescription = null,
-            )
+          modifier = Modifier
+            .sizeIn(
+              minWidth = playButtonSize + playButtonExtraWidth,
+              minHeight = playButtonSize,
+            ),
+        ) {
+          AnimatedContent(
+            targetState = when {
+              state == AudioPlayer.State.Buffering -> PlayButtonState.Buffering
+              isInteracting -> PlayButtonState.Interacting
+              state == AudioPlayer.State.Playing -> PlayButtonState.Playing
+              else -> PlayButtonState.Paused
+            },
+            transitionSpec = {
+              (fadeIn(initialAlpha = 0.4f) + expandIn(expandFrom = Alignment.Center)) togetherWith
+                (fadeOut(targetAlpha = 0.4f) + shrinkOut(shrinkTowards = Alignment.Center))
+            },
+            contentAlignment = Alignment.Center,
+          ) { state ->
+            if (state == PlayButtonState.Buffering) {
+              CircularProgressIndicator(
+                modifier = Modifier.size(playButtonIconSize),
+                strokeWidth = 4.dp,
+              )
+            } else {
+              Icon(
+                when (state) {
+                  PlayButtonState.Interacting -> Icons.Rounded.EditAudio
+                  PlayButtonState.Playing -> Icons.Rounded.Pause
+                  else -> Icons.Rounded.PlayArrow
+                },
+                modifier = Modifier.size(playButtonIconSize),
+                contentDescription = playPauseLabel,
+              )
+            }
           }
         }
       }
 
       AccessoryButton(
         onClick = onForwardClick,
+        label = stringResource(Res.string.action_forward),
       ) { iconSize ->
         ForwardIcon(
           modifier = Modifier.size(iconSize),
@@ -175,33 +191,45 @@ internal fun PlaybackActions(
       )
       val shapes = IconButtonDefaults.shapes()
 
-      FilledIconButton(
-        onClick = onSkipPreviousClick,
-        shapes = shapes,
-        colors = colors,
-        modifier = Modifier
-          .weight(1f)
-          .heightIn(buttonSize),
+      val skipPreviousLabel = stringResource(Res.string.action_skip_previous)
+      IconButtonTooltip(
+        text = skipPreviousLabel,
+        modifier = Modifier.weight(1f),
       ) {
-        Icon(
-          Icons.Rounded.SkipPrevious,
-          modifier = Modifier.size(ButtonDefaults.LargeIconSize),
-          contentDescription = null,
-        )
+        FilledIconButton(
+          onClick = onSkipPreviousClick,
+          shapes = shapes,
+          colors = colors,
+          modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(buttonSize),
+        ) {
+          Icon(
+            Icons.Rounded.SkipPrevious,
+            modifier = Modifier.size(ButtonDefaults.LargeIconSize),
+            contentDescription = skipPreviousLabel,
+          )
+        }
       }
-      FilledIconButton(
-        onClick = onSkipNextClick,
-        shapes = shapes,
-        colors = colors,
-        modifier = Modifier
-          .weight(1f)
-          .heightIn(buttonSize),
+      val skipNextLabel = stringResource(Res.string.action_skip_next)
+      IconButtonTooltip(
+        text = skipNextLabel,
+        modifier = Modifier.weight(1f),
       ) {
-        Icon(
-          Icons.Rounded.SkipNext,
-          modifier = Modifier.size(ButtonDefaults.LargeIconSize),
-          contentDescription = null,
-        )
+        FilledIconButton(
+          onClick = onSkipNextClick,
+          shapes = shapes,
+          colors = colors,
+          modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(buttonSize),
+        ) {
+          Icon(
+            Icons.Rounded.SkipNext,
+            modifier = Modifier.size(ButtonDefaults.LargeIconSize),
+            contentDescription = skipNextLabel,
+          )
+        }
       }
     }
   }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/bookmarks/BookmarksBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/bookmarks/BookmarksBottomSheet.kt
@@ -71,6 +71,7 @@ import app.campfire.common.compose.extensions.readoutFormat
 import app.campfire.common.compose.icons.rounded.Bookmark
 import app.campfire.common.compose.icons.rounded.BookmarkStar
 import app.campfire.common.compose.widgets.FilledTonalIconButton
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.SizedIcon
 import app.campfire.common.compose.widgets.bottomSheetShape
 import app.campfire.common.compose.widgets.circularReveal
@@ -84,6 +85,7 @@ import app.campfire.core.model.LibraryItemId
 import app.campfire.sessions.ui.sheets.SessionSheetLayout
 import app.campfire.user.api.BookmarkRepository
 import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_delete_bookmark
 import campfire.features.sessions.ui.generated.resources.bookmark_bottomsheet_action_create
 import campfire.features.sessions.ui.generated.resources.bookmark_bottomsheet_empty_message
 import campfire.features.sessions.ui.generated.resources.bookmark_bottomsheet_error_message
@@ -95,6 +97,8 @@ import campfire.features.sessions.ui.generated.resources.bookmark_new_dialog_act
 import campfire.features.sessions.ui.generated.resources.bookmark_new_dialog_action_create
 import campfire.features.sessions.ui.generated.resources.bookmark_new_dialog_label_title
 import campfire.features.sessions.ui.generated.resources.bookmark_new_dialog_title
+import campfire.features.sessions.ui.generated.resources.cd_forward_time
+import campfire.features.sessions.ui.generated.resources.cd_rewind_time
 import com.r0adkll.kimchi.annotations.ContributesTo
 import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuitx.overlays.BottomSheetOverlay
@@ -362,14 +366,17 @@ private fun BookmarkListItemContent(
       }
     },
     trailingContent = {
-      IconButton(
-        onClick = onDeleteClick,
-      ) {
-        Icon(
-          Icons.Rounded.DeleteOutline,
-          contentDescription = null,
-          tint = MaterialTheme.colorScheme.error,
-        )
+      val deleteLabel = stringResource(Res.string.action_delete_bookmark)
+      IconButtonTooltip(text = deleteLabel) {
+        IconButton(
+          onClick = onDeleteClick,
+        ) {
+          Icon(
+            Icons.Rounded.DeleteOutline,
+            contentDescription = deleteLabel,
+            tint = MaterialTheme.colorScheme.error,
+          )
+        }
       }
     },
   )
@@ -445,18 +452,21 @@ private fun CreateNewDialog(
               ),
             verticalAlignment = Alignment.CenterVertically,
           ) {
-            IconButton(
-              onClick = {
-                bookmarkTime -= 1.seconds
-              },
-              colors = IconButtonDefaults.iconButtonColors(
-                contentColor = MaterialTheme.colorScheme.primary,
-              ),
-            ) {
-              Icon(
-                Icons.Rounded.Replay,
-                contentDescription = null,
-              )
+            val rewindLabel = stringResource(Res.string.cd_rewind_time, "1")
+            IconButtonTooltip(text = rewindLabel) {
+              IconButton(
+                onClick = {
+                  bookmarkTime -= 1.seconds
+                },
+                colors = IconButtonDefaults.iconButtonColors(
+                  contentColor = MaterialTheme.colorScheme.primary,
+                ),
+              ) {
+                Icon(
+                  Icons.Rounded.Replay,
+                  contentDescription = rewindLabel,
+                )
+              }
             }
 
             Text(
@@ -466,18 +476,21 @@ private fun CreateNewDialog(
               modifier = Modifier.padding(horizontal = 8.dp),
             )
 
-            IconButton(
-              onClick = {
-                bookmarkTime += 5.seconds
-              },
-              colors = IconButtonDefaults.iconButtonColors(
-                contentColor = MaterialTheme.colorScheme.primary,
-              ),
-            ) {
-              Icon(
-                Icons.Rounded.Forward5,
-                contentDescription = null,
-              )
+            val forwardLabel = stringResource(Res.string.cd_forward_time, "5")
+            IconButtonTooltip(text = forwardLabel) {
+              IconButton(
+                onClick = {
+                  bookmarkTime += 5.seconds
+                },
+                colors = IconButtonDefaults.iconButtonColors(
+                  contentColor = MaterialTheme.colorScheme.primary,
+                ),
+              ) {
+                Icon(
+                  Icons.Rounded.Forward5,
+                  contentDescription = forwardLabel,
+                )
+              }
             }
           }
 

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/history/PlaybackHistoryBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/history/PlaybackHistoryBottomSheet.kt
@@ -53,6 +53,7 @@ import app.campfire.common.compose.extensions.relativeDayLabel
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.DeleteSweep
 import app.campfire.common.compose.icons.rounded.Sync
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.readableFormat
 import app.campfire.core.model.LibraryItemId
@@ -60,6 +61,7 @@ import app.campfire.core.model.PlaybackActionType
 import app.campfire.sessions.ui.sheets.SessionSheetLayout
 import app.campfire.sessions.ui.sheets.rememberSessionSheetTitleState
 import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_clear_history
 import campfire.features.sessions.ui.generated.resources.history_bottomsheet_title
 import campfire.features.sessions.ui.generated.resources.history_context_pause
 import campfire.features.sessions.ui.generated.resources.history_context_play
@@ -144,18 +146,21 @@ private fun PlaybackHistoryBottomSheet(
         visible = actions.isNotEmpty(),
         modifier = Modifier.align(Alignment.CenterEnd),
       ) {
-        IconButton(
-          onClick = {
-            scope.launch {
-              component.playbackHistoryRepository.clear(libraryItemId)
-            }
-          },
-        ) {
-          Icon(
-            CampfireIcons.Rounded.DeleteSweep,
-            contentDescription = "Clear history",
-            tint = MaterialTheme.colorScheme.error,
-          )
+        val clearHistoryLabel = stringResource(Res.string.action_clear_history)
+        IconButtonTooltip(text = clearHistoryLabel) {
+          IconButton(
+            onClick = {
+              scope.launch {
+                component.playbackHistoryRepository.clear(libraryItemId)
+              }
+            },
+          ) {
+            Icon(
+              CampfireIcons.Rounded.DeleteSweep,
+              contentDescription = clearHistoryLabel,
+              tint = MaterialTheme.colorScheme.error,
+            )
+          }
         }
       }
     },

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -148,4 +148,6 @@
   <!-- Misc actions-->
   <string name="dialog_confirm_action">Apply</string>
   <string name="dialog_dismiss_action">Cancel</string>
+  <string name="action_back">Back</string>
+  <string name="action_dismiss">Dismiss</string>
 </resources>

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUi.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUi.kt
@@ -49,6 +49,7 @@ import app.campfire.common.compose.layout.LocalSupportingContentState
 import app.campfire.common.compose.layout.SupportingContentState
 import app.campfire.common.compose.layout.isSupportingPaneEnabled
 import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.screens.SettingsScreen
 import app.campfire.core.di.UserScope
 import app.campfire.ui.settings.composables.SettingPaneListItem
@@ -64,6 +65,7 @@ import app.campfire.ui.settings.panes.PaneState
 import app.campfire.ui.settings.panes.PlaybackPane
 import app.campfire.ui.settings.panes.SleepPane
 import campfire.features.settings.ui.generated.resources.Res
+import campfire.features.settings.ui.generated.resources.action_back
 import campfire.features.settings.ui.generated.resources.setting_about_subtitle
 import campfire.features.settings.ui.generated.resources.setting_about_title
 import campfire.features.settings.ui.generated.resources.setting_account_subtitle
@@ -257,13 +259,16 @@ private fun SettingsRootPane(
           navigationIcon = {
             val windowSizeClass = LocalWindowSizeClass.current
             if (!windowSizeClass.isSupportingPaneEnabled) {
-              IconButton(
-                onClick = onBackClick,
-              ) {
-                Icon(
-                  Icons.AutoMirrored.Rounded.ArrowBack,
-                  contentDescription = null,
-                )
+              val backLabel = stringResource(Res.string.action_back)
+              IconButtonTooltip(text = backLabel) {
+                IconButton(
+                  onClick = onBackClick,
+                ) {
+                  Icon(
+                    Icons.AutoMirrored.Rounded.ArrowBack,
+                    contentDescription = backLabel,
+                  )
+                }
               }
             }
           },

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
@@ -50,6 +50,7 @@ import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Download
 import app.campfire.common.compose.widgets.CoverImage
 import app.campfire.common.compose.widgets.EmptyState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.extensions.asReadableBytes
 import app.campfire.core.extensions.ifNotEmpty
 import app.campfire.core.model.LibraryItem
@@ -62,6 +63,7 @@ import app.campfire.ui.settings.composables.Header
 import app.campfire.ui.settings.composables.SwitchSetting
 import campfire.features.settings.ui.generated.resources.Res
 import campfire.features.settings.ui.generated.resources.action_delete_download
+import campfire.features.settings.ui.generated.resources.action_dismiss
 import campfire.features.settings.ui.generated.resources.action_stop_download
 import campfire.features.settings.ui.generated.resources.download_header_downloads
 import campfire.features.settings.ui.generated.resources.label_confirm_download_delete
@@ -170,14 +172,17 @@ private fun ConfirmDeleteListItem(
 
     Spacer(Modifier.width(16.dp))
 
-    OutlinedIconButton(
-      onClick = onDismissRequest,
-    ) {
-      Icon(
-        Icons.Rounded.Clear,
-        contentDescription = null,
-        modifier = Modifier.size(ButtonDefaults.IconSize),
-      )
+    val dismissLabel = stringResource(Res.string.action_dismiss)
+    IconButtonTooltip(text = dismissLabel) {
+      OutlinedIconButton(
+        onClick = onDismissRequest,
+      ) {
+        Icon(
+          Icons.Rounded.Clear,
+          contentDescription = dismissLabel,
+          modifier = Modifier.size(ButtonDefaults.IconSize),
+        )
+      }
     }
 
     Spacer(Modifier.width(4.dp))
@@ -237,27 +242,42 @@ private fun ItemDownloadListItem(
       )
     },
     trailingContent = {
-      FilledTonalIconButton(
-        onClick = onDeleteClick,
-        colors = IconButtonDefaults.filledTonalIconButtonColors(
-          containerColor = MaterialTheme.colorScheme.errorContainer,
-          contentColor = MaterialTheme.colorScheme.error,
-        ),
-      ) {
-        Icon(
-          when (download.state) {
-            Queued,
-            Downloading,
-            -> Icons.Rounded.Dangerous
+      val deleteOrStopLabel = stringResource(
+        when (download.state) {
+          Queued,
+          Stopped,
+          Downloading,
+          -> Res.string.action_stop_download
 
-            Stopped,
-            Completed,
-            Failed,
-            None,
-            -> Icons.Rounded.Delete
-          },
-          contentDescription = null,
-        )
+          Completed,
+          Failed,
+          None,
+          -> Res.string.action_delete_download
+        },
+      )
+      IconButtonTooltip(text = deleteOrStopLabel) {
+        FilledTonalIconButton(
+          onClick = onDeleteClick,
+          colors = IconButtonDefaults.filledTonalIconButtonColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.error,
+          ),
+        ) {
+          Icon(
+            when (download.state) {
+              Queued,
+              Downloading,
+              -> Icons.Rounded.Dangerous
+
+              Stopped,
+              Completed,
+              Failed,
+              None,
+              -> Icons.Rounded.Delete
+            },
+            contentDescription = deleteOrStopLabel,
+          )
+        }
       }
     },
     onClick = onClick,

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/SettingPaneLayout.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/SettingPaneLayout.kt
@@ -25,6 +25,10 @@ import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.CampfireTopAppBarInsets
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import campfire.features.settings.ui.generated.resources.Res
+import campfire.features.settings.ui.generated.resources.action_back
+import org.jetbrains.compose.resources.stringResource
 
 enum class PaneState {
   Single, Double,
@@ -55,13 +59,16 @@ internal fun SettingPaneLayout(
         ?: WindowInsets(0.dp),
       navigationIcon = {
         if (paneState == PaneState.Single) {
-          IconButton(
-            onClick = onBackClick,
-          ) {
-            Icon(
-              Icons.AutoMirrored.Rounded.ArrowBack,
-              contentDescription = null,
-            )
+          val backLabel = stringResource(Res.string.action_back)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(
+              onClick = onBackClick,
+            ) {
+              Icon(
+                Icons.AutoMirrored.Rounded.ArrowBack,
+                contentDescription = backLabel,
+              )
+            }
           }
         }
       },

--- a/features/stats/ui/src/commonMain/composeResources/values/user_stats_ui_strings.xml
+++ b/features/stats/ui/src/commonMain/composeResources/values/user_stats_ui_strings.xml
@@ -13,4 +13,7 @@
   <string name="library_totals_summary_format">There are {{items}} from {{authors}} spanning {{time}} over {{tracks}} taking up {{size}} of storage.</string>
   <string name="stats_user">User</string>
   <string name="stats_library">Library</string>
+
+  <string name="action_back">Back</string>
+  <string name="action_toggle_dark_mode">Toggle dark mode</string>
 </resources>

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
@@ -43,6 +43,7 @@ import app.campfire.common.compose.layout.isSupportingPaneEnabled
 import app.campfire.common.compose.widgets.CampfireMediumTopAppBar
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LoadingState
 import app.campfire.common.screens.StatisticsScreen
 import app.campfire.core.coroutines.LoadState
@@ -66,6 +67,7 @@ import app.campfire.stats.ui.composables.TopAuthorsBarChart
 import app.campfire.stats.ui.composables.TotalStatsCard
 import app.campfire.stats.ui.composables.WeeklyListeningCard
 import campfire.features.stats.ui.generated.resources.Res
+import campfire.features.stats.ui.generated.resources.action_back
 import campfire.features.stats.ui.generated.resources.stats_library
 import campfire.features.stats.ui.generated.resources.stats_user
 import campfire.features.stats.ui.generated.resources.user_stats_error_message
@@ -110,10 +112,13 @@ fun StatsUi(
             }
           },
           navigationIcon = {
-            IconButton(
-              onClick = { state.eventSink(StatsUiEvent.Back) },
-            ) {
-              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+            val backLabel = stringResource(Res.string.action_back)
+            IconButtonTooltip(text = backLabel) {
+              IconButton(
+                onClick = { state.eventSink(StatsUiEvent.Back) },
+              ) {
+                Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+              }
             }
           },
         )
@@ -134,10 +139,13 @@ fun StatsUi(
             }
           },
           navigationIcon = {
-            IconButton(
-              onClick = { state.eventSink(StatsUiEvent.Back) },
-            ) {
-              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+            val backLabel = stringResource(Res.string.action_back)
+            IconButtonTooltip(text = backLabel) {
+              IconButton(
+                onClick = { state.eventSink(StatsUiEvent.Back) },
+              ) {
+                Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+              }
             }
           },
         )

--- a/features/stats/ui/src/jvmMain/kotlin/app/campfire/stats/ui/composables/PreviewScaffold.kt
+++ b/features/stats/ui/src/jvmMain/kotlin/app/campfire/stats/ui/composables/PreviewScaffold.kt
@@ -25,7 +25,12 @@ import app.campfire.common.compose.layout.ContentLayout
 import app.campfire.common.compose.layout.LocalContentLayout
 import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.model.Tent
+import campfire.features.stats.ui.generated.resources.Res
+import campfire.features.stats.ui.generated.resources.action_back
+import campfire.features.stats.ui.generated.resources.action_toggle_dark_mode
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun PreviewScaffold(
@@ -47,20 +52,26 @@ internal fun PreviewScaffold(
           CampfireTopAppBar(
             title = { Text("User statistics") },
             navigationIcon = {
-              IconButton(
-                onClick = {},
-              ) {
-                Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+              val backLabel = stringResource(Res.string.action_back)
+              IconButtonTooltip(text = backLabel) {
+                IconButton(
+                  onClick = {},
+                ) {
+                  Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+                }
               }
             },
             actions = {
-              IconButton(
-                onClick = { _useDarkColors = !_useDarkColors },
-              ) {
-                Icon(
-                  if (_useDarkColors) Icons.Rounded.LightMode else Icons.Rounded.DarkMode,
-                  contentDescription = null,
-                )
+              val toggleDarkLabel = stringResource(Res.string.action_toggle_dark_mode)
+              IconButtonTooltip(text = toggleDarkLabel) {
+                IconButton(
+                  onClick = { _useDarkColors = !_useDarkColors },
+                ) {
+                  Icon(
+                    if (_useDarkColors) Icons.Rounded.LightMode else Icons.Rounded.DarkMode,
+                    contentDescription = toggleDarkLabel,
+                  )
+                }
               }
             },
           )

--- a/infra/audioplayer/public-ui/src/commonMain/composeResources/values/audioplayer_ui_strings.xml
+++ b/infra/audioplayer/public-ui/src/commonMain/composeResources/values/audioplayer_ui_strings.xml
@@ -8,6 +8,7 @@
   <string name="label_this_phone">This phone</string>
   <string name="label_connecting">Connecting…</string>
   <string name="media_route_dialog_title">Devices</string>
+  <string name="action_cast">Cast</string>
 
   <string name="option_shake_to_reset_title">Shake-to-reset</string>
   <string name="option_shake_to_reset_subtitle">Enable shaking to reset the current or previous timer</string>

--- a/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
+++ b/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
@@ -71,9 +71,11 @@ import app.campfire.common.compose.icons.rounded.CastConnected
 import app.campfire.common.compose.icons.rounded.CastConnecting
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.util.withDensity
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.di.AppScope
 import app.campfire.core.extensions.fluentIf
 import campfire.infra.audioplayer.public_ui.generated.resources.Res
+import campfire.infra.audioplayer.public_ui.generated.resources.action_cast
 import campfire.infra.audioplayer.public_ui.generated.resources.label_connecting
 import campfire.infra.audioplayer.public_ui.generated.resources.media_route_dialog_title
 import coil3.compose.AsyncImage
@@ -139,22 +141,27 @@ private fun CastButton(
 ) {
   if (state == CastState.Unavailable) return
 
-  IconButton(
-    onClick = onClick,
+  val castLabel = stringResource(Res.string.action_cast)
+  IconButtonTooltip(
+    text = castLabel,
     modifier = modifier,
   ) {
-    val iconPainter = when (state) {
-      CastState.Unavailable -> error("Invalid state for cast button")
+    IconButton(
+      onClick = onClick,
+    ) {
+      val iconPainter = when (state) {
+        CastState.Unavailable -> error("Invalid state for cast button")
 
-      CastState.NoDevicesAvailable,
-      CastState.NotConnected,
-      -> rememberVectorPainter(CampfireIcons.Rounded.Cast)
+        CastState.NoDevicesAvailable,
+        CastState.NotConnected,
+        -> rememberVectorPainter(CampfireIcons.Rounded.Cast)
 
-      CastState.Connecting -> CampfireIcons.Rounded.CastConnecting
-      CastState.Connected -> rememberVectorPainter(CampfireIcons.Rounded.CastConnected)
+        CastState.Connecting -> CampfireIcons.Rounded.CastConnecting
+        CastState.Connected -> rememberVectorPainter(CampfireIcons.Rounded.CastConnected)
+      }
+
+      Icon(iconPainter, contentDescription = castLabel)
     }
-
-    Icon(iconPainter, contentDescription = null)
   }
 }
 

--- a/infra/whats-new/ui/src/commonMain/composeResources/values/changelog_ui_strings.xml
+++ b/infra/whats-new/ui/src/commonMain/composeResources/values/changelog_ui_strings.xml
@@ -2,4 +2,6 @@
   <string name="changelog_title">Changelog</string>
   <string name="error_changelog_message">Uh-oh! Something went wrong trying to load the changelog.</string>
   <string name="whatsnew_widget_title">See what's new!</string>
+  <string name="action_back">Back</string>
+  <string name="action_dismiss_whats_new">Dismiss what's new</string>
 </resources>

--- a/infra/whats-new/ui/src/commonMain/kotlin/app/campfire/whatsnew/ui/ComposeWhatsNewWidgetProvider.kt
+++ b/infra/whats-new/ui/src/commonMain/kotlin/app/campfire/whatsnew/ui/ComposeWhatsNewWidgetProvider.kt
@@ -42,11 +42,13 @@ import app.campfire.common.compose.icons.Campfire
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.app.ApplicationInfo
 import app.campfire.core.di.AppScope
 import app.campfire.whatsnew.api.WhatsNewRepository
 import app.campfire.whatsnew.api.WhatsNewWidgetProvider
 import campfire.infra.whats_new.ui.generated.resources.Res
+import campfire.infra.whats_new.ui.generated.resources.action_dismiss_whats_new
 import campfire.infra.whats_new.ui.generated.resources.whatsnew_widget_title
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.launch
@@ -151,13 +153,16 @@ private fun WhatsNewWidget(
         )
       }
 
-      IconButton(
-        onClick = onDismiss,
-      ) {
-        Icon(
-          Icons.Rounded.Close,
-          contentDescription = null,
-        )
+      val dismissLabel = stringResource(Res.string.action_dismiss_whats_new)
+      IconButtonTooltip(text = dismissLabel) {
+        IconButton(
+          onClick = onDismiss,
+        ) {
+          Icon(
+            Icons.Rounded.Close,
+            contentDescription = dismissLabel,
+          )
+        }
       }
 
       Spacer(Modifier.size(8.dp))

--- a/infra/whats-new/ui/src/commonMain/kotlin/app/campfire/whatsnew/ui/changelog/ChangelogUi.kt
+++ b/infra/whats-new/ui/src/commonMain/kotlin/app/campfire/whatsnew/ui/changelog/ChangelogUi.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.widgets.CampfireLargeTopAppBar
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LoadingState
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -44,6 +45,7 @@ import app.campfire.whatsnew.ui.changelog.ChangeUi.Change.Position.Middle
 import app.campfire.whatsnew.ui.changelog.ChangeUi.Change.Position.Only
 import app.campfire.whatsnew.ui.changelog.ChangeUi.Change.Position.Top
 import campfire.infra.whats_new.ui.generated.resources.Res
+import campfire.infra.whats_new.ui.generated.resources.action_back
 import campfire.infra.whats_new.ui.generated.resources.changelog_title
 import campfire.infra.whats_new.ui.generated.resources.error_changelog_message
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
@@ -67,10 +69,13 @@ fun Changelog(
         },
         scrollBehavior = scrollBehavior,
         navigationIcon = {
-          IconButton(
-            onClick = { state.eventSink(ChangelogUiEvent.Back) },
-          ) {
-            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+          val backLabel = stringResource(Res.string.action_back)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(
+              onClick = { state.eventSink(ChangelogUiEvent.Back) },
+            ) {
+              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+            }
           }
         },
       )

--- a/ui/appbar/src/commonMain/composeResources/values/ui_appbar_strings.xml
+++ b/ui/appbar/src/commonMain/composeResources/values/ui_appbar_strings.xml
@@ -8,4 +8,6 @@
     <item>romance</item>
     <item>mystery</item>
   </string-array>
+  <string name="action_clear_search">Clear search</string>
+  <string name="action_back">Back</string>
 </resources>

--- a/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireDockedSearchBar.kt
+++ b/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireDockedSearchBar.kt
@@ -30,8 +30,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.extensions.plus
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.search.api.ui.SearchComponent
 import campfire.ui.appbar.generated.resources.Res
+import campfire.ui.appbar.generated.resources.action_clear_search
 import campfire.ui.appbar.generated.resources.search_placeholder_text
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -82,13 +84,16 @@ private fun CampfireDockedSearchBar(
           enter = fadeIn(),
           exit = fadeOut(),
         ) {
-          IconButton(
-            onClick = {
-              textFieldState.clearText()
-              scope.launch { searchBarState.animateToCollapsed() }
-            },
-          ) {
-            Icon(Icons.Rounded.Clear, contentDescription = null)
+          val clearLabel = stringResource(Res.string.action_clear_search)
+          IconButtonTooltip(text = clearLabel) {
+            IconButton(
+              onClick = {
+                textFieldState.clearText()
+                scope.launch { searchBarState.animateToCollapsed() }
+              },
+            ) {
+              Icon(Icons.Rounded.Clear, contentDescription = clearLabel)
+            }
           }
         }
       },

--- a/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireSearchAppBar.kt
+++ b/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireSearchAppBar.kt
@@ -43,9 +43,12 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.extensions.plus
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.search.api.ui.SearchComponent
 import app.campfire.ui.theming.api.widgets.ThemeIconContent
 import campfire.ui.appbar.generated.resources.Res
+import campfire.ui.appbar.generated.resources.action_back
+import campfire.ui.appbar.generated.resources.action_clear_search
 import campfire.ui.appbar.generated.resources.search_placeholder_text
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -114,13 +117,16 @@ private fun CampfireSearchAppBar(
           ) { state ->
             when (state) {
               SearchBarValue.Expanded -> {
-                IconButton(
-                  onClick = { scope.launch { searchBarState.animateToCollapsed() } },
-                ) {
-                  Icon(
-                    Icons.AutoMirrored.Default.ArrowBack,
-                    contentDescription = "Back",
-                  )
+                val backLabel = stringResource(Res.string.action_back)
+                IconButtonTooltip(text = backLabel) {
+                  IconButton(
+                    onClick = { scope.launch { searchBarState.animateToCollapsed() } },
+                  ) {
+                    Icon(
+                      Icons.AutoMirrored.Default.ArrowBack,
+                      contentDescription = backLabel,
+                    )
+                  }
                 }
               }
               SearchBarValue.Collapsed -> {
@@ -133,13 +139,16 @@ private fun CampfireSearchAppBar(
           AnimatedVisibility(
             visible = searchBarState.currentValue == SearchBarValue.Expanded,
           ) {
-            IconButton(
-              onClick = {
-                textFieldState.clearText()
-                scope.launch { searchBarState.animateToCollapsed() }
-              },
-            ) {
-              Icon(Icons.Rounded.Clear, contentDescription = null)
+            val clearLabel = stringResource(Res.string.action_clear_search)
+            IconButtonTooltip(text = clearLabel) {
+              IconButton(
+                onClick = {
+                  textFieldState.clearText()
+                  scope.launch { searchBarState.animateToCollapsed() }
+                },
+              ) {
+                Icon(Icons.Rounded.Clear, contentDescription = clearLabel)
+              }
             }
           }
         },

--- a/ui/attribution/src/commonMain/composeResources/values/attributions_strings.xml
+++ b/ui/attribution/src/commonMain/composeResources/values/attributions_strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="attributions_title">License attributions</string>
   <string name="attributions_error_message">Uh-oh! Looks like there was an issue loading the attributions.</string>
+  <string name="action_back">Back</string>
 </resources>

--- a/ui/attribution/src/commonMain/kotlin/app/campfire/attribution/AttributionUi.kt
+++ b/ui/attribution/src/commonMain/kotlin/app/campfire/attribution/AttributionUi.kt
@@ -15,11 +15,13 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LoadingState
 import app.campfire.common.screens.AttributionScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import campfire.ui.attribution.generated.resources.Res
+import campfire.ui.attribution.generated.resources.action_back
 import campfire.ui.attribution.generated.resources.attributions_error_message
 import campfire.ui.attribution.generated.resources.attributions_title
 import com.mikepenz.aboutlibraries.Libs
@@ -40,10 +42,13 @@ fun Attribution(
         scrollBehavior = scrollBehavior,
         title = { Text(stringResource(Res.string.attributions_title)) },
         navigationIcon = {
-          IconButton(
-            onClick = { state.eventSink(AttributionUiEvent.Back) },
-          ) {
-            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
+          val backLabel = stringResource(Res.string.action_back)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(
+              onClick = { state.eventSink(AttributionUiEvent.Back) },
+            ) {
+              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+            }
           }
         },
       )

--- a/ui/navigation/ui/src/commonMain/composeResources/values/ui_drawer_strings.xml
+++ b/ui/navigation/ui/src/commonMain/composeResources/values/ui_drawer_strings.xml
@@ -33,4 +33,6 @@
 
   <string name="nav_downloads_label">Downloads</string>
   <string name="nav_downloads_content_description">The offline downloaded content for the current user</string>
+
+  <string name="action_change_theme">Change theme</string>
 </resources>

--- a/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/drawer/CampfireDrawer.kt
+++ b/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/drawer/CampfireDrawer.kt
@@ -26,6 +26,7 @@ import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.di.rememberComponent
 import app.campfire.common.compose.layout.NavigationType
 import app.campfire.common.compose.layout.navigationType
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.di.UserScope
 import app.campfire.core.reflect.instanceOf
 import app.campfire.ui.navigation.HomeNavigationItem
@@ -34,10 +35,13 @@ import app.campfire.ui.theming.api.screen.ThemePickerScreen
 import app.campfire.updates.AppUpdateWidget
 import app.campfire.whatsnew.api.WhatsNewWidgetProvider
 import app.campfire.whatsnew.api.screen.ChangelogScreen
+import campfire.ui.navigation.ui.generated.resources.Res
+import campfire.ui.navigation.ui.generated.resources.action_change_theme
 import com.r0adkll.kimchi.annotations.ContributesTo
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.screen.Screen
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
 
 @ContributesTo(UserScope::class)
 interface CampfireDrawerComponent {
@@ -95,15 +99,9 @@ fun CampfireDrawer(
 
     Spacer(Modifier.weight(1f))
 
-    FilledTonalIconButton(
-      shapes = IconButtonDefaults.shapes(),
-      colors = IconButtonDefaults.filledTonalIconButtonColors(),
-      onClick = {
-        navigator.goTo(ThemePickerScreen)
-        scope.launch {
-          drawerState.close()
-        }
-      },
+    val changeThemeLabel = stringResource(Res.string.action_change_theme)
+    IconButtonTooltip(
+      text = changeThemeLabel,
       modifier = Modifier
         .align(Alignment.End)
         .padding(
@@ -111,7 +109,18 @@ fun CampfireDrawer(
           vertical = 8.dp,
         ),
     ) {
-      Icon(Icons.Rounded.Palette, contentDescription = "Change theme")
+      FilledTonalIconButton(
+        shapes = IconButtonDefaults.shapes(),
+        colors = IconButtonDefaults.filledTonalIconButtonColors(),
+        onClick = {
+          navigator.goTo(ThemePickerScreen)
+          scope.launch {
+            drawerState.close()
+          }
+        },
+      ) {
+        Icon(Icons.Rounded.Palette, contentDescription = changeThemeLabel)
+      }
     }
 
     component.appUpdateWidget.Content(

--- a/ui/theming/ui/src/commonMain/composeResources/values/ui_theming_strings.xml
+++ b/ui/theming/ui/src/commonMain/composeResources/values/ui_theming_strings.xml
@@ -6,4 +6,7 @@
   <string name="theme_name_life_float">Life Float Orange</string>
   <string name="theme_name_mountain">Mountain Range Purple</string>
   <string name="theme_name_dynamic">System Wallpaper Dynamic</string>
+  <string name="action_back">Back</string>
+  <string name="action_edit_theme">Edit theme</string>
+  <string name="action_delete_theme">Delete theme</string>
 </resources>

--- a/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/ai/AiThemeBuilderUi.kt
+++ b/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/ai/AiThemeBuilderUi.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.theme.LocalUseDarkColors
 import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.di.UserScope
 import app.campfire.ui.theming.api.HalogenStyle
 import app.campfire.ui.theming.api.colorScheme
@@ -62,8 +63,11 @@ import app.campfire.ui.theming.ui.ai.composables.AppPreview
 import app.campfire.ui.theming.ui.ai.emptystate.ShapeParticleEmptyState
 import app.campfire.ui.theming.ui.ai.emptystate.ShapeParticleGameState
 import app.campfire.ui.theming.ui.builder.composables.IconPicker
+import campfire.ui.theming.ui.generated.resources.Res
+import campfire.ui.theming.ui.generated.resources.action_back
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import kotlin.time.Duration.Companion.nanoseconds
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @CircuitInject(AiThemeBuilderScreen::class, UserScope::class)
@@ -85,8 +89,11 @@ fun AiThemeBuilder(
       CampfireTopAppBar(
         title = { Text("AI Theme Builder") },
         navigationIcon = {
-          IconButton(onClick = { state.eventSink(AiThemeBuilderUiEvent.Back) }) {
-            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+          val backLabel = stringResource(Res.string.action_back)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(onClick = { state.eventSink(AiThemeBuilderUiEvent.Back) }) {
+              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+            }
           }
         },
         scrollBehavior = scrollBehavior,

--- a/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/builder/ThemeBuilderUi.kt
+++ b/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/builder/ThemeBuilderUi.kt
@@ -60,6 +60,7 @@ import app.campfire.common.compose.layout.LocalContentLayout
 import app.campfire.common.compose.theme.LocalUseDarkColors
 import app.campfire.common.compose.theme.alt.AltRedColorPalette
 import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.di.UserScope
 import app.campfire.ui.theming.api.AppTheme
 import app.campfire.ui.theming.api.colorScheme
@@ -70,9 +71,13 @@ import app.campfire.ui.theming.ui.builder.composables.ColorStylePicker
 import app.campfire.ui.theming.ui.builder.composables.ContrastPicker
 import app.campfire.ui.theming.ui.builder.composables.Header
 import app.campfire.ui.theming.ui.builder.composables.IconPicker
+import campfire.ui.theming.ui.generated.resources.Res
+import campfire.ui.theming.ui.generated.resources.action_back
+import campfire.ui.theming.ui.generated.resources.action_delete_theme
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.r0adkll.swatchbuckler.color.dynamiccolor.ColorSpec.SpecVersion
 import com.r0adkll.swatchbuckler.color.dynamiccolor.Variant
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @CircuitInject(ThemeBuilderScreen::class, UserScope::class)
@@ -94,25 +99,31 @@ fun ThemeBuilder(
             Text("Theme Builder")
           },
           navigationIcon = {
-            IconButton(
-              onClick = { state.eventSink(ThemeBuilderUiEvent.Back) },
-            ) {
-              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+            val backLabel = stringResource(Res.string.action_back)
+            IconButtonTooltip(text = backLabel) {
+              IconButton(
+                onClick = { state.eventSink(ThemeBuilderUiEvent.Back) },
+              ) {
+                Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+              }
             }
           },
           actions = {
             var showDeleteConfirmation by remember { mutableStateOf(false) }
             if (!state.theme.isNew) {
-              IconButton(
-                onClick = {
-                  showDeleteConfirmation = true
-                },
-              ) {
-                Icon(
-                  Icons.Rounded.Delete,
-                  contentDescription = "Delete",
-                  tint = MaterialTheme.colorScheme.error,
-                )
+              val deleteLabel = stringResource(Res.string.action_delete_theme)
+              IconButtonTooltip(text = deleteLabel) {
+                IconButton(
+                  onClick = {
+                    showDeleteConfirmation = true
+                  },
+                ) {
+                  Icon(
+                    Icons.Rounded.Delete,
+                    contentDescription = deleteLabel,
+                    tint = MaterialTheme.colorScheme.error,
+                  )
+                }
               }
 
               if (showDeleteConfirmation) {

--- a/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/picker/ThemePickerUi.kt
+++ b/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/picker/ThemePickerUi.kt
@@ -57,6 +57,7 @@ import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.theme.Ai
 import app.campfire.common.compose.icons.theme.Palette
 import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.coroutines.onError
 import app.campfire.core.coroutines.onLoaded
 import app.campfire.core.coroutines.onLoading
@@ -66,6 +67,8 @@ import app.campfire.ui.theming.api.AppThemeImage
 import app.campfire.ui.theming.api.colorScheme
 import app.campfire.ui.theming.api.screen.ThemePickerScreen
 import campfire.ui.theming.ui.generated.resources.Res
+import campfire.ui.theming.ui.generated.resources.action_back
+import campfire.ui.theming.ui.generated.resources.action_edit_theme
 import campfire.ui.theming.ui.generated.resources.theme_name_dynamic
 import campfire.ui.theming.ui.generated.resources.theme_name_forest
 import campfire.ui.theming.ui.generated.resources.theme_name_life_float
@@ -94,10 +97,13 @@ fun ThemePicker(
             Text("Theme")
           },
           navigationIcon = {
-            IconButton(
-              onClick = { state.eventSink(ThemePickerUiEvent.Back) },
-            ) {
-              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+            val backLabel = stringResource(Res.string.action_back)
+            IconButtonTooltip(text = backLabel) {
+              IconButton(
+                onClick = { state.eventSink(ThemePickerUiEvent.Back) },
+              ) {
+                Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+              }
             }
           },
           scrollBehavior = scrollBehavior,
@@ -300,12 +306,15 @@ private fun ThemeOption(
         Spacer(Modifier.width(16.dp))
 
         if (onEditClick != null) {
-          IconButton(onClick = onEditClick) {
-            Icon(
-              if (theme is AppTheme.Fixed.Ai) Icons.Rounded.AutoAwesome else Icons.Rounded.Edit,
-              contentDescription = null,
-              tint = MaterialTheme.colorScheme.onPrimaryContainer,
-            )
+          val editLabel = stringResource(Res.string.action_edit_theme)
+          IconButtonTooltip(text = editLabel) {
+            IconButton(onClick = onEditClick) {
+              Icon(
+                if (theme is AppTheme.Fixed.Ai) Icons.Rounded.AutoAwesome else Icons.Rounded.Edit,
+                contentDescription = editLabel,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+              )
+            }
           }
           Spacer(Modifier.size(8.dp))
         }


### PR DESCRIPTION
## Summary
- Migrated all ~86 icon-only buttons (across 49 Kotlin files in 16 modules) to the `IconButtonTooltip` wrapper, with each call site getting a localized `stringResource` label that drives both the tooltip and the inner `Icon`'s `contentDescription`.
- Replaced `PlaylistFloatingToolbar`'s inline `TooltipBox` helper with the canonical `IconButtonTooltip` wrapper.
- Added per-module string resources (`action_back`, `action_close`, `action_delete_*`, etc.) under each module's existing `composeResources/values/*_strings.xml`.

The misnamed `FilledTonalIconButton`/`OutlinedIconButton`/`TextIconButton` helpers in `common/compose/widgets/Buttons.kt` were intentionally left alone — they take both an `icon` and a `label` slot and aren't icon-only buttons.

## Test plan
- [x] `./gradlew compileKotlinJvm` — BUILD SUCCESSFUL across all modules
- [x] `./scripts/ktlint --check` — clean
- [x] Re-audit grep — zero remaining un-wrapped icon-button call sites
- [x] Manual smoke: long-press an action in the top app bar / playback bar / bookmarks sheet to confirm tooltips render
- [ ] TalkBack/VoiceOver pass on a representative screen (e.g. library item detail) to confirm content descriptions read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)