### PR TITLE
Delete podcast action for admins

### DIFF
--- a/core/src/commonMain/kotlin/app/campfire/core/model/User.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/model/User.kt
@@ -18,6 +18,9 @@ data class User(
   val canEditCollections: Boolean
     get() = type == Type.Admin || type == Type.Root
 
+  val canDeleteItems: Boolean
+    get() = permissions.delete && (type == Type.Admin || type == Type.Root)
+
   enum class Type {
     Root,
     Guest,

--- a/data/network/api/src/commonMain/kotlin/app/campfire/network/AudioBookShelfApi.kt
+++ b/data/network/api/src/commonMain/kotlin/app/campfire/network/AudioBookShelfApi.kt
@@ -238,6 +238,13 @@ interface AudioBookShelfApi {
    */
   suspend fun deleteCollection(collectionId: String): Result<Unit>
 
+  /**
+   * Delete a library item. Pass `hard = true` to also remove the item's files
+   * from the server's filesystem; otherwise only the DB row + cascading data
+   * (progress, playlist membership, RSS feed, metadata cache) are removed.
+   */
+  suspend fun deleteLibraryItem(itemId: String, hard: Boolean = false): Result<Unit>
+
   //endregion
 
   //region Playlists

--- a/data/network/impl/src/commonMain/kotlin/app/campfire/network/KtorAudioBookShelfApi.kt
+++ b/data/network/impl/src/commonMain/kotlin/app/campfire/network/KtorAudioBookShelfApi.kt
@@ -54,6 +54,7 @@ import com.r0adkll.kimchi.annotations.ContributesBinding
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
+import io.ktor.client.request.parameter
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.request.url
@@ -389,6 +390,15 @@ class KtorAudioBookShelfApi(
     return trySendRequest({}) {
       hydratedClientRequest("/api/collections/$collectionId") {
         method = HttpMethod.Delete
+      }
+    }
+  }
+
+  override suspend fun deleteLibraryItem(itemId: String, hard: Boolean): Result<Unit> {
+    return trySendRequest({}) {
+      hydratedClientRequest("/api/items/$itemId") {
+        method = HttpMethod.Delete
+        if (hard) parameter("hard", "1")
       }
     }
   }

--- a/data/network/test/src/commonMain/kotlin/app/campfire/network/test/FakeAudioBookShelfApi.kt
+++ b/data/network/test/src/commonMain/kotlin/app/campfire/network/test/FakeAudioBookShelfApi.kt
@@ -188,6 +188,10 @@ class FakeAudioBookShelfApi : AudioBookShelfApi {
     TODO("Not yet implemented")
   }
 
+  override suspend fun deleteLibraryItem(itemId: String, hard: Boolean): Result<Unit> {
+    TODO("Not yet implemented")
+  }
+
   override suspend fun createPlaylist(
     libraryId: String,
     name: String,

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryItemRepository.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryItemRepository.kt
@@ -9,4 +9,14 @@ interface LibraryItemRepository {
   fun observeLibraryItem(itemId: LibraryItemId): Flow<LibraryItem>
 
   suspend fun getLibraryItem(itemId: LibraryItemId): LibraryItem
+
+  /**
+   * Delete a library item from the server. When [hardDelete] is true the
+   * server also removes the item's files from disk; otherwise only the DB
+   * row + cascading server-side data is removed.
+   *
+   * On success the local cache for this item is cleared. Cleanup of any
+   * locally-downloaded audio files is the caller's responsibility.
+   */
+  suspend fun deleteLibraryItem(itemId: LibraryItemId, hardDelete: Boolean): Result<Unit>
 }

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryItemRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryItemRepository.kt
@@ -8,6 +8,7 @@ import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.Media
 import app.campfire.libraries.api.LibraryItemRepository
 import app.campfire.libraries.item.LibraryItemStore
+import app.campfire.network.AudioBookShelfApi
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNot
@@ -23,6 +24,7 @@ import org.mobilenativefoundation.store.store5.impl.extensions.fresh
 @Inject
 class StoreLibraryItemRepository(
   libraryItemStoreFactory: LibraryItemStore.Factory,
+  private val api: AudioBookShelfApi,
 ) : LibraryItemRepository {
 
   private val itemStore = libraryItemStoreFactory.create()
@@ -48,6 +50,11 @@ class StoreLibraryItemRepository(
     } else {
       itemStore.fresh(itemId)
     }
+  }
+
+  override suspend fun deleteLibraryItem(itemId: LibraryItemId, hardDelete: Boolean): Result<Unit> {
+    return api.deleteLibraryItem(itemId, hardDelete)
+      .onSuccess { itemStore.clear(itemId) }
   }
 
   /**

--- a/features/libraries/test/src/commonMain/kotlin/app/campfire/libraries/test/FakeLibraryItemRepository.kt
+++ b/features/libraries/test/src/commonMain/kotlin/app/campfire/libraries/test/FakeLibraryItemRepository.kt
@@ -17,4 +17,11 @@ class FakeLibraryItemRepository : LibraryItemRepository {
   override suspend fun getLibraryItem(itemId: LibraryItemId): LibraryItem {
     return libraryItem
   }
+
+  val deleteInvocations = mutableListOf<Pair<LibraryItemId, Boolean>>()
+  var deleteResult: Result<Unit> = Result.success(Unit)
+  override suspend fun deleteLibraryItem(itemId: LibraryItemId, hardDelete: Boolean): Result<Unit> {
+    deleteInvocations += itemId to hardDelete
+    return deleteResult
+  }
 }

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -110,4 +110,15 @@
   <string name="action_retry_download">Retry download</string>
   <string name="action_delete_download">Delete download</string>
   <string name="action_add_podcast">Add a podcast</string>
+
+  <string name="cd_more_actions">More actions</string>
+  <string name="menu_item_delete_podcast">Delete podcast</string>
+  <string name="dialog_delete_podcast_title">Delete this podcast?</string>
+  <string name="dialog_delete_podcast_message">This will permanently remove the podcast and all listening progress from your server. This cannot be undone.</string>
+  <string name="dialog_delete_podcast_hard_label">Also delete files from server</string>
+  <string name="dialog_delete_podcast_hard_description">Permanently removes the podcast folder and all audio files from disk. The library item is removed either way.</string>
+  <string name="dialog_delete_podcast_action_confirm">Delete</string>
+  <string name="dialog_delete_podcast_action_confirm_hard">Delete &amp; remove files</string>
+  <string name="dialog_delete_podcast_action_cancel">Cancel</string>
+  <string name="error_delete_podcast">Couldn\'t delete podcast. Try again.</string>
 </resources>

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
@@ -3,13 +3,16 @@ package app.campfire.libraries.ui.detail
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.coroutines.map
 import app.campfire.core.di.UserScope
+import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.MediaType
 import app.campfire.core.session.UserSession
@@ -24,6 +27,7 @@ import app.campfire.ui.theming.api.ThemeManager
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.r0adkll.swatchbuckler.compose.Schema
 import com.slack.circuit.foundation.NonPausablePresenter
+import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.Navigator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
@@ -45,6 +49,7 @@ class LibraryItemPresenter(
   private val themeManager: ThemeManager,
   private val themeSettings: ThemeSettings,
   private val dispatcherProvider: DispatcherProvider,
+  private val offlineDownloadManager: OfflineDownloadManager,
 ) : NonPausablePresenter<LibraryItemUiState> {
 
   @Suppress("UNCHECKED_CAST")
@@ -88,12 +93,15 @@ class LibraryItemPresenter(
       } else themeManager.observeSwatchFor(screen.libraryItemId)
     }.collectAsState(null)
 
+    var errorMessage by rememberRetained { mutableStateOf<String?>(null) }
+
     return LibraryItemUiState(
       user = userSession.requiredUser,
       libraryItem = libraryItemContentState.dataOrNull,
       theme = theme,
       swatch = swatch,
       contentState = contentState,
+      errorMessage = errorMessage,
     ) { event ->
       when (event) {
         LibraryItemUiEvent.OnBack -> navigator.pop()
@@ -105,6 +113,26 @@ class LibraryItemPresenter(
               seedColor = event.seedColor,
             )
           }
+        }
+
+        is LibraryItemUiEvent.DeleteItemClick -> {
+          val item = libraryItemContentState.dataOrNull ?: return@LibraryItemUiState
+          scope.launch {
+            repository.deleteLibraryItem(screen.libraryItemId, event.hardDelete)
+              .onSuccess {
+                runCatching { offlineDownloadManager.delete(item) }
+                  .onFailure { bark(throwable = it) { "Failed to clean up offline downloads after delete" } }
+                navigator.pop()
+              }
+              .onFailure { error ->
+                bark(throwable = error) { "Failed to delete library item ${screen.libraryItemId}" }
+                errorMessage = error.message ?: "Couldn't delete podcast"
+              }
+          }
+        }
+
+        LibraryItemUiEvent.ClearError -> {
+          errorMessage = null
         }
 
         // If we don't handle the event then pass it through the content state

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
-import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.DeleteForever
 import androidx.compose.material.icons.rounded.LibraryAdd
 import androidx.compose.material.icons.rounded.MoreVert
@@ -48,7 +47,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import app.campfire.analytics.Analytics
 import app.campfire.analytics.events.ActionEvent

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
@@ -16,7 +16,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.DeleteForever
 import androidx.compose.material.icons.rounded.LibraryAdd
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -27,12 +32,14 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +48,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import app.campfire.analytics.Analytics
 import app.campfire.analytics.events.ActionEvent
@@ -63,6 +71,7 @@ import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryId
 import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.MediaType
 import app.campfire.core.model.User
 import app.campfire.core.model.User.Permissions
 import app.campfire.core.model.User.Type
@@ -70,6 +79,7 @@ import app.campfire.core.model.UserId
 import app.campfire.core.model.preview.libraryItem
 import app.campfire.core.model.preview.mediaProgress
 import app.campfire.libraries.api.screen.LibraryItemScreen
+import app.campfire.libraries.ui.detail.composables.DeletePodcastDialog
 import app.campfire.libraries.ui.detail.composables.SwatchToolbar
 import app.campfire.libraries.ui.detail.composables.slots.ChapterContainerColor
 import app.campfire.libraries.ui.detail.composables.slots.ChapterHeaderSlot
@@ -88,8 +98,10 @@ import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import campfire.features.libraries.ui.generated.resources.Res
 import campfire.features.libraries.ui.generated.resources.cd_add_to_collection
 import campfire.features.libraries.ui.generated.resources.cd_back_arrow
+import campfire.features.libraries.ui.generated.resources.cd_more_actions
 import campfire.features.libraries.ui.generated.resources.error_library_item_message
 import campfire.features.libraries.ui.generated.resources.genres_title
+import campfire.features.libraries.ui.generated.resources.menu_item_delete_podcast
 import campfire.features.libraries.ui.generated.resources.tags_title
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.sharedelements.PreviewSharedElementTransitionLayout
@@ -128,9 +140,21 @@ fun LibraryItemContent(
   val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
   var showAddToCollectionDialog by remember { mutableStateOf(false) }
+  var showOverflowMenu by remember { mutableStateOf(false) }
+  var showDeleteDialog by remember { mutableStateOf(false) }
 
   val snackBarHost = remember { SnackbarHostState() }
   val surfaceColor = MaterialTheme.colorScheme.surfaceColorAtElevation(LocalAbsoluteTonalElevation.current)
+
+  state.errorMessage?.let { message ->
+    LaunchedEffect(message) {
+      snackBarHost.showSnackbar(message)
+      state.eventSink(LibraryItemUiEvent.ClearError)
+    }
+  }
+
+  val canDeletePodcast = state.user.canDeleteItems &&
+    state.libraryItem?.mediaType == MediaType.Podcast
   Scaffold(
     containerColor = surfaceColor,
     snackbarHost = {
@@ -191,6 +215,43 @@ fun LibraryItemContent(
               }
             }
           }
+
+          if (canDeletePodcast) {
+            val moreActionsLabel = stringResource(Res.string.cd_more_actions)
+            IconButtonTooltip(text = moreActionsLabel) {
+              IconButton(onClick = { showOverflowMenu = true }) {
+                Icon(
+                  Icons.Rounded.MoreVert,
+                  contentDescription = moreActionsLabel,
+                )
+              }
+            }
+            DropdownMenu(
+              expanded = showOverflowMenu,
+              onDismissRequest = { showOverflowMenu = false },
+              shape = MaterialTheme.shapes.medium,
+            ) {
+              DropdownMenuItem(
+                text = {
+                  Text(
+                    text = stringResource(Res.string.menu_item_delete_podcast),
+                    color = MaterialTheme.colorScheme.error,
+                  )
+                },
+                leadingIcon = {
+                  Icon(
+                    Icons.Rounded.DeleteForever,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                  )
+                },
+                onClick = {
+                  showOverflowMenu = false
+                  showDeleteDialog = true
+                },
+              )
+            }
+          }
         },
       )
     },
@@ -234,6 +295,23 @@ fun LibraryItemContent(
       item = state.libraryItem!!,
       onDismiss = { showAddToCollectionDialog = false },
       modifier = Modifier,
+    )
+  }
+
+  if (showDeleteDialog) {
+    DeletePodcastDialog(
+      onConfirm = { hardDelete ->
+        Analytics.send(
+          ActionEvent(
+            "delete_podcast",
+            Click,
+            if (hardDelete) "hard" else "soft",
+          ),
+        )
+        showDeleteDialog = false
+        state.eventSink(LibraryItemUiEvent.DeleteItemClick(hardDelete))
+      },
+      onDismissRequest = { showDeleteDialog = false },
     )
   }
 }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUiState.kt
@@ -23,6 +23,7 @@ data class LibraryItemUiState(
   val swatch: Swatch? = null,
   val theme: Theme? = null,
   val contentState: LoadState<out ContentUiState>,
+  val errorMessage: String? = null,
   val eventSink: (LibraryItemUiEvent) -> Unit,
 ) : CircuitUiState
 
@@ -66,6 +67,9 @@ sealed interface LibraryItemUiEvent : CircuitUiEvent {
   data class OpenPlaylist(val playlistId: PlaylistId, val isCreated: Boolean) : LibraryItemUiEvent
   data class OpenEpisode(val episode: PodcastEpisode) : LibraryItemUiEvent
   data object FindEpisodes : LibraryItemUiEvent
+
+  data class DeleteItemClick(val hardDelete: Boolean) : LibraryItemUiEvent
+  data object ClearError : LibraryItemUiEvent
 
   data object OnBack : LibraryItemUiEvent
 }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/DeletePodcastDialog.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/DeletePodcastDialog.kt
@@ -1,0 +1,103 @@
+package app.campfire.libraries.ui.detail.composables
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.extensions.alpha
+import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.dialog_delete_podcast_action_cancel
+import campfire.features.libraries.ui.generated.resources.dialog_delete_podcast_action_confirm
+import campfire.features.libraries.ui.generated.resources.dialog_delete_podcast_action_confirm_hard
+import campfire.features.libraries.ui.generated.resources.dialog_delete_podcast_hard_description
+import campfire.features.libraries.ui.generated.resources.dialog_delete_podcast_hard_label
+import campfire.features.libraries.ui.generated.resources.dialog_delete_podcast_message
+import campfire.features.libraries.ui.generated.resources.dialog_delete_podcast_title
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun DeletePodcastDialog(
+  onConfirm: (hardDelete: Boolean) -> Unit,
+  onDismissRequest: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var hardDelete by remember { mutableStateOf(false) }
+
+  AlertDialog(
+    modifier = modifier,
+    onDismissRequest = onDismissRequest,
+    title = { Text(stringResource(Res.string.dialog_delete_podcast_title)) },
+    text = {
+      Column {
+        Text(stringResource(Res.string.dialog_delete_podcast_message))
+        Spacer(Modifier.height(16.dp))
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier
+            .toggleable(
+              value = hardDelete,
+              role = Role.Switch,
+              onValueChange = { hardDelete = it },
+            )
+            .padding(vertical = 4.dp),
+        ) {
+          Column(modifier = Modifier.weight(1f)) {
+            Text(
+              text = stringResource(Res.string.dialog_delete_podcast_hard_label),
+              style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+              text = stringResource(Res.string.dialog_delete_podcast_hard_description),
+              style = MaterialTheme.typography.bodySmall.alpha(0.7f),
+            )
+          }
+          Switch(
+            checked = hardDelete,
+            onCheckedChange = null,
+            modifier = Modifier.padding(start = 16.dp),
+          )
+        }
+      }
+    },
+    confirmButton = {
+      TextButton(
+        onClick = { onConfirm(hardDelete) },
+        colors = ButtonDefaults.textButtonColors(
+          contentColor = MaterialTheme.colorScheme.error,
+        ),
+      ) {
+        Text(
+          stringResource(
+            if (hardDelete) {
+              Res.string.dialog_delete_podcast_action_confirm_hard
+            } else {
+              Res.string.dialog_delete_podcast_action_confirm
+            },
+          ),
+        )
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismissRequest) {
+        Text(stringResource(Res.string.dialog_delete_podcast_action_cancel))
+      }
+    },
+  )
+}

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
@@ -88,6 +88,7 @@ abstract class BaseLibraryItemPresenterTest {
     themeManager = themeManager,
     themeSettings = themeSettings,
     dispatcherProvider = dispatcherProvider,
+    offlineDownloadManager = offlineDownloadManager,
   )
 }
 

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
@@ -78,7 +78,7 @@ abstract class BaseLibraryItemPresenterTest {
     addToPlaylistDialog = AddToPlaylistDialog.NoOp,
   )
 
-  protected val presenter = LibraryItemPresenter(
+  internal val presenter = LibraryItemPresenter(
     userSession = UserSession.LoggedIn(user("user_id")),
     screen = screen,
     navigator = navigator,

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenterEventsTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenterEventsTest.kt
@@ -20,10 +20,12 @@ import app.cash.burst.Burst
 import app.cash.burst.burstValues
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
 import assertk.assertions.single
@@ -52,6 +54,9 @@ class LibraryItemPresenterEventsTest : BaseLibraryItemPresenterTest() {
       NarratorClick,
       AuthorClick,
       PlayClick,
+      DeleteItemClickSoft,
+      DeleteItemClickHard,
+      DeleteItemClickFailure,
       OnBack,
     ),
   ) = runTest {
@@ -402,5 +407,54 @@ private val TimeInBookChange = EventTest(
       .isEqualTo("time_in_book_clicked")
 
     assertThat(settings.showTimeInBook).isTrue()
+  },
+)
+
+private val DeleteItemClickSoft = EventTest(
+  event = LibraryItemUiEvent.DeleteItemClick(hardDelete = false),
+  assert = {
+    assertThat(libraryItemRepository.deleteInvocations)
+      .single()
+      .isEqualTo(TestLibraryItemId to false)
+
+    assertThat(offlineDownloadManager.invocations)
+      .firstInstanceOf<FakeOfflineDownloadManager.Invocation.Delete>()
+      .transform { it.item.id }
+      .isEqualTo(TestLibraryItemId)
+
+    navigator.awaitPop()
+  },
+)
+
+private val DeleteItemClickHard = EventTest(
+  event = LibraryItemUiEvent.DeleteItemClick(hardDelete = true),
+  assert = {
+    assertThat(libraryItemRepository.deleteInvocations)
+      .single()
+      .isEqualTo(TestLibraryItemId to true)
+
+    navigator.awaitPop()
+  },
+)
+
+private val DeleteItemClickFailure = EventTest(
+  event = LibraryItemUiEvent.DeleteItemClick(hardDelete = false),
+  setup = {
+    libraryItemRepository.deleteResult = Result.failure(IllegalStateException("boom"))
+  },
+  assert = {
+    assertThat(libraryItemRepository.deleteInvocations).hasSize(1)
+
+    presenter.test {
+      skipItems(1)
+      val withError = awaitItem()
+      assertThat(withError.errorMessage).isEqualTo("boom")
+
+      withError.eventSink(LibraryItemUiEvent.ClearError)
+      val cleared = awaitItem()
+      assertThat(cleared.errorMessage).isNull()
+
+      cancelAndIgnoreRemainingEvents()
+    }
   },
 )

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenterEventsTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenterEventsTest.kt
@@ -56,7 +56,6 @@ class LibraryItemPresenterEventsTest : BaseLibraryItemPresenterTest() {
       PlayClick,
       DeleteItemClickSoft,
       DeleteItemClickHard,
-      DeleteItemClickFailure,
       OnBack,
     ),
   ) = runTest {
@@ -76,6 +75,35 @@ class LibraryItemPresenterEventsTest : BaseLibraryItemPresenterTest() {
       item.eventSink(eventTest.event)
 
       eventTest.assert(this@LibraryItemPresenterEventsTest)
+
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun deleteItemClick_onFailure_setsErrorMessage_andClearErrorResetsIt() = runTest {
+    val libraryItem = emptyLibraryItem()
+    libraryItemRepository.libraryItemFlow.emit(libraryItem)
+    libraryItemRepository.deleteResult = Result.failure(IllegalStateException("boom"))
+
+    presenter.test {
+      skipItems(1)
+      val item = awaitItem()
+
+      item.eventSink(LibraryItemUiEvent.DeleteItemClick(hardDelete = false))
+
+      // Drain until the launched coroutine completes and writes errorMessage
+      var withError = awaitItem()
+      while (withError.errorMessage == null) {
+        withError = awaitItem()
+      }
+      assertThat(withError.errorMessage).isEqualTo("boom")
+
+      withError.eventSink(LibraryItemUiEvent.ClearError)
+      val cleared = awaitItem()
+      assertThat(cleared.errorMessage).isNull()
+
+      assertThat(libraryItemRepository.deleteInvocations).hasSize(1)
 
       cancelAndIgnoreRemainingEvents()
     }
@@ -434,27 +462,5 @@ private val DeleteItemClickHard = EventTest(
       .isEqualTo(TestLibraryItemId to true)
 
     navigator.awaitPop()
-  },
-)
-
-private val DeleteItemClickFailure = EventTest(
-  event = LibraryItemUiEvent.DeleteItemClick(hardDelete = false),
-  setup = {
-    libraryItemRepository.deleteResult = Result.failure(IllegalStateException("boom"))
-  },
-  assert = {
-    assertThat(libraryItemRepository.deleteInvocations).hasSize(1)
-
-    presenter.test {
-      skipItems(1)
-      val withError = awaitItem()
-      assertThat(withError.errorMessage).isEqualTo("boom")
-
-      withError.eventSink(LibraryItemUiEvent.ClearError)
-      val cleared = awaitItem()
-      assertThat(cleared.errorMessage).isNull()
-
-      cancelAndIgnoreRemainingEvents()
-    }
   },
 )

--- a/features/podcasts/api/src/commonMain/kotlin/app/campfire/podcasts/api/screen/FindEpisodesScreen.kt
+++ b/features/podcasts/api/src/commonMain/kotlin/app/campfire/podcasts/api/screen/FindEpisodesScreen.kt
@@ -1,10 +1,17 @@
 package app.campfire.podcasts.api.screen
 
 import app.campfire.common.screens.DetailScreen
+import app.campfire.common.screens.Presentation
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.parcelize.Parcelize
 
 @Parcelize
 data class FindEpisodesScreen(
   val libraryItemId: LibraryItemId,
-) : DetailScreen(name = "FindEpisodes")
+) : DetailScreen(name = "FindEpisodes") {
+  override val presentation: Presentation
+    get() = Presentation(
+      hideBottomNav = true,
+      hidePlaybackBar = true,
+    )
+}

--- a/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/find/FindEpisodesUi.kt
+++ b/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/find/FindEpisodesUi.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
-import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.core.di.UserScope
 import app.campfire.podcasts.api.screen.FindEpisodesScreen
 import app.campfire.podcasts.ui.find.composables.CenteredMessage

--- a/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/find/FindEpisodesUi.kt
+++ b/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/find/FindEpisodesUi.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -68,7 +69,7 @@ fun FindEpisodesUi(
 
   Scaffold(
     modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-    contentWindowInsets = CampfireWindowInsets
+    contentWindowInsets = ScaffoldDefaults.contentWindowInsets
       .exclude(WindowInsets.systemBars)
       .exclude(WindowInsets.navigationBars),
     topBar = {


### PR DESCRIPTION
## Summary
- Admin/root users with `permissions.delete` can now delete a podcast from the library item detail screen via a top-bar overflow menu
- Confirmation `AlertDialog` includes a toggleable `Switch` row for hard delete (also removes server files); confirm button label flips to "Delete & remove files" when on
- Presenter cleans up local offline downloads + clears the `LibraryItem` Store cache on success, then `navigator.pop()`s; failures surface via a snackbar driven by new `errorMessage` state + `ClearError` event

Closes #817

## Implementation notes
- New: `AudioBookShelfApi.deleteLibraryItem(itemId, hard)` → `DELETE /api/items/{id}` with optional `?hard=1`
- New: `LibraryItemRepository.deleteLibraryItem(itemId, hardDelete)` — delegates to API, evicts Store cache on success
- New: `User.canDeleteItems` convenience (`permissions.delete && (Admin || Root)`) — matches server-side defaults where only root has `delete:true` out of the box
- New `DeletePodcastDialog` composable
- Visibility gate: `user.canDeleteItems && libraryItem.mediaType == Podcast` — books intentionally out of scope

## Test plan
- [ ] Sign in as an admin/root user with `permissions.delete = true` → overflow appears on a podcast detail screen
- [ ] Sign in as a non-admin or admin without `delete` permission → overflow does not appear
- [ ] Confirm soft delete: dialog opens, switch off, tap "Delete" → server-side podcast removed, screen pops, item disappears from library
- [ ] Confirm hard delete: dialog opens, toggle switch on (button label changes to "Delete & remove files"), tap → server files also removed from disk
- [ ] If item had offline downloads, they're cleaned up on success
- [ ] Force a failure (offline / bad token) → snackbar surfaces, screen stays open, can retry
- [ ] Book detail screen: overflow never appears (podcast-only)
- [ ] Switch row is a single tap target (toggleable Row, not just the Switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)