### PR TITLE
CI: split Android compile/APK and cache K/N for iOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,50 @@ jobs:
 #          fi
 
   android:
+    name: Android — compile validation
+    needs: [code-style]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Download Google Services JSON
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          if [ -n "$GOOGLE_SERVICES_JSON" ]; then
+            echo "$GOOGLE_SERVICES_JSON" > app/android/google-services.json
+          else
+            echo "Skipping google-services.json (no secret available — fork PR or external contributor)"
+          fi
+
+      - name: Validate Android compilation
+        run: ./gradlew :app:android:compileAlphaReleaseSources
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-compile-reports
+          path: |
+            **/build/reports/*
+
+  android-apk:
+    name: Android — alpha APK
+    # Async w.r.t. `android` validation — runs in parallel, only on first-party PRs so we
+    # have somewhere to post the comment (and access to first-party secrets if needed).
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [code-style]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -179,21 +223,11 @@ jobs:
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
             echo "$GOOGLE_SERVICES_JSON" > app/android/google-services.json
           else
-            echo "Skipping google-services.json (no secret available — fork PR or external contributor)"
+            echo "Skipping google-services.json (no secret available)"
           fi
 
-      - name: Build Android App
-        run: |
-          ./gradlew :app:android:assembleAlphaRelease
-
-      # FIXME: Disable for now as we need to figure out how to run the danger container from here
-      # - name: Danger Lint
-      #   if: ${{ github.event_name == 'pull_request' }}
-      #   uses: docker://ghcr.io/danger/danger-kotlin:1.3.3
-      #   with:
-      #     args: --failOnErrors --no-publish-check
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Alpha Release APK
+        run: ./gradlew :app:android:assembleAlphaRelease
 
       - name: Upload APK
         id: upload_artifact
@@ -204,7 +238,6 @@ jobs:
           path: app/android/build/outputs/apk/alpha/release/android-alpha-release.apk
 
       - name: Post Artifact URL to PR
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
@@ -212,20 +245,12 @@ jobs:
           comment-tag: apk_url
 
       - name: Upload reports
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: android-reports
+          name: android-apk-reports
           path: |
             **/build/reports/*
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: android-test-results
-          path: |
-            **/build/test-results/*
 
   desktop:
     needs: [code-style]
@@ -285,11 +310,22 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      # Kotlin/Native dist + cinterop caches live outside ~/.gradle, so they aren't
+      # restored by setup-java's gradle cache or setup-gradle. Caching ~/.konan
+      # avoids re-downloading and re-compiling the K/N dist on every run.
+      - name: Cache Kotlin/Native (~/.konan)
+        uses: actions/cache@v5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
+
       - name: iosSimulatorArm64Test
         run: ./gradlew iosSimulatorArm64Test
 
       - name: Upload reports
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: ios-reports
@@ -297,7 +333,7 @@ jobs:
             **/build/reports/*
 
       - name: Upload test results
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: ios-test-results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,7 +319,7 @@ jobs:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            konan-${{ runner.os }}-
+            konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: iosSimulatorArm64Test
         run: ./gradlew iosSimulatorArm64Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
 #          fi
 
   android:
-    name: Android — compile validation
+    name: Android / Compilation
     needs: [code-style]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -173,7 +173,7 @@ jobs:
             **/build/reports/*
 
   android-apk:
-    name: Android — alpha APK
+    name: Android / APK
     # Async w.r.t. `android` validation — runs in parallel, only on first-party PRs so we
     # have somewhere to post the comment (and access to first-party secrets if needed).
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
## Summary
- Android `android` job now blocks only on `:app:android:compileAlphaReleaseSources` (KSP + Kotlin + Java + resources, no R8/dex/sign/packaging).
- New parallel `android-apk` job builds the alpha release APK and posts the artifact link to the PR; gated on first-party PRs only (the place where the comment can land + where keystore/Firebase secrets exist if we ever need them).
- iOS job caches `~/.konan` (Kotlin/Native dist + cinterop deps) — biggest single macOS-runner win since neither setup-java's gradle cache nor setup-gradle restores it.
- Trimmed `if: always()` → `if: failure()` on the report/test-result uploads — only useful on red builds.

## Why
Main CI was slow because `assembleAlphaRelease` (R8 + dex + sign + package) gated the whole branch even when all that's needed for merge correctness is "does it compile?" Splitting lets the blocking signal arrive much earlier; the APK build keeps running in parallel for PR feedback.

## Test plan
- [ ] First-party PR: confirm `android` (compile validation), `android-apk`, `desktop`, `ios-test` all start in parallel after `code-style` finishes.
- [ ] First-party PR: confirm the bot comments the APK link as before (tag `apk_url`).
- [ ] Fork PR: confirm `android-apk` is skipped and `android` still runs the compile validation.
- [ ] Push to `main`: confirm `android-apk` is skipped (alpha-release.yml handles main).
- [ ] iOS job: confirm `~/.konan` cache hit on the second run shaves a meaningful chunk of time.

## Follow-ups (not in this PR)
- `settings.gradle.kts` disables the Gradle build cache on CI (`local.isEnabled = !isCi`). Wiring up a remote/persisted build cache would compound across `android`, `android-apk`, `desktop`, `ios-test`, and `code-coverage`.
- `code-coverage` runs `test allTests koverXmlReport` on every PR and is now likely the longest blocking job. Worth revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)