### PR TITLE
Fix LAN server connection on Android 16+ (Local Network Protection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Missing runtime permission on Android 17 when connecting to local network addresses
+
 ### Other Notes & Contributions
 
 ## [0.13.0-beta]

--- a/app/android/src/debug/java/app/campfire/android/LivewireComponent.kt
+++ b/app/android/src/debug/java/app/campfire/android/LivewireComponent.kt
@@ -52,8 +52,6 @@ interface LivewireComponent {
           artworkLoader = CoilDebugArtworkLoader(application),
         ),
       )
-
-      debugLogging(true)
     }
   }
 }

--- a/app/android/src/main/AndroidManifest.xml
+++ b/app/android/src/main/AndroidManifest.xml
@@ -5,6 +5,13 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.VIBRATE" />
+  <!--
+    Android 16+ Local Network Protection (targetSdk 36+) gates access to private IP ranges
+    (e.g. 192.168.x.x self-hosted Audiobookshelf servers) behind this runtime permission.
+    Without it, connections to LAN addresses are silently dropped and time out. It must also
+    be requested at runtime (prot=dangerous) before the first local-network request.
+  -->
+  <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
   <application
     android:name=".CampfireApplication"
@@ -15,6 +22,7 @@
     android:label="@string/app_name"
     android:enableOnBackInvokedCallback="true"
     android:usesCleartextTraffic="true"
+    android:networkSecurityConfig="@xml/network_security_config"
     android:largeHeap="true">
     <activity
       android:name=".MainActivity"

--- a/app/android/src/main/java/app/campfire/android/MainActivity.kt
+++ b/app/android/src/main/java/app/campfire/android/MainActivity.kt
@@ -24,11 +24,15 @@ import app.campfire.core.di.ComponentHolder
 import app.campfire.core.logging.bark
 import app.campfire.core.navigation.DeepLink
 import app.campfire.core.navigation.DeepLinkKeys
+import app.campfire.core.session.serverUrl
 import app.campfire.core.toast.GlobalToaster
 import app.campfire.tracing.Trace
 import app.campfire.tracing.trace
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
 class MainActivity : ComponentActivity() {
@@ -57,6 +61,17 @@ class MainActivity : ComponentActivity() {
     // Register all flow launchers
     component.componentActivityPlugins.forEach { launcher ->
       launcher.register(this)
+    }
+
+    // Upgrade path: a user already signed in to a LAN server before the app began targeting
+    // Android 16+ won't pass through the login screen, so prompt for local-network access here
+    // if their active server is private and the permission is missing. Waits for the session to
+    // restore (it may still be Loading at onCreate), then requests once. No-ops otherwise.
+    lifecycleScope.launch {
+      val serverUrl = component.userSessionManager.observe()
+        .mapNotNull { it.serverUrl }
+        .first()
+      component.localNetworkPermission.requestIfNeeded(serverUrl)
     }
 
     WindowCompat.setDecorFitsSystemWindows(window, false)

--- a/app/android/src/main/java/app/campfire/android/di/ActivityComponent.kt
+++ b/app/android/src/main/java/app/campfire/android/di/ActivityComponent.kt
@@ -2,6 +2,7 @@ package app.campfire.android.di
 
 import android.app.Activity
 import androidx.core.os.ConfigurationCompat
+import app.campfire.account.api.UserSessionManager
 import app.campfire.audioplayer.impl.MediaControllerConnector
 import app.campfire.audioplayer.impl.cast.MediaRouterCastController
 import app.campfire.audioplayer.offline.OfflineDownloadManager
@@ -10,6 +11,7 @@ import app.campfire.core.ComponentActivityPlugin
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UiScope
+import app.campfire.core.permission.LocalNetworkPermissionController
 import com.r0adkll.kimchi.annotations.ContributesSubcomponent
 import java.util.Locale
 import me.tatarka.inject.annotations.Provides
@@ -25,6 +27,8 @@ interface ActivityComponent {
   val mediaRouterCastController: MediaRouterCastController
   val componentActivityPlugins: Set<ComponentActivityPlugin>
   val offlineDownloadManager: OfflineDownloadManager
+  val userSessionManager: UserSessionManager
+  val localNetworkPermission: LocalNetworkPermissionController
 
   @Provides
   fun provideActivityLocale(activity: Activity): Locale {

--- a/app/android/src/main/java/app/campfire/android/permission/AndroidLocalNetworkPermissionController.kt
+++ b/app/android/src/main/java/app/campfire/android/permission/AndroidLocalNetworkPermissionController.kt
@@ -1,0 +1,63 @@
+package app.campfire.android.permission
+
+import android.app.Application
+import android.content.pm.PackageManager
+import android.os.Build
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.core.logging.bark
+import app.campfire.core.permission.LocalNetworkPermissionController
+import app.campfire.core.permission.isPrivateNetworkAddress
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Android 16+ Local Network Protection gates private IP ranges behind the runtime
+ * `ACCESS_LOCAL_NETWORK` permission. This prompts for it lazily — only once the user enters a
+ * LAN address — so people connecting to a remote server are never asked.
+ */
+@SingleIn(AppScope::class)
+@Inject
+@ContributesBinding(AppScope::class)
+class AndroidLocalNetworkPermissionController(
+  private val application: Application,
+  private val launcher: LocalNetworkPermissionLauncher,
+) : LocalNetworkPermissionController {
+
+  private val mutex = Mutex()
+  private var requestedThisSession = false
+
+  override suspend fun requestIfNeeded(serverUrl: String): Boolean {
+    // LNP only applies on Android 16+; older versions have no such gate.
+    if (Build.VERSION.SDK_INT < LNP_MIN_SDK) return true
+    if (!isPrivateNetworkAddress(serverUrl)) return true
+    if (isGranted()) return true
+
+    mutex.withLock {
+      // Re-check inside the lock in case a concurrent request already resolved it.
+      if (isGranted()) return true
+      // Only surface the system dialog once per session; after that respect the OS decision
+      // (a permanent denial returns immediately without UI anyway).
+      if (requestedThisSession) return false
+      requestedThisSession = true
+    }
+
+    val granted = launcher.launch(ACCESS_LOCAL_NETWORK).getOrDefault(false)
+    bark { "ACCESS_LOCAL_NETWORK permission ${if (granted) "granted" else "denied"}" }
+    return granted
+  }
+
+  private fun isGranted(): Boolean =
+    application.checkSelfPermission(ACCESS_LOCAL_NETWORK) == PackageManager.PERMISSION_GRANTED
+
+  private companion object {
+    // Local Network Protection was introduced in Android 16 (API 36).
+    const val LNP_MIN_SDK = 36
+
+    // String literal rather than Manifest.permission.ACCESS_LOCAL_NETWORK so this still compiles
+    // against a compileSdk that predates the constant.
+    const val ACCESS_LOCAL_NETWORK = "android.permission.ACCESS_LOCAL_NETWORK"
+  }
+}

--- a/app/android/src/main/java/app/campfire/android/permission/LocalNetworkPermissionLauncher.kt
+++ b/app/android/src/main/java/app/campfire/android/permission/LocalNetworkPermissionLauncher.kt
@@ -1,0 +1,22 @@
+package app.campfire.android.permission
+
+import androidx.activity.result.contract.ActivityResultContracts
+import app.campfire.core.ActivityResultFlowLauncher
+import app.campfire.core.ComponentActivityPlugin
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Activity-scoped launcher for the runtime `ACCESS_LOCAL_NETWORK` permission request. Registered
+ * against [androidx.activity.ComponentActivity] via the [ComponentActivityPlugin] multibinding so
+ * `suspend fun launch(permission)` can be called from anywhere (see
+ * [AndroidLocalNetworkPermissionController]).
+ */
+@SingleIn(AppScope::class)
+@Inject
+@ContributesMultibinding(AppScope::class, boundType = ComponentActivityPlugin::class)
+class LocalNetworkPermissionLauncher : ActivityResultFlowLauncher<String, Boolean>(
+  ActivityResultContracts.RequestPermission(),
+)

--- a/app/android/src/main/res/xml/network_security_config.xml
+++ b/app/android/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <!-- Since this app serves self-hosted content there is no option other than this. -->
+  <base-config cleartextTrafficPermitted="true"
+    tools:ignore="InsecureBaseConfiguration">
+  </base-config>
+</network-security-config>

--- a/app/common/src/iosMain/kotlin/app/campfire/common/permission/NoOpLocalNetworkPermissionController.kt
+++ b/app/common/src/iosMain/kotlin/app/campfire/common/permission/NoOpLocalNetworkPermissionController.kt
@@ -1,0 +1,18 @@
+package app.campfire.common.permission
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.core.permission.LocalNetworkPermissionController
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * iOS surfaces its own local-network prompt automatically on first LAN access (driven by
+ * `NSLocalNetworkUsageDescription`), so there is nothing to request explicitly here.
+ */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+@Inject
+class NoOpLocalNetworkPermissionController : LocalNetworkPermissionController {
+  override suspend fun requestIfNeeded(serverUrl: String): Boolean = true
+}

--- a/app/common/src/jvmMain/kotlin/app/campfire/common/permission/NoOpLocalNetworkPermissionController.kt
+++ b/app/common/src/jvmMain/kotlin/app/campfire/common/permission/NoOpLocalNetworkPermissionController.kt
@@ -1,0 +1,15 @@
+package app.campfire.common.permission
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.core.permission.LocalNetworkPermissionController
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import me.tatarka.inject.annotations.Inject
+
+/** Desktop has no local-network permission gate, so access is always available. */
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+@Inject
+class NoOpLocalNetworkPermissionController : LocalNetworkPermissionController {
+  override suspend fun requestIfNeeded(serverUrl: String): Boolean = true
+}

--- a/core/src/commonMain/kotlin/app/campfire/core/permission/LocalNetworkPermissionController.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/permission/LocalNetworkPermissionController.kt
@@ -1,0 +1,23 @@
+package app.campfire.core.permission
+
+/**
+ * Gates access to the platform's "local network" permission (Android 16+ Local Network
+ * Protection). Campfire talks to self-hosted Audiobookshelf servers that frequently live on the
+ * LAN (e.g. `192.168.x.x`), and on affected platforms those connections are silently dropped
+ * until the user grants access.
+ *
+ * The request is deferred until the user actually enters a private/LAN address, rather than
+ * prompting on launch, so people connecting to a public/remote server are never asked.
+ */
+interface LocalNetworkPermissionController {
+
+  /**
+   * If [serverUrl] targets a private/LAN address and the local-network permission is not yet
+   * granted, prompts for it (once per session) and suspends until the user responds.
+   *
+   * Returns `true` when access is available (granted, not needed, or the platform has no such
+   * gate) and `false` when it was denied. A `false` result is non-fatal — remote servers still
+   * work — so callers may proceed regardless.
+   */
+  suspend fun requestIfNeeded(serverUrl: String): Boolean
+}

--- a/core/src/commonMain/kotlin/app/campfire/core/permission/PrivateNetworkAddress.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/permission/PrivateNetworkAddress.kt
@@ -1,0 +1,73 @@
+package app.campfire.core.permission
+
+/**
+ * Best-effort, multiplatform check for whether [serverUrl] points at a private / local-network
+ * host — the addresses gated by Android's Local Network Protection. Covers RFC 1918 IPv4 ranges,
+ * loopback, link-local, IPv6 loopback/ULA/link-local, and common local hostnames.
+ *
+ * Intentionally conservative: it parses the host out of a URL-ish string without a full URL
+ * library so it can live in `:core`. Unknown/public hosts return `false`.
+ */
+fun isPrivateNetworkAddress(serverUrl: String): Boolean {
+  val host = extractHost(serverUrl)?.lowercase() ?: return false
+
+  if (host == "localhost" ||
+    host.endsWith(".local") ||
+    host.endsWith(".lan") ||
+    host.endsWith(".home") ||
+    host.endsWith(".internal")
+  ) {
+    return true
+  }
+
+  // IPv6 (already unbracketed by extractHost)
+  if (host.contains(':')) {
+    if (host == "::1") return true
+    // Unique-local fc00::/7 (fc/fd) and link-local fe80::/10.
+    return host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:")
+  }
+
+  // IPv4
+  val octets = host.split('.')
+  if (octets.size == 4 && octets.all { it.toIntOrNull() in 0..255 }) {
+    val a = octets[0].toInt()
+    val b = octets[1].toInt()
+    return when {
+      a == 10 -> true // 10.0.0.0/8
+      a == 127 -> true // loopback 127.0.0.0/8
+      a == 192 && b == 168 -> true // 192.168.0.0/16
+      a == 172 && b in 16..31 -> true // 172.16.0.0/12
+      a == 169 && b == 254 -> true // link-local 169.254.0.0/16
+      else -> false
+    }
+  }
+
+  return false
+}
+
+/** Pulls the bare host out of a possibly-schemed `host:port/path` string. */
+private fun extractHost(serverUrl: String): String? {
+  var s = serverUrl.trim()
+  if (s.isEmpty()) return null
+
+  // Strip scheme
+  val schemeIdx = s.indexOf("://")
+  if (schemeIdx >= 0) s = s.substring(schemeIdx + 3)
+
+  // Strip path / query / fragment
+  s = s.substringBefore('/').substringBefore('?').substringBefore('#')
+
+  // Strip userinfo
+  s = s.substringAfterLast('@')
+  if (s.isEmpty()) return null
+
+  // Bracketed IPv6: [::1]:8080 -> ::1
+  if (s.startsWith('[')) {
+    val end = s.indexOf(']')
+    if (end > 0) return s.substring(1, end)
+    return null
+  }
+
+  // host:port (IPv4/hostname) -> host. A bare unbracketed IPv6 has multiple ':' — keep as-is.
+  return if (s.count { it == ':' } == 1) s.substringBefore(':') else s
+}

--- a/core/src/commonTest/kotlin/app/campfire/core/permission/PrivateNetworkAddressTest.kt
+++ b/core/src/commonTest/kotlin/app/campfire/core/permission/PrivateNetworkAddressTest.kt
@@ -1,0 +1,58 @@
+package app.campfire.core.permission
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class PrivateNetworkAddressTest {
+
+  @Test
+  fun rfc1918_ipv4_ranges_are_private() {
+    assertThat(isPrivateNetworkAddress("http://192.168.1.202:13378")).isTrue()
+    assertThat(isPrivateNetworkAddress("http://10.0.0.5:8080")).isTrue()
+    assertThat(isPrivateNetworkAddress("http://172.16.0.1")).isTrue()
+    assertThat(isPrivateNetworkAddress("http://172.31.255.254/status")).isTrue()
+  }
+
+  @Test
+  fun loopback_and_link_local_are_private() {
+    assertThat(isPrivateNetworkAddress("http://127.0.0.1:13378")).isTrue()
+    assertThat(isPrivateNetworkAddress("http://169.254.10.10")).isTrue()
+    assertThat(isPrivateNetworkAddress("https://localhost:3000")).isTrue()
+  }
+
+  @Test
+  fun local_hostnames_are_private() {
+    assertThat(isPrivateNetworkAddress("http://nas.local:13378")).isTrue()
+    assertThat(isPrivateNetworkAddress("http://server.lan")).isTrue()
+  }
+
+  @Test
+  fun ipv6_loopback_ula_and_link_local_are_private() {
+    assertThat(isPrivateNetworkAddress("http://[::1]:13378")).isTrue()
+    assertThat(isPrivateNetworkAddress("http://[fd00::1]:8080")).isTrue()
+    assertThat(isPrivateNetworkAddress("http://[fe80::1]")).isTrue()
+  }
+
+  @Test
+  fun public_hosts_and_ips_are_not_private() {
+    assertThat(isPrivateNetworkAddress("https://audiobooks.example.com")).isFalse()
+    assertThat(isPrivateNetworkAddress("https://abs.example.com:13378/status")).isFalse()
+    assertThat(isPrivateNetworkAddress("http://8.8.8.8")).isFalse()
+    assertThat(isPrivateNetworkAddress("http://172.32.0.1")).isFalse() // just outside 172.16/12
+    assertThat(isPrivateNetworkAddress("http://11.0.0.1")).isFalse()
+  }
+
+  @Test
+  fun credentials_in_url_do_not_confuse_host_parsing() {
+    assertThat(isPrivateNetworkAddress("http://user:pass@192.168.1.5:13378")).isTrue()
+    assertThat(isPrivateNetworkAddress("http://user:pass@example.com")).isFalse()
+  }
+
+  @Test
+  fun blank_or_garbage_is_not_private() {
+    assertThat(isPrivateNetworkAddress("")).isFalse()
+    assertThat(isPrivateNetworkAddress("   ")).isFalse()
+  }
+}

--- a/data/network/impl/src/commonMain/kotlin/app/campfire/network/KtorAuthAudioBookShelfApi.kt
+++ b/data/network/impl/src/commonMain/kotlin/app/campfire/network/KtorAuthAudioBookShelfApi.kt
@@ -58,7 +58,7 @@ class KtorAuthAudioBookShelfApi(
     extraHeaders: Map<String, String>?,
   ): Result<ServerStatus> {
     return trySendRequest {
-      client.get("$serverUrl/status") {
+      client.get("${cleanServerUrl(serverUrl)}/status") {
         maybeHeaders(extraHeaders)
       }
     }

--- a/data/network/impl/src/commonMain/kotlin/app/campfire/network/di/HttpClientModule.kt
+++ b/data/network/impl/src/commonMain/kotlin/app/campfire/network/di/HttpClientModule.kt
@@ -21,6 +21,7 @@ import com.r0adkll.kimchi.annotations.ContributesTo
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.cache.HttpCache
@@ -56,7 +57,17 @@ interface HttpClientModule {
     applicationInfo: ApplicationInfo,
   ): HttpClient {
     return HttpClient {
-      install(LivewireNetworkPlugin)
+      // Debug-only network inspection. This installs a ResponseObserver that reads the full
+      // body of every response, so it must never ride along on release builds.
+      if (applicationInfo.debugBuild) {
+        install(LivewireNetworkPlugin)
+      }
+
+      install(HttpTimeout) {
+        connectTimeoutMillis = 10_000
+        requestTimeoutMillis = 30_000
+        socketTimeoutMillis = 30_000
+      }
 
       install(ContentNegotiation) {
         json(

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginPresenter.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginPresenter.kt
@@ -25,6 +25,7 @@ import app.campfire.core.extensions.capitalized
 import app.campfire.core.model.NetworkSettings
 import app.campfire.core.model.Tent
 import app.campfire.core.model.UserId
+import app.campfire.core.permission.LocalNetworkPermissionController
 import app.campfire.network.oidc.AuthorizationFlow
 import coil3.toUri
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
@@ -43,6 +44,7 @@ class LoginPresenter(
   @Assisted private val navigator: Navigator,
   private val authRepository: AuthRepository,
   private val oauthAuthorizationFlow: AuthorizationFlow,
+  private val localNetworkPermission: LocalNetworkPermissionController,
 ) : Presenter<LoginUiState> {
 
   private val initialTent: Tent = when (screen) {
@@ -226,6 +228,10 @@ class LoginPresenter(
         connectionState = ConnectionState.Error(IllegalArgumentException("Invalid URL"))
         return@LaunchedEffect
       }
+
+      // A LAN server (e.g. 192.168.x.x) needs the local-network permission on Android 16+, or the
+      // status probe below silently times out. Prompt lazily now that a private address is present.
+      localNetworkPermission.requestIfNeeded(serverUrl)
 
       authRepository.status(serverUrl, networkSettings)
         .onSuccess { status ->

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomePresenter.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/welcome/WelcomePresenter.kt
@@ -6,6 +6,7 @@ import app.campfire.auth.ui.login.LoginPresenter
 import app.campfire.common.screens.LoginScreen
 import app.campfire.common.screens.WelcomeScreen
 import app.campfire.core.di.UserScope
+import app.campfire.core.permission.LocalNetworkPermissionController
 import app.campfire.network.oidc.AuthorizationFlow
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
@@ -18,6 +19,7 @@ import me.tatarka.inject.annotations.Inject
 class WelcomePresenter(
   private val authRepository: AuthRepository,
   private val oauthAuthorizationFlow: AuthorizationFlow,
+  private val localNetworkPermission: LocalNetworkPermissionController,
   @Assisted private val navigator: Navigator,
 ) : Presenter<WelcomeUiState> {
 
@@ -26,6 +28,7 @@ class WelcomePresenter(
     navigator = navigator,
     authRepository = authRepository,
     oauthAuthorizationFlow = oauthAuthorizationFlow,
+    localNetworkPermission = localNetworkPermission,
   )
 
   @Composable


### PR DESCRIPTION
Closes #876

## Problem

On Android 16+ (the reporter is on "Android 17" / API 37), Campfire couldn't reach a self-hosted Audiobookshelf server on the local network (`http://192.168.1.202:13378`), and locally-stored books wouldn't start playing (spinning play button).

Root cause: **Android's Local Network Protection (LNP)**. Bumping `targetSdk` to 36+ opts the app into LNP, which gates access to private IP ranges behind the runtime `android.permission.ACCESS_LOCAL_NETWORK` (`prot=dangerous`). The app never declared or requested it, so the OS **silently dropped every connection to `192.168.x.x`** → a 10s `ConnectTimeoutException`. This blackholed the login "cannot see server" probe, session sync, and starting a playback session — while the browser (exempt from per-app LNP) reached the server fine, which is the tell.

Diagnosed on-device: `failed to connect to /192.168.1.202 (port 13378) ... after 10000ms`, with `cmd appops get <pkg> ACCESS_LOCAL_NETWORK` reporting `ignore`.

## Fix

- **Declare** `ACCESS_LOCAL_NETWORK` in the Android manifest.
- **Multiplatform controller**: `LocalNetworkPermissionController` + `isPrivateNetworkAddress()` in `:core`. Android impl requests the permission **lazily** — only for private/LAN hosts, only on SDK 36+, once per session — via an activity-registered `RequestPermission` launcher. No-op impls for desktop/iOS.
- **Prompt at the right moment** (not on cold start): `LoginPresenter` requests right before the `/status` probe when a LAN address is entered, so users connecting to a **remote** server are never asked.
- **Upgrade path**: a user already signed in to a LAN server before the app targeted Android 16+ never passes through login, so `MainActivity` requests on launch once the session restores to a logged-in private server URL.

Also included (surfaced during diagnosis, kept as hardening):
- `HttpTimeout` on the base Ktor client so requests fail fast instead of hanging at the engine default (this is what turned the infinite hang into a diagnosable 10s error).
- Gate the debug `LivewireNetworkPlugin` (a full-response-body `ResponseObserver`) to debug builds so it never ships on release.
- Route the login `status()` probe through `cleanServerUrl` for scheme consistency with `login()`.

## Verification

- **Android** (Pixel 9 Pro Fold, API 37): the exact failing URL now returns `RESPONSE: 200 OK`. Confirmed the deferred login prompt fires on entering a LAN address, and the upgrade prompt fires on launch for an already-signed-in LAN session. No prompt for remote servers / logged-out state.
- **Desktop (JVM)**: DI merge (`kspKotlin`) + compile pass with the no-op binding.
- Added unit tests for `isPrivateNetworkAddress` (RFC1918, loopback, link-local, IPv6 ULA, `.local`, userinfo, public hosts).
- iOS not built in this pass (relies on its own `NSLocalNetworkUsageDescription` prompt; no-op impl mirrors the validated JVM one).

## Notes

- The playback "spinning" symptom is very likely the same LAN blackhole (starting a play session POSTs to the server, which was timing out) but I have not independently reproduced/confirmed the playback path — feedback welcome.
- `:core` doesn't run the kimchi KSP processor, so only the plain interface + util live there; the per-platform `@ContributesBinding` impls live in `app/android` and `app/common` (mirroring the existing `AppLifecycleObserver` pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)