### PR TITLE
Add podcast offline download support

### DIFF
--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/dialog/ConfirmDownloadDialog.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/dialog/ConfirmDownloadDialog.kt
@@ -30,6 +30,7 @@ import app.campfire.analytics.events.ScreenViewEvent
 import app.campfire.common.compose.analytics.Impression
 import app.campfire.core.extensions.asReadableBytes
 import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.PodcastEpisode
 import campfire.common.compose.generated.resources.Res
 import campfire.common.compose.generated.resources.dialog_download_action_confirm
 import campfire.common.compose.generated.resources.dialog_download_action_dismiss
@@ -46,7 +47,25 @@ fun ConfirmDownloadDialog(
   modifier: Modifier = Modifier,
 ) {
   ConfirmDownloadDialog(
-    items = listOf(item),
+    title = item.media.metadata.title.orEmpty(),
+    sizeInBytes = item.media.sizeInBytes,
+    onConfirm = onConfirm,
+    onDismissRequest = onDismissRequest,
+    modifier = modifier,
+  )
+}
+
+@Composable
+fun ConfirmDownloadDialog(
+  item: LibraryItem,
+  episode: PodcastEpisode,
+  onConfirm: (doNotShowAgain: Boolean) -> Unit,
+  onDismissRequest: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  ConfirmDownloadDialog(
+    title = episode.title,
+    sizeInBytes = episode.sizeInBytes.takeIf { it > 0L } ?: item.media.sizeInBytes,
     onConfirm = onConfirm,
     onDismissRequest = onDismissRequest,
     modifier = modifier,
@@ -60,15 +79,8 @@ fun ConfirmDownloadDialog(
   onDismissRequest: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  Impression {
-    ScreenViewEvent("ConfirmDownload", ScreenType.Dialog)
-  }
-
-  var doNotShowAgain by remember { mutableStateOf(false) }
-  AlertDialog(
-    modifier = modifier,
-    onDismissRequest = onDismissRequest,
-    title = {
+  ConfirmDownloadDialog(
+    titleContent = {
       Text(
         buildAnnotatedString {
           append("Download ")
@@ -82,15 +94,64 @@ fun ConfirmDownloadDialog(
         },
       )
     },
+    sizeInBytes = items.sumOf { it.media.sizeInBytes },
+    onConfirm = onConfirm,
+    onDismissRequest = onDismissRequest,
+    modifier = modifier,
+  )
+}
+
+@Composable
+fun ConfirmDownloadDialog(
+  title: String,
+  sizeInBytes: Long,
+  onConfirm: (doNotShowAgain: Boolean) -> Unit,
+  onDismissRequest: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  ConfirmDownloadDialog(
+    titleContent = {
+      Text(
+        buildAnnotatedString {
+          append("Download ")
+          withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+            append("\"$title\"")
+          }
+        },
+      )
+    },
+    sizeInBytes = sizeInBytes,
+    onConfirm = onConfirm,
+    onDismissRequest = onDismissRequest,
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun ConfirmDownloadDialog(
+  titleContent: @Composable () -> Unit,
+  sizeInBytes: Long,
+  onConfirm: (doNotShowAgain: Boolean) -> Unit,
+  onDismissRequest: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Impression {
+    ScreenViewEvent("ConfirmDownload", ScreenType.Dialog)
+  }
+
+  var doNotShowAgain by remember { mutableStateOf(false) }
+  AlertDialog(
+    modifier = modifier,
+    onDismissRequest = onDismissRequest,
+    title = titleContent,
     text = {
-      val totalSize = items.sumOf { it.media.sizeInBytes }
       Column {
         Text(
           buildAnnotatedString {
             append(stringResource(Res.string.dialog_download_message_prefix))
             append(" ")
             withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
-              append(totalSize.asReadableBytes())
+              append(sizeInBytes.asReadableBytes())
             }
             append(" ")
             append(stringResource(Res.string.dialog_download_message_suffix))

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -110,6 +110,11 @@
   <string name="action_retry_download">Retry download</string>
   <string name="action_delete_download">Delete download</string>
   <string name="action_add_podcast">Add a podcast</string>
+  <string name="action_download_episode">Download episode for offline</string>
+  <string name="action_stop_episode_download">Stop episode download</string>
+  <string name="action_remove_episode_download">Remove offline episode</string>
+  <string name="action_episode_download_queued">Episode download queued</string>
+  <string name="action_episode_download_in_progress">Episode downloading</string>
 
   <string name="cd_more_actions">More actions</string>
   <string name="menu_item_delete_podcast">Delete podcast</string>

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenter.kt
@@ -14,6 +14,7 @@ import app.campfire.core.coroutines.map
 import app.campfire.core.di.UserScope
 import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.Media
 import app.campfire.core.model.MediaType
 import app.campfire.core.session.UserSession
 import app.campfire.core.session.requiredUser
@@ -120,7 +121,12 @@ class LibraryItemPresenter(
           scope.launch {
             repository.deleteLibraryItem(screen.libraryItemId, event.hardDelete)
               .onSuccess {
-                runCatching { offlineDownloadManager.delete(item) }
+                runCatching {
+                  offlineDownloadManager.delete(item)
+                  (item.media as? Media.Podcast)?.episodes?.forEach { episode ->
+                    offlineDownloadManager.deleteEpisode(item, episode)
+                  }
+                }
                   .onFailure { bark(throwable = it) { "Failed to clean up offline downloads after delete" } }
                 navigator.pop()
               }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUiState.kt
@@ -64,6 +64,13 @@ sealed interface LibraryItemUiEvent : CircuitUiEvent {
   data object RemoveDownloadClick : LibraryItemUiEvent
   data object StopDownloadClick : LibraryItemUiEvent
 
+  data class DownloadEpisodeClick(
+    val episode: PodcastEpisode,
+    val doNotShowAgain: Boolean = true,
+  ) : LibraryItemUiEvent
+  data class RemoveEpisodeDownloadClick(val episode: PodcastEpisode) : LibraryItemUiEvent
+  data class StopEpisodeDownloadClick(val episode: PodcastEpisode) : LibraryItemUiEvent
+
   data class OpenPlaylist(val playlistId: PlaylistId, val isCreated: Boolean) : LibraryItemUiEvent
   data class OpenEpisode(val episode: PodcastEpisode) : LibraryItemUiEvent
   data object FindEpisodes : LibraryItemUiEvent

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ExpressiveControlBar.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ExpressiveControlBar.kt
@@ -119,6 +119,7 @@ internal fun ExpressiveControlBar(
   onAddToPlaylistClick: () -> Unit,
   onAddToQueueClick: () -> Unit,
   modifier: Modifier = Modifier,
+  totalSizeInBytes: Long = -1L,
 ) {
   Surface(
     modifier = modifier
@@ -148,6 +149,7 @@ internal fun ExpressiveControlBar(
 
         OfflineStatus(
           offlineDownload = offlineDownload,
+          totalSizeInBytes = totalSizeInBytes,
           onDeleteClick = onDeleteDownloadClick,
           onStopClick = onStopDownloadClick,
           onRetryClick = onDownloadClick,
@@ -179,6 +181,7 @@ internal fun ExpressiveControlBar(
 @Composable
 private fun OfflineStatus(
   offlineDownload: OfflineDownload,
+  totalSizeInBytes: Long,
   onDeleteClick: () -> Unit,
   onStopClick: () -> Unit,
   onRetryClick: () -> Unit,
@@ -317,10 +320,18 @@ private fun OfflineStatus(
     )
 
     if (!offlineDownload.isCompleted) {
+      val actualProgress = if (totalSizeInBytes > 0L) {
+        (offlineDownload.progress.bytes.toFloat() / totalSizeInBytes.toFloat())
+          .coerceIn(0f, 1f)
+      } else {
+        offlineDownload.progress.percent
+      }
+
       OfflineProgressBar(
-        progress = offlineDownload.progress.percent,
+        progress = actualProgress,
         bytesDownloaded = offlineDownload.progress.bytes,
-        contentLength = offlineDownload.contentLength,
+        contentLength = totalSizeInBytes.takeIf { it > 0L }
+          ?: offlineDownload.contentLength,
         isIndeterminate = offlineDownload.progress.indeterminate,
       )
     }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/MediaProgressBar.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/MediaProgressBar.kt
@@ -108,8 +108,12 @@ internal fun MediaProgressBar(
         else -> {
           val duration = progress.duration ?: totalDuration.asSeconds()
           val remainingDurationMillis = (duration - (duration * progress.actualProgress)).div(playbackSpeed) * 1000f
-          val remainingDuration = remainingDurationMillis.roundToLong().milliseconds.readoutFormat()
-          stringResource(Res.string.remaining_duration_format, remainingDuration)
+          if (!remainingDurationMillis.isNaN()) {
+            val remainingDuration = remainingDurationMillis.roundToLong().milliseconds.readoutFormat()
+            stringResource(Res.string.remaining_duration_format, remainingDuration)
+          } else {
+            "--"
+          }
         }
       }
       Row(

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/EpisodeSlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/EpisodeSlot.kt
@@ -1,6 +1,7 @@
 package app.campfire.libraries.ui.detail.composables.slots
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -8,21 +9,31 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.rounded.DownloadDone
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import app.campfire.audioplayer.offline.OfflineDownload
+import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.filled.MarkFinished
+import app.campfire.common.compose.icons.rounded.Download
 import app.campfire.common.compose.icons.rounded.MarkFinished
+import app.campfire.common.compose.permission.PermissionState
+import app.campfire.common.compose.permission.rememberPostNotificationPermissionState
 import app.campfire.common.compose.widgets.EpisodeListItem
 import app.campfire.common.compose.widgets.EpisodeListItemDefaults
 import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.dialog.ConfirmDownloadDialog
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Media
 import app.campfire.core.model.MediaProgress
@@ -32,8 +43,12 @@ import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import app.campfire.playlists.api.dialog.PlaylistDialogResult
 import campfire.features.libraries.ui.generated.resources.Res
 import campfire.features.libraries.ui.generated.resources.action_add_episode_to_playlist
+import campfire.features.libraries.ui.generated.resources.action_download_episode
+import campfire.features.libraries.ui.generated.resources.action_episode_download_in_progress
+import campfire.features.libraries.ui.generated.resources.action_episode_download_queued
 import campfire.features.libraries.ui.generated.resources.action_mark_episode_finished
 import campfire.features.libraries.ui.generated.resources.action_mark_episode_not_finished
+import campfire.features.libraries.ui.generated.resources.action_remove_episode_download
 import org.jetbrains.compose.resources.stringResource
 
 class EpisodeSlot(
@@ -42,6 +57,8 @@ class EpisodeSlot(
   private val episode: PodcastEpisode,
   private val progress: MediaProgress?,
   private val isCurrentSession: Boolean,
+  private val offlineDownload: OfflineDownload?,
+  private val showConfirmDownloadDialog: Boolean,
   private val addToPlaylistDialog: AddToPlaylistDialog,
 ) : ContentSlot {
 
@@ -71,6 +88,31 @@ class EpisodeSlot(
       )
     }
 
+    var showDownloadConfirmation by remember { mutableStateOf(false) }
+    var doNotShowDownloadConfirmationAgain by remember { mutableStateOf(false) }
+    val postNotificationPermissionState = rememberPostNotificationPermissionState { granted ->
+      if (granted) {
+        eventSink(LibraryItemUiEvent.DownloadEpisodeClick(episode, doNotShowDownloadConfirmationAgain))
+        showDownloadConfirmation = false
+      }
+    }
+    if (showDownloadConfirmation) {
+      ConfirmDownloadDialog(
+        item = libraryItem,
+        episode = episode,
+        onConfirm = { doNotShowAgain ->
+          if (postNotificationPermissionState is PermissionState.Granted) {
+            eventSink(LibraryItemUiEvent.DownloadEpisodeClick(episode, doNotShowAgain))
+            showDownloadConfirmation = false
+          } else {
+            doNotShowDownloadConfirmationAgain = doNotShowAgain
+            postNotificationPermissionState.launchPermissionRequest()
+          }
+        },
+        onDismissRequest = { showDownloadConfirmation = false },
+      )
+    }
+
     val isFinished = progress?.isFinished == true
 
     Column(
@@ -97,6 +139,25 @@ class EpisodeSlot(
           EpisodeListItemDefaults.singleItemShape()
         },
         actions = {
+          if (episode.audioTrack != null) {
+            DownloadEpisodeAction(
+              offlineDownload = offlineDownload,
+              onDownloadClick = {
+                if (showConfirmDownloadDialog) {
+                  showDownloadConfirmation = true
+                } else {
+                  eventSink(LibraryItemUiEvent.DownloadEpisodeClick(episode))
+                }
+              },
+              onStopClick = {
+                eventSink(LibraryItemUiEvent.StopEpisodeDownloadClick(episode))
+              },
+              onRemoveClick = {
+                eventSink(LibraryItemUiEvent.RemoveEpisodeDownloadClick(episode))
+              },
+            )
+          }
+
           val addToPlaylistLabel = stringResource(Res.string.action_add_episode_to_playlist)
           IconButtonTooltip(text = addToPlaylistLabel) {
             IconButton(
@@ -163,6 +224,107 @@ class EpisodeSlot(
         Spacer(Modifier.height(2.dp))
       } else {
         Spacer(Modifier.height(48.dp))
+      }
+    }
+  }
+}
+
+@Composable
+private fun DownloadEpisodeAction(
+  offlineDownload: OfflineDownload?,
+  onDownloadClick: () -> Unit,
+  onStopClick: () -> Unit,
+  onRemoveClick: () -> Unit,
+) {
+  val state = offlineDownload?.state ?: OfflineDownload.State.None
+
+  val label = stringResource(
+    when (state) {
+      OfflineDownload.State.Queued -> Res.string.action_episode_download_queued
+      OfflineDownload.State.Downloading -> Res.string.action_episode_download_in_progress
+      OfflineDownload.State.Completed -> Res.string.action_remove_episode_download
+      OfflineDownload.State.None,
+      OfflineDownload.State.Failed,
+      OfflineDownload.State.Stopped,
+      -> Res.string.action_download_episode
+    },
+  )
+
+  val onClick: () -> Unit = when (state) {
+    OfflineDownload.State.Queued,
+    OfflineDownload.State.Downloading,
+    -> onStopClick
+
+    OfflineDownload.State.Completed -> onRemoveClick
+
+    OfflineDownload.State.None,
+    OfflineDownload.State.Failed,
+    OfflineDownload.State.Stopped,
+    -> onDownloadClick
+  }
+
+  IconButtonTooltip(text = label) {
+    IconButton(
+      onClick = onClick,
+      modifier = Modifier
+        .size(
+          IconButtonDefaults.extraSmallContainerSize(
+            IconButtonDefaults.IconButtonWidthOption.Uniform,
+          ),
+        ),
+      shape = IconButtonDefaults.extraSmallSquareShape,
+    ) {
+      val iconSize = IconButtonDefaults.extraSmallIconSize
+      when (state) {
+        OfflineDownload.State.Queued -> {
+          Box(
+            modifier = Modifier.size(iconSize),
+            contentAlignment = Alignment.Center,
+          ) {
+            CircularProgressIndicator(
+              strokeWidth = 2.dp,
+              modifier = Modifier.size(iconSize),
+            )
+          }
+        }
+        OfflineDownload.State.Downloading -> {
+          val downloadProgress = offlineDownload?.progress
+          Box(
+            modifier = Modifier.size(iconSize),
+            contentAlignment = Alignment.Center,
+          ) {
+            if (downloadProgress == null || downloadProgress.indeterminate) {
+              CircularProgressIndicator(
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(iconSize),
+              )
+            } else {
+              CircularProgressIndicator(
+                progress = { downloadProgress.percent },
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(iconSize),
+              )
+            }
+          }
+        }
+        OfflineDownload.State.Completed -> {
+          Icon(
+            Icons.Rounded.DownloadDone,
+            contentDescription = label,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(iconSize),
+          )
+        }
+        OfflineDownload.State.None,
+        OfflineDownload.State.Failed,
+        OfflineDownload.State.Stopped,
+        -> {
+          Icon(
+            CampfireIcons.Rounded.Download,
+            contentDescription = label,
+            modifier = Modifier.size(iconSize),
+          )
+        }
       }
     }
   }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/ExpressiveControlSlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/ExpressiveControlSlot.kt
@@ -86,6 +86,7 @@ class ExpressiveControlSlot(
       hasSession = hasSession,
       isCurrentSession = isCurrentSession,
       offlineDownload = offlineDownload,
+      totalSizeInBytes = libraryItem.media.sizeInBytes,
       mediaProgress = mediaProgress,
       onPlayClick = {
         eventSink(LibraryItemUiEvent.PlayClick)

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/PodcastPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/PodcastPresenter.kt
@@ -14,9 +14,12 @@ import app.campfire.analytics.events.ActionEvent
 import app.campfire.analytics.events.Click
 import app.campfire.audioplayer.PlaybackController
 import app.campfire.audioplayer.history.PlaybackHistoryRepository
+import app.campfire.audioplayer.offline.OfflineDownload
+import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Media
 import app.campfire.core.model.MediaProgress
+import app.campfire.core.model.PodcastEpisodeId
 import app.campfire.core.model.Session
 import app.campfire.core.model.User
 import app.campfire.libraries.api.screen.LibraryItemScreen
@@ -37,6 +40,7 @@ import app.campfire.libraries.ui.detail.podcast.episode.showPodcastEpisodeBottom
 import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import app.campfire.podcasts.api.screen.FindEpisodesScreen
 import app.campfire.sessions.api.SessionsRepository
+import app.campfire.settings.api.CampfireSettings
 import app.campfire.user.api.MediaProgressKey
 import app.campfire.user.api.MediaProgressRepository
 import app.campfire.user.api.UserRepository
@@ -58,6 +62,8 @@ class PodcastPresenter(
   private val mediaProgressRepository: MediaProgressRepository,
   private val playbackHistoryRepository: PlaybackHistoryRepository,
   private val playbackController: PlaybackController,
+  private val offlineDownloadManager: OfflineDownloadManager,
+  private val settings: CampfireSettings,
   private val addToPlaylistDialog: AddToPlaylistDialog,
 ) : AbstractLibraryItemPresenter {
 
@@ -84,11 +90,25 @@ class PodcastPresenter(
         }
     }.collectAsState(emptyMap())
 
+    val podcastEpisodes = remember(libraryItem) {
+      (libraryItem.media as? Media.Podcast)?.episodes.orEmpty()
+    }
+
+    val episodeDownloads by remember(libraryItem, podcastEpisodes) {
+      offlineDownloadManager.observeForEpisodes(libraryItem, podcastEpisodes)
+    }.collectAsState(emptyMap())
+
+    val showConfirmDownloadDialog by remember {
+      settings.observeShowConfirmDownload()
+    }.collectAsState()
+
     val slots = buildSlots(
       user = currentUser,
       libraryItem = libraryItem,
       currentSession = currentSession,
       mediaProgress = mediaProgress,
+      episodeDownloads = episodeDownloads,
+      showConfirmDownloadDialog = showConfirmDownloadDialog,
       addToPlaylistDialog = addToPlaylistDialog,
       sharedTransitionKey = screen.sharedTransitionKey,
     )
@@ -163,6 +183,22 @@ class PodcastPresenter(
             navigator.goTo(FindEpisodesScreen(libraryItem.id))
           }
 
+          is LibraryItemUiEvent.DownloadEpisodeClick -> {
+            analytics.send(ActionEvent("download_episode", Click))
+            settings.showConfirmDownload = !event.doNotShowAgain
+            offlineDownloadManager.downloadEpisode(libraryItem, event.episode)
+          }
+
+          is LibraryItemUiEvent.RemoveEpisodeDownloadClick -> {
+            analytics.send(ActionEvent("delete_episode_download", Click))
+            offlineDownloadManager.deleteEpisode(libraryItem, event.episode)
+          }
+
+          is LibraryItemUiEvent.StopEpisodeDownloadClick -> {
+            analytics.send(ActionEvent("stop_episode_download", Click))
+            offlineDownloadManager.stopEpisode(libraryItem, event.episode)
+          }
+
           else -> Unit
         }
       },
@@ -176,6 +212,8 @@ private fun buildSlots(
   libraryItem: LibraryItem,
   currentSession: Session?,
   mediaProgress: Map<MediaProgressKey, MediaProgress>,
+  episodeDownloads: Map<PodcastEpisodeId, OfflineDownload>,
+  showConfirmDownloadDialog: Boolean,
   addToPlaylistDialog: AddToPlaylistDialog,
   sharedTransitionKey: String,
 ): List<ContentSlot> = buildList {
@@ -240,6 +278,8 @@ private fun buildSlots(
         progress = progress,
         isCurrentSession = currentSession?.libraryItem?.id == episode.libraryItemId &&
           currentSession.episodeId == episode.id,
+        offlineDownload = episodeDownloads[episode.id],
+        showConfirmDownloadDialog = showConfirmDownloadDialog,
         addToPlaylistDialog = addToPlaylistDialog,
       )
     }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeBottomSheet.kt
@@ -39,9 +39,12 @@ import app.campfire.common.compose.extensions.readoutAtMost
 import app.campfire.common.compose.extensions.toRichTextHtml
 import app.campfire.common.compose.layout.ContentLayout
 import app.campfire.common.compose.layout.LocalContentLayout
+import app.campfire.common.compose.permission.PermissionState
+import app.campfire.common.compose.permission.rememberPostNotificationPermissionState
 import app.campfire.common.compose.widgets.MetadataChip
 import app.campfire.common.compose.widgets.MetadataHeader
 import app.campfire.common.compose.widgets.WithTimestampUriHandler
+import app.campfire.common.compose.widgets.dialog.ConfirmDownloadDialog
 import app.campfire.core.di.ComponentHolder
 import app.campfire.core.di.UserScope
 import app.campfire.core.extensions.asDate
@@ -117,6 +120,31 @@ private fun PodcastEpisodeBottomSheet(
     )
   }
 
+  var showDownloadConfirmation by remember { mutableStateOf(false) }
+  var doNotShowDownloadConfirmationAgain by remember { mutableStateOf(false) }
+  val postNotificationPermissionState = rememberPostNotificationPermissionState { granted ->
+    if (granted) {
+      state.eventSink(PodcastEpisodeUiEvent.DownloadClick(doNotShowDownloadConfirmationAgain))
+      showDownloadConfirmation = false
+    }
+  }
+  if (showDownloadConfirmation) {
+    ConfirmDownloadDialog(
+      item = state.libraryItem,
+      episode = state.episode,
+      onConfirm = { doNotShowAgain ->
+        if (postNotificationPermissionState is PermissionState.Granted) {
+          state.eventSink(PodcastEpisodeUiEvent.DownloadClick(doNotShowAgain))
+          showDownloadConfirmation = false
+        } else {
+          doNotShowDownloadConfirmationAgain = doNotShowAgain
+          postNotificationPermissionState.launchPermissionRequest()
+        }
+      },
+      onDismissRequest = { showDownloadConfirmation = false },
+    )
+  }
+
   Column(
     modifier = modifier
       .padding(16.dp)
@@ -179,14 +207,24 @@ private fun PodcastEpisodeBottomSheet(
       hasSession = state.hasSession,
       isCurrentSession = state.sessionState is SessionUiState.Current,
       mediaProgress = state.progress,
-      offlineDownload = null,
+      offlineDownload = state.offlineDownload,
       onPlayClick = { state.eventSink(PodcastEpisodeUiEvent.PlayClick) },
-      onDownloadClick = { },
+      onDownloadClick = {
+        if (state.showConfirmDownloadDialog) {
+          showDownloadConfirmation = true
+        } else {
+          state.eventSink(PodcastEpisodeUiEvent.DownloadClick())
+        }
+      },
       onMarkFinished = { state.eventSink(PodcastEpisodeUiEvent.MarkFinished) },
       onMarkNotFinished = { state.eventSink(PodcastEpisodeUiEvent.MarkNotFinished) },
       onDiscardProgress = { state.eventSink(PodcastEpisodeUiEvent.DiscardProgress) },
-      onStopDownloadClick = {},
-      onDeleteDownloadClick = {},
+      onStopDownloadClick = {
+        state.eventSink(PodcastEpisodeUiEvent.StopDownloadClick)
+      },
+      onDeleteDownloadClick = {
+        state.eventSink(PodcastEpisodeUiEvent.RemoveDownloadClick)
+      },
       onAddToPlaylistClick = {
         showAddToPlaylistDialog = true
       },

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodePresenter.kt
@@ -13,6 +13,7 @@ import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.audioplayer.PlaybackController
 import app.campfire.audioplayer.history.PlaybackHistoryRepository
+import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.PodcastEpisode
 import app.campfire.libraries.ui.detail.SessionUiState
@@ -20,6 +21,7 @@ import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import app.campfire.sessions.api.SessionQueue
 import app.campfire.sessions.api.SessionsRepository
 import app.campfire.sessions.api.observeContains
+import app.campfire.settings.api.CampfireSettings
 import app.campfire.user.api.MediaProgressRepository
 import com.slack.circuit.overlay.OverlayNavigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -50,6 +52,8 @@ class PodcastEpisodePresenter(
   private val mediaProgressRepository: MediaProgressRepository,
   private val playbackHistoryRepository: PlaybackHistoryRepository,
   private val audioPlayerHolder: AudioPlayerHolder,
+  private val offlineDownloadManager: OfflineDownloadManager,
+  private val settings: CampfireSettings,
   private val addToPlaylistDialog: AddToPlaylistDialog,
 ) : Presenter<PodcastEpisodeUiState> {
 
@@ -115,6 +119,14 @@ class PodcastEpisodePresenter(
       sessionQueue.observeContains(episode.libraryItemId, episode.id)
     }.collectAsState(false)
 
+    val offlineDownload by remember(libraryItem, episode) {
+      offlineDownloadManager.observeForEpisode(libraryItem, episode)
+    }.collectAsState(null)
+
+    val showConfirmDownloadDialog by remember {
+      settings.observeShowConfirmDownload()
+    }.collectAsState()
+
     return PodcastEpisodeUiState(
       libraryItem = libraryItem,
       episode = episode,
@@ -124,6 +136,8 @@ class PodcastEpisodePresenter(
       isQueued = isQueued,
       hasSession = currentSession != null,
       sessionState = episodeSession,
+      offlineDownload = offlineDownload,
+      showConfirmDownloadDialog = showConfirmDownloadDialog,
       addToPlaylistDialog = addToPlaylistDialog,
     ) { event ->
       when (event) {
@@ -225,6 +239,22 @@ class PodcastEpisodePresenter(
           scope.launch {
             sessionQueue.remove(episode.libraryItemId, episode.id)
           }
+        }
+
+        is PodcastEpisodeUiEvent.DownloadClick -> {
+          analytics.send(ActionEvent("download_episode", Click))
+          settings.showConfirmDownload = !event.doNotShowAgain
+          offlineDownloadManager.downloadEpisode(libraryItem, episode)
+        }
+
+        PodcastEpisodeUiEvent.RemoveDownloadClick -> {
+          analytics.send(ActionEvent("delete_episode_download", Click))
+          offlineDownloadManager.deleteEpisode(libraryItem, episode)
+        }
+
+        PodcastEpisodeUiEvent.StopDownloadClick -> {
+          analytics.send(ActionEvent("stop_episode_download", Click))
+          offlineDownloadManager.stopEpisode(libraryItem, episode)
         }
       }
     }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/podcast/episode/PodcastEpisodeUiState.kt
@@ -1,5 +1,6 @@
 package app.campfire.libraries.ui.detail.podcast.episode
 
+import app.campfire.audioplayer.offline.OfflineDownload
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.MediaProgress
 import app.campfire.core.model.PodcastEpisode
@@ -17,6 +18,8 @@ data class PodcastEpisodeUiState(
   val isQueued: Boolean,
   val hasSession: Boolean,
   val sessionState: SessionUiState,
+  val offlineDownload: OfflineDownload?,
+  val showConfirmDownloadDialog: Boolean,
   val addToPlaylistDialog: AddToPlaylistDialog,
   val eventSink: (PodcastEpisodeUiEvent) -> Unit,
 ) : CircuitUiState
@@ -29,4 +32,7 @@ sealed interface PodcastEpisodeUiEvent {
   data class Seek(val position: Duration) : PodcastEpisodeUiEvent
   data object AddToQueue : PodcastEpisodeUiEvent
   data object RemoveFromQueue : PodcastEpisodeUiEvent
+  data class DownloadClick(val doNotShowAgain: Boolean = true) : PodcastEpisodeUiEvent
+  data object RemoveDownloadClick : PodcastEpisodeUiEvent
+  data object StopDownloadClick : PodcastEpisodeUiEvent
 }

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
@@ -75,6 +75,8 @@ abstract class BaseLibraryItemPresenterTest {
     mediaProgressRepository = mediaProgressRepository,
     playbackHistoryRepository = playbackHistoryRepository,
     playbackController = playbackController,
+    offlineDownloadManager = offlineDownloadManager,
+    settings = settings,
     addToPlaylistDialog = AddToPlaylistDialog.NoOp,
   )
 

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/composables/slots/ExpressiveControlSlotTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/composables/slots/ExpressiveControlSlotTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import app.campfire.audioplayer.offline.OfflineDownload
 import app.campfire.core.model.preview.mediaProgress
 import app.campfire.home.ui.libraryItem
+import app.campfire.home.ui.media
 import app.campfire.libraries.ui.detail.TestLibraryItemId
 import app.campfire.libraries.ui.detail.composables.setCampfireContent
 import app.campfire.playlists.api.dialog.AddToPlaylistDialog
@@ -137,9 +138,11 @@ class ExpressiveControlSlotTest {
 
   @Test
   fun determinateTest() = runComposeUiTest {
-    val libraryItem = libraryItem()
     val progressBytes = 1L * 1024L * 1024L // 1Mb
     val contentLength = 10L * 1024L * 1024L // 10Mb
+    // ExpressiveControlSlot prefers libraryItem.media.sizeInBytes over the offline
+    // download's contentLength when present, so align the two for this test.
+    val libraryItem = libraryItem(media = media(sizeInBytes = contentLength))
     val offlineDownload = OfflineDownload(
       libraryItemId = TestLibraryItemId,
       state = OfflineDownload.State.Downloading,

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -283,7 +283,12 @@ class SettingsPresenter(
 
         is SettingsUiEvent.DownloadsSettingEvent -> when (event) {
           is ShowDownloadConfirmation -> settings.showConfirmDownload = event.enabled
-          is DownloadClicked -> navigator.goTo(LibraryItemScreen(event.libraryItem.id))
+          is DownloadClicked -> navigator.goTo(
+            LibraryItemScreen(
+              libraryItemId = event.entry.libraryItem.id,
+              episodeId = (event.entry as? DownloadEntry.Episode)?.episode?.id,
+            )
+          )
           is DeleteDownload -> when (val entry = event.entry) {
             is DownloadEntry.Book -> offlineDownloadManager.delete(entry.libraryItem)
             is DownloadEntry.Episode -> offlineDownloadManager.deleteEpisode(

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -21,6 +21,7 @@ import app.campfire.core.app.ApplicationUrls
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.currentPlatform
 import app.campfire.core.di.UserScope
+import app.campfire.core.model.Media
 import app.campfire.core.model.Server
 import app.campfire.core.session.UserSession
 import app.campfire.core.session.requiredUser
@@ -148,14 +149,25 @@ class SettingsPresenter(
       offlineDownloadManager.observeAll()
     }.collectAsState(emptyList())
 
-    val downloadedLibraryItems by remember {
+    val downloadEntries by remember {
       snapshotFlow { downloads }
-        .mapLatest {
-          it.associateWith { item ->
-            libraryItemRepository.getLibraryItem(item.libraryItemId)
-          }
+        .mapLatest { items ->
+          items
+            .mapNotNull { download ->
+              val libraryItem = libraryItemRepository.getLibraryItem(download.libraryItemId)
+              val episodeId = download.episodeId
+              if (episodeId == null) {
+                DownloadEntry.Book(libraryItem, download)
+              } else {
+                val media = libraryItem.media as? Media.Podcast ?: return@mapNotNull null
+                val episode = media.episodes.find { it.id == episodeId }
+                  ?: return@mapNotNull null
+                DownloadEntry.Episode(libraryItem, episode, download)
+              }
+            }
+            .sortedByDescending { it.download.updateTimeMs }
         }
-    }.collectAsState(emptyMap())
+    }.collectAsState(emptyList())
 
     // Sleep Settings
     val shakeToResetEnabled by remember { sleepSettings.observeShakeToResetEnabled() }.collectAsState()
@@ -199,7 +211,7 @@ class SettingsPresenter(
       ),
       downloadsSettings = DownloadsSettingsInfo(
         showDownloadConfirmation = showDownloadConfirmation,
-        downloads = downloadedLibraryItems,
+        downloads = downloadEntries,
       ),
       playbackSettings = PlaybackSettingsInfo(
         forwardTime = forwardTime.milliseconds,
@@ -272,7 +284,13 @@ class SettingsPresenter(
         is SettingsUiEvent.DownloadsSettingEvent -> when (event) {
           is ShowDownloadConfirmation -> settings.showConfirmDownload = event.enabled
           is DownloadClicked -> navigator.goTo(LibraryItemScreen(event.libraryItem.id))
-          is DeleteDownload -> offlineDownloadManager.delete(event.libraryItem)
+          is DeleteDownload -> when (val entry = event.entry) {
+            is DownloadEntry.Book -> offlineDownloadManager.delete(entry.libraryItem)
+            is DownloadEntry.Episode -> offlineDownloadManager.deleteEpisode(
+              entry.libraryItem,
+              entry.episode,
+            )
+          }
         }
 
         is SettingsUiEvent.PlaybackSettingEvent -> when (event) {

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -287,7 +287,7 @@ class SettingsPresenter(
             LibraryItemScreen(
               libraryItemId = event.entry.libraryItem.id,
               episodeId = (event.entry as? DownloadEntry.Episode)?.episode?.id,
-            )
+            ),
           )
           is DeleteDownload -> when (val entry = event.entry) {
             is DownloadEntry.Book -> offlineDownloadManager.delete(entry.libraryItem)

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -8,6 +8,7 @@ import app.campfire.common.screens.SettingsScreen
 import app.campfire.core.app.ApplicationInfo
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.PodcastEpisode
 import app.campfire.core.model.Server
 import app.campfire.core.model.Tent
 import app.campfire.settings.api.AndroidAutoCategory
@@ -50,8 +51,25 @@ data class AppearanceSettingsInfo(
 @Immutable
 data class DownloadsSettingsInfo(
   val showDownloadConfirmation: Boolean,
-  val downloads: Map<OfflineDownload, LibraryItem>,
+  val downloads: List<DownloadEntry>,
 )
+
+@Immutable
+sealed interface DownloadEntry {
+  val libraryItem: LibraryItem
+  val download: OfflineDownload
+
+  data class Book(
+    override val libraryItem: LibraryItem,
+    override val download: OfflineDownload,
+  ) : DownloadEntry
+
+  data class Episode(
+    override val libraryItem: LibraryItem,
+    val episode: PodcastEpisode,
+    override val download: OfflineDownload,
+  ) : DownloadEntry
+}
 
 @Immutable
 data class PlaybackSettingsInfo(
@@ -150,7 +168,7 @@ sealed interface SettingsUiEvent : CircuitUiEvent {
   sealed interface DownloadsSettingEvent : SettingsUiEvent {
     data class ShowDownloadConfirmation(val enabled: Boolean) : DownloadsSettingEvent
     data class DownloadClicked(val libraryItem: LibraryItem) : DownloadsSettingEvent
-    data class DeleteDownload(val libraryItem: LibraryItem) : DownloadsSettingEvent
+    data class DeleteDownload(val entry: DownloadEntry) : DownloadsSettingEvent
   }
 
   // Playback Setting Events

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -167,7 +167,7 @@ sealed interface SettingsUiEvent : CircuitUiEvent {
   // Downloads Pane Events
   sealed interface DownloadsSettingEvent : SettingsUiEvent {
     data class ShowDownloadConfirmation(val enabled: Boolean) : DownloadsSettingEvent
-    data class DownloadClicked(val libraryItem: LibraryItem) : DownloadsSettingEvent
+    data class DownloadClicked(val entry: DownloadEntry) : DownloadsSettingEvent
     data class DeleteDownload(val entry: DownloadEntry) : DownloadsSettingEvent
   }
 

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
@@ -116,7 +116,7 @@ internal fun DownloadsPane(
             entry = entry,
             onClick = {
               state.eventSink(
-                SettingsUiEvent.DownloadsSettingEvent.DownloadClicked(entry.libraryItem),
+                SettingsUiEvent.DownloadsSettingEvent.DownloadClicked(entry),
               )
             },
             onDeleteClick = {

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/DownloadsPane.kt
@@ -52,9 +52,8 @@ import app.campfire.common.compose.widgets.CoverImage
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.extensions.asReadableBytes
-import app.campfire.core.extensions.ifNotEmpty
 import app.campfire.core.model.LibraryItem
-import app.campfire.core.model.LibraryItemId
+import app.campfire.ui.settings.DownloadEntry
 import app.campfire.ui.settings.SettingsUiEvent
 import app.campfire.ui.settings.SettingsUiState
 import app.campfire.ui.settings.composables.ActionSetting
@@ -93,35 +92,35 @@ internal fun DownloadsPane(
 
     Header(title = { Text(stringResource(Res.string.download_header_downloads)) })
 
-    state.downloadsSettings.downloads.ifNotEmpty {
-      var showConfirmation by remember { mutableStateOf<LibraryItemId?>(null) }
-      forEach { (download, item) ->
+    if (state.downloadsSettings.downloads.isNotEmpty()) {
+      var confirmingKey by remember { mutableStateOf<String?>(null) }
+      state.downloadsSettings.downloads.forEach { entry ->
+        val key = entry.confirmKey
         ConfirmationLayout(
-          showConfirmation = showConfirmation == item.id,
+          showConfirmation = confirmingKey == key,
           confirm = {
             ConfirmDeleteListItem(
-              download = download,
+              download = entry.download,
               onDeleteClick = {
                 state.eventSink(
-                  SettingsUiEvent.DownloadsSettingEvent.DeleteDownload(item),
+                  SettingsUiEvent.DownloadsSettingEvent.DeleteDownload(entry),
                 )
               },
               onDismissRequest = {
-                showConfirmation = null
+                confirmingKey = null
               },
             )
           },
         ) {
           ItemDownloadListItem(
-            item = item,
-            download = download,
+            entry = entry,
             onClick = {
               state.eventSink(
-                SettingsUiEvent.DownloadsSettingEvent.DownloadClicked(item),
+                SettingsUiEvent.DownloadsSettingEvent.DownloadClicked(entry.libraryItem),
               )
             },
             onDeleteClick = {
-              showConfirmation = item.id
+              confirmingKey = key
             },
           )
         }
@@ -224,17 +223,37 @@ private fun ConfirmDeleteListItem(
   }
 }
 
+private val DownloadEntry.confirmKey: String
+  get() = when (this) {
+    is DownloadEntry.Book -> libraryItem.id
+    is DownloadEntry.Episode -> "${libraryItem.id}:${episode.id}"
+  }
+
 @Composable
 private fun ItemDownloadListItem(
-  item: LibraryItem,
-  download: OfflineDownload,
+  entry: DownloadEntry,
   onClick: () -> Unit,
   onDeleteClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  val item = entry.libraryItem
+  val download = entry.download
+  val titleText = when (entry) {
+    is DownloadEntry.Book -> item.media.metadata.title ?: "<unknown item>"
+    is DownloadEntry.Episode -> entry.episode.title
+  }
+  val supportingText = when (entry) {
+    is DownloadEntry.Book -> item.media.sizeInBytes.asReadableBytes()
+    is DownloadEntry.Episode -> buildString {
+      append(item.media.metadata.title ?: "<unknown podcast>")
+      append(" · ")
+      append(entry.episode.sizeInBytes.asReadableBytes())
+    }
+  }
+
   ActionSetting(
-    headlineContent = { Text(item.media.metadata.title ?: "<unknown item>") },
-    supportingContent = { Text(item.media.sizeInBytes.asReadableBytes()) },
+    headlineContent = { Text(titleText) },
+    supportingContent = { Text(supportingText) },
     leadingContent = {
       ItemDownloadImage(
         item = item,

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownload.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownload.kt
@@ -8,6 +8,7 @@ import app.campfire.audioplayer.offline.OfflineDownload.State.Queued
 import app.campfire.audioplayer.offline.OfflineDownload.State.Stopped
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisodeId
 import app.campfire.core.offline.OfflineStatus
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
@@ -21,7 +22,8 @@ fun OfflineDownload?.isNullOrNone(): Boolean {
 }
 
 /**
- * Represents the download state of a [LibraryItem].
+ * Represents the download state of a [LibraryItem] or a single podcast episode within it.
+ * [episodeId] is null for book-level downloads, populated for per-episode downloads.
  */
 data class OfflineDownload(
   val libraryItemId: LibraryItemId,
@@ -30,6 +32,7 @@ data class OfflineDownload(
   val updateTimeMs: Long = -1L,
   val contentLength: Long = -1L,
   val progress: Progress = Progress(0L, 0f),
+  val episodeId: PodcastEpisodeId? = null,
 ) {
 
   val isCompleted: Boolean

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadKey.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadKey.kt
@@ -24,18 +24,6 @@ data class OfflineDownloadKey(
   companion object {
     private const val SEPARATOR = '|'
 
-    fun decode(bytes: ByteArray): OfflineDownloadKey {
-      val decoded = bytes.decodeToString()
-      val separatorIndex = decoded.indexOf(SEPARATOR)
-      if (separatorIndex < 0) {
-        return OfflineDownloadKey(libraryItemId = decoded, episodeId = null)
-      }
-      val libraryItemId = decoded.substring(0, separatorIndex)
-      val episode = decoded.substring(separatorIndex + 1)
-      return OfflineDownloadKey(
-        libraryItemId = libraryItemId,
-        episodeId = episode.ifEmpty { null },
-      )
-    }
+    fun decode(bytes: ByteArray): OfflineDownloadKey = OfflineDownloadPayload.decode(bytes).key
   }
 }

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadKey.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadKey.kt
@@ -1,0 +1,41 @@
+package app.campfire.audioplayer.offline
+
+import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisodeId
+
+/**
+ * Composite key used to tag a download with the library item and (optionally) the
+ * podcast episode it belongs to. Encoded into a [androidx.media3.exoplayer.offline.DownloadRequest]'s
+ * `data` byte payload so the runtime download index can be grouped/observed per
+ * `(libraryItemId, episodeId?)` pair.
+ *
+ * Encoding is `"<libraryItemId>|<episodeId>"`. The book path emits `episodeId = ""`
+ * (so the key encodes to `"<libraryItemId>|"`). [decode] tolerates legacy book entries
+ * that were written as a bare `libraryItemId` with no separator — those decode to
+ * `episodeId = null`.
+ */
+data class OfflineDownloadKey(
+  val libraryItemId: LibraryItemId,
+  val episodeId: PodcastEpisodeId? = null,
+) {
+
+  fun encode(): ByteArray = "$libraryItemId$SEPARATOR${episodeId ?: ""}".encodeToByteArray()
+
+  companion object {
+    private const val SEPARATOR = '|'
+
+    fun decode(bytes: ByteArray): OfflineDownloadKey {
+      val decoded = bytes.decodeToString()
+      val separatorIndex = decoded.indexOf(SEPARATOR)
+      if (separatorIndex < 0) {
+        return OfflineDownloadKey(libraryItemId = decoded, episodeId = null)
+      }
+      val libraryItemId = decoded.substring(0, separatorIndex)
+      val episode = decoded.substring(separatorIndex + 1)
+      return OfflineDownloadKey(
+        libraryItemId = libraryItemId,
+        episodeId = episode.ifEmpty { null },
+      )
+    }
+  }
+}

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadManager.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadManager.kt
@@ -2,6 +2,8 @@ package app.campfire.audioplayer.offline
 
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
 import kotlinx.coroutines.flow.Flow
 
 interface OfflineDownloadManager {
@@ -34,6 +36,20 @@ interface OfflineDownloadManager {
   fun observeForItems(items: List<LibraryItem>): Flow<Map<LibraryItemId, OfflineDownload>>
 
   /**
+   * Observe the current download status for a single podcast episode.
+   */
+  fun observeForEpisode(item: LibraryItem, episode: PodcastEpisode): Flow<OfflineDownload>
+
+  /**
+   * Observe the current download status for a list of podcast episodes within the
+   * same parent [item].
+   */
+  fun observeForEpisodes(
+    item: LibraryItem,
+    episodes: List<PodcastEpisode>,
+  ): Flow<Map<PodcastEpisodeId, OfflineDownload>>
+
+  /**
    * Download a [LibraryItem] for offline playback.
    * @param item The [LibraryItem] to download.
    */
@@ -46,16 +62,31 @@ interface OfflineDownloadManager {
   fun downloadAll(items: List<LibraryItem>)
 
   /**
+   * Download a single podcast [episode] for offline playback.
+   */
+  fun downloadEpisode(item: LibraryItem, episode: PodcastEpisode)
+
+  /**
    * Delete the offline download of a [LibraryItem].
    * @param item The [LibraryItem] to delete the download for.
    */
   fun delete(item: LibraryItem)
 
   /**
+   * Delete the offline download of a single podcast [episode].
+   */
+  fun deleteEpisode(item: LibraryItem, episode: PodcastEpisode)
+
+  /**
    * Stop any current download of a [LibraryItem].
    * @param item The [LibraryItem] to stop the download for.
    */
   fun stop(item: LibraryItem)
+
+  /**
+   * Stop any current download of a single podcast [episode].
+   */
+  fun stopEpisode(item: LibraryItem, episode: PodcastEpisode)
 
   /**
    * Resume any paused downloads due to process death or other events

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadPayload.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/offline/OfflineDownloadPayload.kt
@@ -1,0 +1,78 @@
+package app.campfire.audioplayer.offline
+
+import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisodeId
+
+/**
+ * Persisted alongside each `DownloadRequest` via `setData(...)`. Carries the routing
+ * [key] plus user-facing display strings so the foreground service notification can
+ * render an informative title without needing to hit the DB at update time.
+ *
+ * Wire format: four fields separated by ASCII Unit Separator (``) — picked
+ * because it never appears in user-facing titles.
+ *
+ * Backward-compat: [decode] accepts three forms so already-shipped downloads keep
+ * working without migration:
+ *   - bare `<libraryItemId>` (pre-podcast book downloads)
+ *   - `<libraryItemId>|<episodeId>` (the just-shipped episode format)
+ *   - `<libraryItemId><episodeId><title><subtitle>` (this format)
+ */
+data class OfflineDownloadPayload(
+  val key: OfflineDownloadKey,
+  val title: String = "",
+  val subtitle: String = "",
+) {
+
+  constructor(
+    libraryItemId: LibraryItemId,
+    episodeId: PodcastEpisodeId? = null,
+    title: String = "",
+    subtitle: String = "",
+  ) : this(OfflineDownloadKey(libraryItemId, episodeId), title, subtitle)
+
+  fun encode(): ByteArray = buildString {
+    append(key.libraryItemId)
+    append(SEPARATOR)
+    append(key.episodeId ?: "")
+    append(SEPARATOR)
+    append(title)
+    append(SEPARATOR)
+    append(subtitle)
+  }.encodeToByteArray()
+
+  companion object {
+    private const val SEPARATOR = ''
+    private const val LEGACY_SEPARATOR = '|'
+
+    fun decode(bytes: ByteArray): OfflineDownloadPayload {
+      val decoded = bytes.decodeToString()
+
+      // New format: -separated fields.
+      if (decoded.contains(SEPARATOR)) {
+        val parts = decoded.split(SEPARATOR)
+        return OfflineDownloadPayload(
+          key = OfflineDownloadKey(
+            libraryItemId = parts.getOrNull(0).orEmpty(),
+            episodeId = parts.getOrNull(1)?.ifEmpty { null },
+          ),
+          title = parts.getOrNull(2).orEmpty(),
+          subtitle = parts.getOrNull(3).orEmpty(),
+        )
+      }
+
+      // Legacy episode format: <libraryItemId>|<episodeId>.
+      if (decoded.contains(LEGACY_SEPARATOR)) {
+        val parts = decoded.split(LEGACY_SEPARATOR, limit = 2)
+        return OfflineDownloadPayload(
+          key = OfflineDownloadKey(
+            libraryItemId = parts[0],
+            episodeId = parts.getOrNull(1)?.ifEmpty { null },
+          ),
+        )
+      }
+
+      // Legacy bare libraryItemId.
+      return OfflineDownloadPayload(key = OfflineDownloadKey(libraryItemId = decoded))
+    }
+  }
+}

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/AndroidOfflineDownloadManager.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/AndroidOfflineDownloadManager.kt
@@ -6,8 +6,8 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import app.campfire.audioplayer.offline.OfflineDownload
-import app.campfire.audioplayer.offline.OfflineDownloadKey
 import app.campfire.audioplayer.offline.OfflineDownloadManager
+import app.campfire.audioplayer.offline.OfflineDownloadPayload
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
 import app.campfire.core.logging.bark
@@ -119,9 +119,16 @@ class AndroidOfflineDownloadManager(
   }
 
   override fun download(item: LibraryItem) {
+    val payload = OfflineDownloadPayload(
+      libraryItemId = item.id,
+      episodeId = null,
+      title = item.media.metadata.title.orEmpty(),
+      subtitle = item.media.metadata.authorName.orEmpty(),
+    ).encode()
+
     item.media.tracks.forEach { track ->
       val request = DownloadRequest.Builder(track.metadata.filename, track.contentUrl.toUri())
-        .setData(item.id.encodeToByteArray())
+        .setData(payload)
         .build()
 
       DownloadService.sendAddDownload(
@@ -143,8 +150,14 @@ class AndroidOfflineDownloadManager(
       bark { "Cannot download episode ${episode.id}: missing audioTrack" }
       return
     }
+    val payload = OfflineDownloadPayload(
+      libraryItemId = item.id,
+      episodeId = episode.id,
+      title = episode.title,
+      subtitle = item.media.metadata.title.orEmpty(),
+    ).encode()
     val request = DownloadRequest.Builder(episodeDownloadId(item.id, episode.id), track.contentUrl.toUri())
-      .setData(OfflineDownloadKey(item.id, episode.id).encode())
+      .setData(payload)
       .build()
 
     DownloadService.sendAddDownload(

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/AndroidOfflineDownloadManager.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/AndroidOfflineDownloadManager.kt
@@ -6,11 +6,15 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import app.campfire.audioplayer.offline.OfflineDownload
+import app.campfire.audioplayer.offline.OfflineDownloadKey
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
+import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -77,6 +81,43 @@ class AndroidOfflineDownloadManager(
       }
   }
 
+  override fun observeForEpisode(item: LibraryItem, episode: PodcastEpisode): Flow<OfflineDownload> {
+    return downloadTracker.observeEvents()
+      .flatMapLatest {
+        channelFlow {
+          var download = downloadTracker.getOfflineDownload(item, episode)
+          do {
+            send(download)
+            delay(1.seconds)
+            download = downloadTracker.getOfflineDownload(item, episode)
+          } while (isActive && download.state != OfflineDownload.State.Completed)
+        }
+      }
+  }
+
+  override fun observeForEpisodes(
+    item: LibraryItem,
+    episodes: List<PodcastEpisode>,
+  ): Flow<Map<PodcastEpisodeId, OfflineDownload>> {
+    return downloadTracker.observeEvents()
+      .flatMapLatest {
+        channelFlow {
+          var downloads = episodes.associate { episode ->
+            episode.id to downloadTracker.getOfflineDownload(item, episode)
+          }
+          send(downloads)
+
+          while (isActive && downloads.values.any { it.isActive }) {
+            delay(5.seconds)
+            downloads = episodes.associate { episode ->
+              episode.id to downloadTracker.getOfflineDownload(item, episode)
+            }
+            send(downloads)
+          }
+        }
+      }
+  }
+
   override fun download(item: LibraryItem) {
     item.media.tracks.forEach { track ->
       val request = DownloadRequest.Builder(track.metadata.filename, track.contentUrl.toUri())
@@ -96,6 +137,24 @@ class AndroidOfflineDownloadManager(
     items.forEach { download(it) }
   }
 
+  override fun downloadEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    val track = episode.audioTrack
+    if (track == null) {
+      bark { "Cannot download episode ${episode.id}: missing audioTrack" }
+      return
+    }
+    val request = DownloadRequest.Builder(episodeDownloadId(item.id, episode.id), track.contentUrl.toUri())
+      .setData(OfflineDownloadKey(item.id, episode.id).encode())
+      .build()
+
+    DownloadService.sendAddDownload(
+      application,
+      CampfireDownloadService::class.java,
+      request,
+      true,
+    )
+  }
+
   override fun delete(item: LibraryItem) {
     item.media.tracks.forEach { track ->
       DownloadService.sendRemoveDownload(
@@ -107,8 +166,21 @@ class AndroidOfflineDownloadManager(
     }
   }
 
+  override fun deleteEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    DownloadService.sendRemoveDownload(
+      application,
+      CampfireDownloadService::class.java,
+      episodeDownloadId(item.id, episode.id),
+      true,
+    )
+  }
+
   override fun stop(item: LibraryItem) {
     delete(item)
+  }
+
+  override fun stopEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    deleteEpisode(item, episode)
   }
 
   override fun resumeDownloads() {
@@ -119,4 +191,7 @@ class AndroidOfflineDownloadManager(
       true,
     )
   }
+
+  private fun episodeDownloadId(itemId: LibraryItemId, episodeId: PodcastEpisodeId): String =
+    "$itemId:$episodeId"
 }

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/CampfireDownloadNotifications.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/CampfireDownloadNotifications.kt
@@ -1,0 +1,201 @@
+package app.campfire.audioplayer.impl.offline
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Build
+import androidx.annotation.DrawableRes
+import androidx.annotation.OptIn
+import androidx.annotation.StringRes
+import androidx.core.app.NotificationCompat
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.R as Media3R
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.scheduler.Requirements
+import app.campfire.audioplayer.offline.OfflineDownloadPayload
+import app.campfire.infra.audioplayer.impl.R
+
+/**
+ * Forked from `androidx.media3.exoplayer.offline.DownloadNotificationHelper` so the
+ * foreground notification can show the title of the item currently downloading
+ * (decoded from each request's [OfflineDownloadPayload]) and surface the library-item
+ * count in the notification title when more than one is in flight.
+ *
+ * Aggregation logic (progress, paused-for-network detection, indeterminate progress)
+ * matches the upstream helper so the notification still reflects Media3's view of
+ * the world; only the presentation differs.
+ */
+@OptIn(UnstableApi::class)
+class CampfireDownloadNotifications(
+  context: Context,
+  private val channelId: String,
+) {
+
+  private val appContext: Context = context.applicationContext
+
+  fun buildProgressNotification(
+    @DrawableRes smallIcon: Int,
+    contentIntent: PendingIntent?,
+    downloads: List<Download>,
+    @Requirements.RequirementFlags notMetRequirements: Int,
+  ): Notification {
+    var totalPercentage = 0f
+    var downloadTaskCount = 0
+    var allDownloadPercentagesUnknown = true
+    var haveDownloadedBytes = false
+    var haveDownloadingTasks = false
+    var haveQueuedTasks = false
+    var haveRemovingTasks = false
+
+    downloads.forEach { download ->
+      when (download.state) {
+        Download.STATE_REMOVING -> haveRemovingTasks = true
+        Download.STATE_QUEUED -> haveQueuedTasks = true
+        Download.STATE_RESTARTING,
+        Download.STATE_DOWNLOADING,
+        -> {
+          haveDownloadingTasks = true
+          val percent = download.percentDownloaded
+          if (percent != C.PERCENTAGE_UNSET.toFloat()) {
+            allDownloadPercentagesUnknown = false
+            totalPercentage += percent
+          }
+          if (download.bytesDownloaded > 0L) haveDownloadedBytes = true
+          downloadTaskCount++
+        }
+        else -> Unit
+      }
+    }
+
+    @StringRes var titleStringId: Int = NULL_STRING_ID
+    var showProgress = true
+    when {
+      haveDownloadingTasks -> titleStringId = Media3R.string.exo_download_downloading
+      haveQueuedTasks && notMetRequirements != 0 -> {
+        showProgress = false
+        titleStringId = when {
+          (notMetRequirements and Requirements.NETWORK_UNMETERED) != 0 ->
+            Media3R.string.exo_download_paused_for_wifi
+          (notMetRequirements and Requirements.NETWORK) != 0 ->
+            Media3R.string.exo_download_paused_for_network
+          else -> Media3R.string.exo_download_paused
+        }
+      }
+      haveRemovingTasks -> titleStringId = Media3R.string.exo_download_removing
+    }
+
+    var maxProgress = 0
+    var currentProgress = 0
+    var indeterminateProgress = false
+    if (showProgress) {
+      maxProgress = 100
+      if (haveDownloadingTasks) {
+        currentProgress = if (downloadTaskCount > 0) (totalPercentage / downloadTaskCount).toInt() else 0
+        indeterminateProgress = allDownloadPercentagesUnknown && haveDownloadedBytes
+      } else {
+        indeterminateProgress = true
+      }
+    }
+
+    // Decode every download's payload once, group by libraryItemId so a multi-track
+    // book counts as one logical item. Preserve insertion order via LinkedHashMap.
+    val groupsByItem = linkedMapOf<String, MutableList<PayloadDownload>>()
+    downloads.forEach { download ->
+      val payload = OfflineDownloadPayload.decode(download.request.data)
+      groupsByItem.getOrPut(payload.key.libraryItemId) { mutableListOf() }
+        .add(PayloadDownload(download, payload))
+    }
+
+    val totalItems = groupsByItem.size
+    val doneItems = groupsByItem.count { (_, group) ->
+      group.all { it.download.state == Download.STATE_COMPLETED }
+    }
+    val inFlightItems = totalItems - doneItems
+
+    // Lead: prefer the first in-flight group whose payload has any actively downloading
+    // track so the notification follows what's currently being written to disk rather
+    // than pinning to a queued item that hasn't started.
+    val inFlightGroups = groupsByItem.values.filter { group -> group.any { it.isInFlight() } }
+    val activeGroup = inFlightGroups.firstOrNull { group -> group.any { it.isActivelyDownloading() } }
+    val leadPayload = (activeGroup ?: inFlightGroups.firstOrNull())?.first()?.payload
+    val collapsedText = leadPayload?.let(::formatLine)
+
+    val baseLabel = if (titleStringId == NULL_STRING_ID) null else appContext.getString(titleStringId)
+    val contentTitle = when {
+      baseLabel == null -> null
+      inFlightItems > 1 -> appContext.getString(
+        R.string.download_notification_title_with_count,
+        baseLabel,
+        inFlightItems,
+      )
+      else -> baseLabel
+    }
+
+    val subText = if (inFlightItems >= 1) {
+      appContext.resources.getQuantityString(
+        R.plurals.download_notification_items,
+        inFlightItems,
+        inFlightItems,
+      )
+    } else {
+      null
+    }
+
+    val summaryText = if (showProgress && haveDownloadingTasks && !indeterminateProgress && totalItems > 1) {
+      appContext.getString(
+        R.string.download_notification_summary,
+        currentProgress,
+        doneItems,
+        totalItems,
+      )
+    } else {
+      null
+    }
+
+    val style = collapsedText?.let {
+      NotificationCompat.BigTextStyle()
+        .bigText(it)
+        .also { style -> summaryText?.let(style::setSummaryText) }
+    }
+
+    val builder = NotificationCompat.Builder(appContext, channelId)
+      .setSmallIcon(smallIcon)
+      .setContentTitle(contentTitle)
+      .setContentIntent(contentIntent)
+      .setContentText(collapsedText)
+      .setSubText(subText)
+      .setNumber(inFlightItems)
+      .setOngoing(true)
+      .setShowWhen(false)
+      .setOnlyAlertOnce(true)
+      .setProgress(maxProgress, currentProgress, indeterminateProgress)
+
+    style?.let(builder::setStyle)
+
+    if (Build.VERSION.SDK_INT >= 31) {
+      builder.setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+    }
+
+    return builder.build()
+  }
+
+  private fun formatLine(payload: OfflineDownloadPayload): String? {
+    val title = payload.title.takeIf { it.isNotEmpty() } ?: return null
+    return if (payload.subtitle.isNotEmpty()) "$title · ${payload.subtitle}" else title
+  }
+
+  private data class PayloadDownload(
+    val download: Download,
+    val payload: OfflineDownloadPayload,
+  ) {
+    fun isInFlight(): Boolean =
+      download.state != Download.STATE_COMPLETED && download.state != Download.STATE_FAILED
+
+    fun isActivelyDownloading(): Boolean = download.state == Download.STATE_DOWNLOADING
+  }
+
+  companion object {
+    private const val NULL_STRING_ID = 0
+  }
+}

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/CampfireDownloadService.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/CampfireDownloadService.kt
@@ -6,7 +6,6 @@ import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadManager
-import androidx.media3.exoplayer.offline.DownloadNotificationHelper
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.media3.exoplayer.scheduler.PlatformScheduler
 import androidx.media3.exoplayer.scheduler.Scheduler
@@ -37,10 +36,10 @@ class CampfireDownloadService : DownloadService(
     ComponentHolder.component<CampfireDownloadServiceComponent>()
   }
 
-  private val downloadNotificationHelper by lazy {
-    DownloadNotificationHelper(
-      this,
-      CHANNEL_ID,
+  private val downloadNotifications by lazy {
+    CampfireDownloadNotifications(
+      context = this,
+      channelId = CHANNEL_ID,
     )
   }
 
@@ -53,26 +52,16 @@ class CampfireDownloadService : DownloadService(
   }
 
   override fun getForegroundNotification(downloads: MutableList<Download>, notMetRequirements: Int): Notification {
-    val message = if (downloads.size > 1) {
-      getString(R.string.download_notification_message, downloads.size)
-    } else if (downloads.size == 1) {
-      downloads.first().request.toMediaItem().mediaMetadata.title?.toString()
-    } else {
-      null
-    }
-
-    return downloadNotificationHelper.buildProgressNotification(
-      this,
-      R.drawable.ic_notification,
-      PendingIntent.getActivity(
+    return downloadNotifications.buildProgressNotification(
+      smallIcon = R.drawable.ic_notification,
+      contentIntent = PendingIntent.getActivity(
         this,
         0,
         component.activityIntentProvider.provide(),
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
       ),
-      message,
-      downloads,
-      notMetRequirements,
+      downloads = downloads,
+      notMetRequirements = notMetRequirements,
     )
   }
 

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/DownloadTracker.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/DownloadTracker.kt
@@ -151,10 +151,9 @@ class DownloadTracker(
     }
 
     val currentProgress = (totalPercentage / downloadTaskCount)
-    val currentProgressV2 = if (totalContentLength > 0L) {
-      downloadedBytes.toFloat() / totalContentLength.toFloat()
-    } else 0f
-    val isIndeterminate = !haveDownloadingTasks || (allDownloadPercentagesUnknown && downloadedBytes > 0L)
+    val isIndeterminate = !haveDownloadingTasks ||
+      contentLength <= 0L ||
+      (allDownloadPercentagesUnknown && downloadedBytes > 0L)
 
     return OfflineDownload(
       libraryItemId = key.libraryItemId,
@@ -172,8 +171,7 @@ class DownloadTracker(
       contentLength = contentLength,
       progress = OfflineDownload.Progress(
         bytes = downloadedBytes,
-        percent = currentProgressV2.coerceIn(0f, 1f),
-//          (currentProgress / 100f).coerceIn(0f, 1f),
+        percent = (currentProgress / 100f).coerceIn(0f, 1f),
         indeterminate = isIndeterminate,
       ),
     )

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/DownloadTracker.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/DownloadTracker.kt
@@ -8,13 +8,14 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadManager
 import app.campfire.audioplayer.offline.OfflineDownload
+import app.campfire.audioplayer.offline.OfflineDownloadKey
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.qualifier.ForScope
 import app.campfire.core.logging.LogPriority
 import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItem
-import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
@@ -61,12 +62,12 @@ class DownloadTracker(
   @kotlin.OptIn(ExperimentalCoroutinesApi::class)
   fun observeDownloads(): Flow<List<OfflineDownload>> = events
     .mapLatest {
-      val itemIds = downloads.values
-        .map { it.request.data.decodeToString() }
+      val keys = downloads.values
+        .map { OfflineDownloadKey.decode(it.request.data) }
         .toSet()
 
-      itemIds.map { itemId ->
-        getOfflineDownload(itemId)
+      keys.map { key ->
+        getOfflineDownload(key)
       }
     }
 
@@ -76,38 +77,45 @@ class DownloadTracker(
         downloads[it.contentUrl.toUri()]
       }
     } else {
-      // Find all the downloads by the items associated metadata id. Due to API design restraints, the
-      // tracks meta is not always guaranteed on the LibraryItems
+      // Find all the downloads by the items associated metadata id. Restrict to
+      // book-level entries (episodeId == null) so a podcast's item-level state isn't
+      // polluted by its per-episode downloads.
       downloads.values
-        .filter { it.request.data.decodeToString() == item.id }
+        .filter {
+          val decoded = OfflineDownloadKey.decode(it.request.data)
+          decoded.libraryItemId == item.id && decoded.episodeId == null
+        }
     }
 
     // If we don't have any active downloads for an item, just return the default
     if (itemDownloads.isEmpty()) return OfflineDownload(item.id)
 
     return computeOfflineDownload(
-      itemId = item.id,
+      key = OfflineDownloadKey(item.id),
       itemDownloads = itemDownloads,
     )
   }
 
-  fun getOfflineDownload(itemId: LibraryItemId): OfflineDownload {
-    // Find all the downloads by the items associated metadata id. Due to API design restraints, the
-    // tracks meta is not always guaranteed on the LibraryItems
-    val itemDownloads = downloads.values
-      .filter { it.request.data.decodeToString() == itemId }
+  fun getOfflineDownload(item: LibraryItem, episode: PodcastEpisode): OfflineDownload {
+    return getOfflineDownload(OfflineDownloadKey(item.id, episode.id))
+  }
 
-    // If we don't have any active downloads for an item, just return the default
-    if (itemDownloads.isEmpty()) return OfflineDownload(itemId)
+  fun getOfflineDownload(key: OfflineDownloadKey): OfflineDownload {
+    val itemDownloads = downloads.values
+      .filter { OfflineDownloadKey.decode(it.request.data) == key }
+
+    if (itemDownloads.isEmpty()) {
+      return OfflineDownload(libraryItemId = key.libraryItemId, episodeId = key.episodeId)
+    }
 
     return computeOfflineDownload(
-      itemId = itemId,
+      key = key,
       itemDownloads = itemDownloads,
     )
   }
 
   private fun computeOfflineDownload(
-    itemId: LibraryItemId,
+    key: OfflineDownloadKey,
     itemDownloads: List<Download>,
   ): OfflineDownload {
     // Condense the collective set of states
@@ -124,6 +132,7 @@ class DownloadTracker(
     var downloadTaskCount = 0
     var totalPercentage = 0f
     var downloadedBytes = 0L
+    var totalContentLength = 0L
     itemDownloads.forEach { download ->
       when (download.state) {
         Download.STATE_DOWNLOADING -> {
@@ -138,13 +147,18 @@ class DownloadTracker(
       }
 
       downloadedBytes += download.bytesDownloaded
+      totalContentLength += download.contentLength
     }
 
     val currentProgress = (totalPercentage / downloadTaskCount)
+    val currentProgressV2 = if (totalContentLength > 0L) {
+      downloadedBytes.toFloat() / totalContentLength.toFloat()
+    } else 0f
     val isIndeterminate = !haveDownloadingTasks || (allDownloadPercentagesUnknown && downloadedBytes > 0L)
 
     return OfflineDownload(
-      libraryItemId = itemId,
+      libraryItemId = key.libraryItemId,
+      episodeId = key.episodeId,
       state = when {
         states.contains(Download.STATE_FAILED) -> OfflineDownload.State.Failed
         states.contains(Download.STATE_STOPPED) -> OfflineDownload.State.Stopped
@@ -158,7 +172,8 @@ class DownloadTracker(
       contentLength = contentLength,
       progress = OfflineDownload.Progress(
         bytes = downloadedBytes,
-        percent = (currentProgress / 100f).coerceIn(0f, 1f),
+        percent = currentProgressV2.coerceIn(0f, 1f),
+//          (currentProgress / 100f).coerceIn(0f, 1f),
         indeterminate = isIndeterminate,
       ),
     )

--- a/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
+++ b/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
@@ -9,7 +9,16 @@
   <string name="download_notification_channel_name">Offline Download Notifications</string>
   <string name="download_notification_channel_description">Notifications about downloading media for
     offline playback will appear in this channel</string>
-  <string name="download_notification_message">Downloading %1$d items</string>
+  <!-- Appended to the Media3-provided status label when more than one library item is in flight.
+       Example: "Downloading · 3 items". -->
+  <string name="download_notification_title_with_count">%1$s · %2$d items</string>
+  <!-- Notification expanded summary line. Example: "42% · 1 of 3 done". -->
+  <string name="download_notification_summary">%1$d%% · %2$d of %3$d done</string>
+  <!-- Notification header sub-text. Rendered next to the app name as "Campfire · 3 items". -->
+  <plurals name="download_notification_items">
+    <item quantity="one">%d item</item>
+    <item quantity="other">%d items</item>
+  </plurals>
 
   <string name="exo_controls_skip_backward">Skip backward</string>
   <string name="exo_controls_skip_forward">Skip forward</string>

--- a/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/offline/IosOfflineDownloadManager.kt
+++ b/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/offline/IosOfflineDownloadManager.kt
@@ -7,6 +7,8 @@ import app.campfire.core.di.SingleIn
 import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -32,6 +34,17 @@ class IosOfflineDownloadManager : OfflineDownloadManager {
     return emptyFlow()
   }
 
+  override fun observeForEpisode(item: LibraryItem, episode: PodcastEpisode): Flow<OfflineDownload> {
+    return emptyFlow()
+  }
+
+  override fun observeForEpisodes(
+    item: LibraryItem,
+    episodes: List<PodcastEpisode>,
+  ): Flow<Map<PodcastEpisodeId, OfflineDownload>> {
+    return emptyFlow()
+  }
+
   override fun download(item: LibraryItem) {
     bark { "Not implemented yet!" }
   }
@@ -40,11 +53,23 @@ class IosOfflineDownloadManager : OfflineDownloadManager {
     bark { "Not implemented yet!" }
   }
 
+  override fun downloadEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    bark { "Not implemented yet!" }
+  }
+
   override fun delete(item: LibraryItem) {
     bark { "Not implemented yet!" }
   }
 
+  override fun deleteEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    bark { "Not implemented yet!" }
+  }
+
   override fun stop(item: LibraryItem) {
+    bark { "Not implemented yet!" }
+  }
+
+  override fun stopEpisode(item: LibraryItem, episode: PodcastEpisode) {
     bark { "Not implemented yet!" }
   }
 

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/offline/DesktopOfflineDownloadManager.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/offline/DesktopOfflineDownloadManager.kt
@@ -7,6 +7,8 @@ import app.campfire.core.di.SingleIn
 import app.campfire.core.logging.bark
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -32,6 +34,17 @@ class DesktopOfflineDownloadManager : OfflineDownloadManager {
     return emptyFlow()
   }
 
+  override fun observeForEpisode(item: LibraryItem, episode: PodcastEpisode): Flow<OfflineDownload> {
+    return emptyFlow()
+  }
+
+  override fun observeForEpisodes(
+    item: LibraryItem,
+    episodes: List<PodcastEpisode>,
+  ): Flow<Map<PodcastEpisodeId, OfflineDownload>> {
+    return emptyFlow()
+  }
+
   override fun download(item: LibraryItem) {
     bark { "Not implemented yet!" }
   }
@@ -40,11 +53,23 @@ class DesktopOfflineDownloadManager : OfflineDownloadManager {
     bark { "Not implemented yet!" }
   }
 
+  override fun downloadEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    bark { "Not implemented yet!" }
+  }
+
   override fun delete(item: LibraryItem) {
     bark { "Not implemented yet!" }
   }
 
+  override fun deleteEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    bark { "Not implemented yet!" }
+  }
+
   override fun stop(item: LibraryItem) {
+    bark { "Not implemented yet!" }
+  }
+
+  override fun stopEpisode(item: LibraryItem, episode: PodcastEpisode) {
     bark { "Not implemented yet!" }
   }
 

--- a/infra/audioplayer/test/src/commonMain/kotlin/app/campfire/audioplayer/test/offline/FakeOfflineDownloadManager.kt
+++ b/infra/audioplayer/test/src/commonMain/kotlin/app/campfire/audioplayer/test/offline/FakeOfflineDownloadManager.kt
@@ -4,6 +4,8 @@ import app.campfire.audioplayer.offline.OfflineDownload
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 
@@ -31,6 +33,19 @@ class FakeOfflineDownloadManager : OfflineDownloadManager {
     return observeForItemsFlow
   }
 
+  val observeForEpisodeFlow = MutableSharedFlow<OfflineDownload>(replay = 1)
+  override fun observeForEpisode(item: LibraryItem, episode: PodcastEpisode): Flow<OfflineDownload> {
+    return observeForEpisodeFlow
+  }
+
+  val observeForEpisodesFlow = MutableSharedFlow<Map<PodcastEpisodeId, OfflineDownload>>(replay = 1)
+  override fun observeForEpisodes(
+    item: LibraryItem,
+    episodes: List<PodcastEpisode>,
+  ): Flow<Map<PodcastEpisodeId, OfflineDownload>> {
+    return observeForEpisodesFlow
+  }
+
   override fun download(item: LibraryItem) {
     invocations += Invocation.Download(item)
   }
@@ -39,12 +54,24 @@ class FakeOfflineDownloadManager : OfflineDownloadManager {
     invocations += Invocation.DownloadAll(items)
   }
 
+  override fun downloadEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    invocations += Invocation.DownloadEpisode(item, episode)
+  }
+
   override fun delete(item: LibraryItem) {
     invocations += Invocation.Delete(item)
   }
 
+  override fun deleteEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    invocations += Invocation.DeleteEpisode(item, episode)
+  }
+
   override fun stop(item: LibraryItem) {
     invocations += Invocation.Stop(item)
+  }
+
+  override fun stopEpisode(item: LibraryItem, episode: PodcastEpisode) {
+    invocations += Invocation.StopEpisode(item, episode)
   }
 
   override fun resumeDownloads() {
@@ -54,8 +81,11 @@ class FakeOfflineDownloadManager : OfflineDownloadManager {
   sealed interface Invocation {
     data class Download(val item: LibraryItem) : Invocation
     data class DownloadAll(val items: List<LibraryItem>) : Invocation
+    data class DownloadEpisode(val item: LibraryItem, val episode: PodcastEpisode) : Invocation
     data class Delete(val item: LibraryItem) : Invocation
+    data class DeleteEpisode(val item: LibraryItem, val episode: PodcastEpisode) : Invocation
     data class Stop(val item: LibraryItem) : Invocation
+    data class StopEpisode(val item: LibraryItem, val episode: PodcastEpisode) : Invocation
     object ResumeDownloads : Invocation
   }
 }


### PR DESCRIPTION
## Summary
- Per-episode offline downloads for podcasts on Android via Media3, reusing the existing book download pipeline (shared `SimpleCache` makes offline playback "just work" once a download completes). iOS / Desktop stay stubs — same pattern as books today.
- New episode-aware methods on `OfflineDownloadManager` (`downloadEpisode` / `deleteEpisode` / `stopEpisode` / `observeForEpisode` / `observeForEpisodes`) plus an `OfflineDownloadPayload` that carries `(libraryItemId, episodeId, title, subtitle)` in each Media3 `DownloadRequest.setData(...)`. Backward-compatible decode handles already-shipped book downloads.
- Episode UI: download icon on each episode row in `EpisodeSlot` and full controls (download / stop / delete) in the `PodcastEpisodeBottomSheet` via the existing `ExpressiveControlBar`. Reuses the books' "confirm download" dialog (new `(item, episode)` overload shows episode title + size) and POST_NOTIFICATIONS permission gate.
- Settings → Downloads section reworked to a sealed `DownloadEntry { Book; Episode }`; episode rows render with parent-podcast subtitle, route taps to the correct `LibraryItemScreen` + episode, and delete dispatches to `deleteEpisode`.
- Forked `DownloadNotificationHelper` into `CampfireDownloadNotifications` — preserves Media3's progress aggregation but adds the current item's "Title · Subtitle" as the notification's content text + BigText body, item count in the title (`Downloading · 3 items`), header subText, expanded summary (`42% · 1 of 3 done`), and launcher badge count.
- Cascade-delete: when an admin deletes a podcast, any downloaded episodes are evicted from the cache too.

Closes #796

## Test plan
- [ ] `./gradlew :infra:audioplayer:api:check :infra:audioplayer:impl:check :features:libraries:ui:check :features:settings:ui:check`
- [ ] Android emulator: tap download on an episode row → notification permission prompt (if needed) → confirmation dialog shows episode title + size → download starts; row icon transitions Download → progress → DownloadDone; service notification shows `Downloading · {N} items` header, `Title · Subtitle` body, `42% · 1 of N done` summary on expand
- [ ] Airplane mode + tap play on a completed download → episode plays end-to-end from cache (zero successful HTTP reads in Logcat)
- [ ] Settings → Downloads: mixed book + episode entries render with correct titles; delete works for both
- [ ] Delete a podcast (admin) → its downloaded episodes are evicted from `filesDir/exoPlayerDownloads`
- [ ] TalkBack announces the episode download icon's localized label
- [ ] Existing book downloads created before this change still play offline (verifies `OfflineDownloadPayload.decode` legacy fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)