### PR TITLE
Add list/grid display toggle to Collections & Playlists screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- List/grid display toggle for the Series, Collections, and Playlists screens, remembered independently per screen
+- New grid-style collection card with a dynamic cover mosaic (adapts to 1–4+ items) for the grid layout
+
 ### Changed
+
+- Collection, series, and playlist cards now show an item-count badge in the corner of the cover
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- List/grid display toggle for the Series, Collections, and Playlists screens, remembered independently per screen
-- New grid-style collection card with a dynamic cover mosaic (adapts to 1–4+ items) for the grid layout
+- List/grid display toggle for the Series, Collections, and Playlists screens
 
 ### Changed
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/FilterBar.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/FilterBar.kt
@@ -48,10 +48,10 @@ private val FilterBarHeight = 56.dp
 fun FilterBar(
   count: @Composable () -> Unit,
   itemDisplayState: ItemDisplayState,
-  sortMode: ContentSortMode,
-  sortDirection: SortDirection,
-  onSortClick: () -> Unit,
   modifier: Modifier = Modifier,
+  sortMode: ContentSortMode? = null,
+  sortDirection: SortDirection = SortDirection.Ascending,
+  onSortClick: (() -> Unit)? = null,
   onDisplayStateClick: (() -> Unit)? = null,
   isFiltered: Boolean = false,
   onFilterClick: (() -> Unit)? = null,
@@ -96,12 +96,14 @@ fun FilterBar(
 
       Spacer(Modifier.weight(1f))
 
-      SortIconButton(
-        sortMode = sortMode,
-        sortDirection = sortDirection,
-        onClick = onSortClick,
-        modifier = Modifier.offset(x = 12.dp),
-      )
+      if (sortMode != null && onSortClick != null) {
+        SortIconButton(
+          sortMode = sortMode,
+          sortDirection = sortDirection,
+          onClick = onSortClick,
+          modifier = Modifier.offset(x = 12.dp),
+        )
+      }
 
       if (onFilterClick != null) {
         val filterLabel = stringResource(Res.string.action_filter)

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/ItemCollectionCard.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/ItemCollectionCard.kt
@@ -3,6 +3,7 @@ package app.campfire.common.compose.widgets
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +16,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.Layout
@@ -76,16 +78,25 @@ fun ItemCollectionCard(
     onClick = onClick,
     colors = colors,
   ) {
-    MultiBookLayout(
-      items = items,
-      sharedTransitionKeyModifier = name,
-      itemSize = itemSize,
-      modifier = Modifier
-        .background(MaterialTheme.colorScheme.primaryContainer)
-        .defaultMinSize(minHeight = BookImageSize)
-        .fillMaxWidth()
-        .clip(RoundedCornerShape(BookCornerSize)),
-    )
+    Box {
+      MultiBookLayout(
+        items = items,
+        sharedTransitionKeyModifier = name,
+        itemSize = itemSize,
+        modifier = Modifier
+          .background(MaterialTheme.colorScheme.primaryContainer)
+          .defaultMinSize(minHeight = BookImageSize)
+          .fillMaxWidth()
+          .clip(RoundedCornerShape(BookCornerSize)),
+      )
+
+      CollectionCountBadge(
+        count = items.size,
+        modifier = Modifier
+          .align(Alignment.TopEnd)
+          .padding(8.dp),
+      )
+    }
 
     Column(
       Modifier.padding(

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/ItemCollectionGridCard.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/ItemCollectionGridCard.kt
@@ -1,0 +1,392 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class)
+
+package app.campfire.common.compose.widgets
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.extensions.thenIf
+import app.campfire.common.compose.extensions.thenIfNotNull
+import app.campfire.core.model.LibraryItem
+import campfire.common.compose.generated.resources.Res
+import campfire.common.compose.generated.resources.filter_bar_book_count
+import campfire.common.compose.generated.resources.placeholder_book
+import coil3.compose.rememberAsyncImagePainter
+import com.slack.circuit.sharedelements.SharedElementTransitionScope
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.pluralStringResource
+
+private val CardMaxWidth = 400.dp
+private val MosaicGap = 2.dp
+
+/** Maximum number of covers rendered within the [CollectionCoverStyle.Mosaic] cover. */
+const val MaxMosaicCovers = 4
+
+/**
+ * How the cover art for an [ItemCollectionGridCard] is rendered.
+ */
+enum class CollectionCoverStyle {
+  /**
+   * A dynamic mosaic of up to [MaxMosaicCovers] covers that adapts its layout to the number
+   * of items (1 = single, 2 = split, 3 = feature + stack, 4+ = 2x2 grid).
+   */
+  Mosaic,
+
+  /**
+   * A single cover using the first item in the collection, matching [LibraryItemCard].
+   */
+  FirstItem,
+}
+
+/**
+ * A grid-friendly variant of [ItemCollectionCard] for representing a collection, series, or playlist
+ * as a single square card, visually consistent with [LibraryItemCard] but able to gracefully
+ * represent the multiple items contained within it.
+ *
+ * A count badge is drawn in the corner of the cover whenever the collection holds more than one item.
+ *
+ * @param name the collection's display name, shown as the card title.
+ * @param items the items contained in the collection; their covers drive the cover art.
+ * @param onClick invoked when the card is tapped.
+ * @param subtitle an optional secondary line; when null a "N Books" count label is shown instead.
+ * @param coverStyle whether to render a dynamic [CollectionCoverStyle.Mosaic] of covers or just the
+ *   [CollectionCoverStyle.FirstItem] cover.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ItemCollectionGridCard(
+  name: String,
+  items: List<LibraryItem>,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  subtitle: String? = null,
+  sharedTransitionKey: String = name,
+  coverStyle: CollectionCoverStyle = CollectionCoverStyle.Mosaic,
+  marqueeEnabled: Boolean = LocalItemCardMarquee.current,
+  showInformation: Boolean = true,
+  shape: Shape = MaterialTheme.shapes.largeIncreased,
+  colors: CardColors = CardDefaults.elevatedCardColors(
+    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+  ),
+) = SharedElementTransitionScope {
+  val animationScope = findAnimatedScope(SharedElementTransitionScope.AnimatedScope.Navigation)
+
+  ElevatedContentCard(
+    modifier = modifier
+      .thenIfNotNull(animationScope) { scope ->
+        sharedBounds(
+          sharedContentState = rememberSharedContentState(
+            ItemCollectionSharedTransitionKey(
+              id = sharedTransitionKey,
+              type = ItemCollectionSharedTransitionKey.ElementType.Bounds,
+            ),
+          ),
+          animatedVisibilityScope = scope,
+        )
+      },
+    onClick = onClick,
+    colors = colors,
+    shape = shape,
+  ) {
+    Box(
+      modifier = Modifier
+        .aspectRatio(1f)
+        .fillMaxWidth()
+        .widthIn(max = CardMaxWidth)
+        .clip(shape),
+    ) {
+      when (coverStyle) {
+        CollectionCoverStyle.Mosaic -> MosaicCover(
+          items = items,
+          sharedTransitionKeyModifier = sharedTransitionKey,
+          modifier = Modifier.fillMaxSize(),
+        )
+        CollectionCoverStyle.FirstItem -> FirstItemCover(
+          item = items.firstOrNull(),
+          sharedTransitionKeyModifier = sharedTransitionKey,
+          modifier = Modifier.fillMaxSize(),
+        )
+      }
+
+      CollectionCountBadge(
+        count = items.size,
+        modifier = Modifier
+          .align(Alignment.TopEnd)
+          .padding(8.dp),
+      )
+    }
+
+    if (showInformation) {
+      ItemCollectionInformation(
+        title = name,
+        subtitle = subtitle,
+        itemCount = items.size,
+        sharedTransitionKey = sharedTransitionKey,
+        marqueeEnabled = marqueeEnabled,
+      )
+    }
+  }
+}
+
+@Composable
+internal fun BoxScope.CollectionCountBadge(
+  count: Int,
+  modifier: Modifier = Modifier,
+) {
+  if (count <= 1) return
+
+  Box(
+    modifier = modifier
+      .clip(CircleShape)
+      .background(color = MaterialTheme.colorScheme.scrim.copy(0.68f))
+      .defaultMinSize(minWidth = 24.dp, minHeight = 24.dp)
+      .padding(horizontal = 8.dp, vertical = 4.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(
+      text = "$count",
+      style = MaterialTheme.typography.labelMedium,
+      color = Color.White,
+    )
+  }
+}
+
+@Composable
+private fun FirstItemCover(
+  item: LibraryItem?,
+  sharedTransitionKeyModifier: String,
+  modifier: Modifier = Modifier,
+) = SharedElementTransitionScope {
+  val animationScope = findAnimatedScope(SharedElementTransitionScope.AnimatedScope.Navigation)
+
+  CoverCell(
+    imageUrl = item?.media?.coverImageUrl,
+    contentDescription = item?.media?.metadata?.title,
+    modifier = modifier,
+    sharedElementModifier = Modifier
+      .thenIfNotNull(item?.let { animationScope }) { scope ->
+        sharedElement(
+          sharedContentState = rememberSharedContentState(
+            LibraryItemSharedTransitionKey(
+              id = item!!.id + sharedTransitionKeyModifier,
+              type = LibraryItemSharedTransitionKey.ElementType.Image,
+            ),
+          ),
+          animatedVisibilityScope = scope,
+        )
+      },
+  )
+}
+
+@Composable
+private fun MosaicCover(
+  items: List<LibraryItem>,
+  sharedTransitionKeyModifier: String,
+  modifier: Modifier = Modifier,
+) {
+  val covers = remember(items) { items.take(MaxMosaicCovers) }
+
+  when (covers.size) {
+    0 -> CoverCell(imageUrl = null, contentDescription = null, modifier = modifier)
+    1 -> MosaicCell(covers[0], sharedTransitionKeyModifier, modifier = modifier)
+    2 -> Row(
+      modifier = modifier,
+      horizontalArrangement = Arrangement.spacedBy(MosaicGap),
+    ) {
+      covers.forEach { item ->
+        MosaicCell(
+          item = item,
+          sharedTransitionKeyModifier = sharedTransitionKeyModifier,
+          modifier = Modifier
+            .weight(1f)
+            .fillMaxHeight(),
+        )
+      }
+    }
+    3 -> Row(
+      modifier = modifier,
+      horizontalArrangement = Arrangement.spacedBy(MosaicGap),
+    ) {
+      // Feature the first cover on the left, stack the remaining two on the right
+      MosaicCell(
+        item = covers[0],
+        sharedTransitionKeyModifier = sharedTransitionKeyModifier,
+        modifier = Modifier
+          .weight(1f)
+          .fillMaxHeight(),
+      )
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(MosaicGap),
+      ) {
+        covers.drop(1).forEach { item ->
+          MosaicCell(
+            item = item,
+            sharedTransitionKeyModifier = sharedTransitionKeyModifier,
+            modifier = Modifier
+              .weight(1f)
+              .fillMaxWidth(),
+          )
+        }
+      }
+    }
+    else -> Column(
+      modifier = modifier,
+      verticalArrangement = Arrangement.spacedBy(MosaicGap),
+    ) {
+      // 2x2 grid
+      for (rowIndex in 0 until 2) {
+        Row(
+          modifier = Modifier.weight(1f),
+          horizontalArrangement = Arrangement.spacedBy(MosaicGap),
+        ) {
+          for (columnIndex in 0 until 2) {
+            val item = covers[rowIndex * 2 + columnIndex]
+            MosaicCell(
+              item = item,
+              sharedTransitionKeyModifier = sharedTransitionKeyModifier,
+              modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun MosaicCell(
+  item: LibraryItem,
+  sharedTransitionKeyModifier: String,
+  modifier: Modifier = Modifier,
+) = SharedElementTransitionScope {
+  val animationScope = findAnimatedScope(SharedElementTransitionScope.AnimatedScope.Navigation)
+
+  CoverCell(
+    imageUrl = item.media.coverImageUrl,
+    contentDescription = item.media.metadata.title,
+    modifier = modifier,
+    sharedElementModifier = Modifier
+      .thenIfNotNull(animationScope) { scope ->
+        sharedElement(
+          sharedContentState = rememberSharedContentState(
+            LibraryItemSharedTransitionKey(
+              id = item.id + sharedTransitionKeyModifier,
+              type = LibraryItemSharedTransitionKey.ElementType.Image,
+            ),
+          ),
+          animatedVisibilityScope = scope,
+        )
+      },
+  )
+}
+
+@Composable
+private fun CoverCell(
+  imageUrl: String?,
+  contentDescription: String?,
+  modifier: Modifier = Modifier,
+  sharedElementModifier: Modifier = Modifier,
+) {
+  Box(
+    modifier = modifier.background(MaterialTheme.colorScheme.primaryContainer),
+  ) {
+    val painter = key(imageUrl) {
+      rememberAsyncImagePainter(
+        model = imageUrl,
+        error = painterResource(Res.drawable.placeholder_book),
+      )
+    }
+
+    Image(
+      painter = painter,
+      contentDescription = contentDescription,
+      contentScale = ContentScale.Crop,
+      modifier = sharedElementModifier.fillMaxSize(),
+    )
+  }
+}
+
+@Composable
+private fun ItemCollectionInformation(
+  title: String,
+  subtitle: String?,
+  itemCount: Int,
+  sharedTransitionKey: String,
+  modifier: Modifier = Modifier,
+  marqueeEnabled: Boolean = true,
+) = SharedElementTransitionScope {
+  val animationScope = findAnimatedScope(SharedElementTransitionScope.AnimatedScope.Navigation)
+
+  Column(
+    modifier.padding(vertical = 16.dp),
+  ) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.titleSmall,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+      modifier = Modifier
+        .thenIfNotNull(animationScope) { scope ->
+          sharedBounds(
+            sharedContentState = rememberSharedContentState(
+              ItemCollectionSharedTransitionKey(
+                id = sharedTransitionKey,
+                type = ItemCollectionSharedTransitionKey.ElementType.Title,
+              ),
+            ),
+            animatedVisibilityScope = scope,
+          )
+        }
+        .thenIf(marqueeEnabled) {
+          basicMarquee()
+        }
+        .padding(horizontal = 16.dp),
+    )
+
+    Text(
+      text = subtitle
+        ?: pluralStringResource(Res.plurals.filter_bar_book_count, itemCount, itemCount),
+      style = MaterialTheme.typography.bodySmall,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+      modifier = Modifier
+        .thenIf(marqueeEnabled) {
+          basicMarquee()
+        }
+        .padding(horizontal = 16.dp),
+    )
+  }
+}

--- a/core/src/commonMain/kotlin/app/campfire/core/settings/GroupDisplayState.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/settings/GroupDisplayState.kt
@@ -1,0 +1,20 @@
+package app.campfire.core.settings
+
+enum class GroupDisplayState(override val storageKey: String) : EnumSetting {
+  List("list"),
+  Grid("grid"),
+  ;
+
+  fun next(): GroupDisplayState = when (this) {
+    List -> Grid
+    Grid -> List
+  }
+
+  companion object : EnumSettingProvider<GroupDisplayState> {
+    val Default get() = List
+
+    override fun fromStorageKey(key: String?): GroupDisplayState {
+      return entries.find { it.storageKey == key } ?: Default
+    }
+  }
+}

--- a/features/collections/ui/src/commonMain/composeResources/values/collection_ui_strings.xml
+++ b/features/collections/ui/src/commonMain/composeResources/values/collection_ui_strings.xml
@@ -1,6 +1,11 @@
 <resources>
   <string name="collections_title">Collections</string>
 
+  <plurals name="filter_bar_collection_count">
+    <item quantity="one">%1$d Collection</item>
+    <item quantity="other">%1$d Collections</item>
+  </plurals>
+
   <string name="error_collection_items_message">Something went wrong when trying to load this library's collections</string>
   <string name="empty_collection_items_message">Doesn't look like you have any collections. Try adding one now!</string>
   <string name="error_collection_detail_message">Something went wrong when trying to load this collection</string>

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsPresenter.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsPresenter.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import app.campfire.analytics.Analytics
+import app.campfire.analytics.events.ActionEvent
 import app.campfire.analytics.events.ContentSelected
 import app.campfire.analytics.events.ContentType
 import app.campfire.collections.api.CollectionsRepository
@@ -13,6 +14,7 @@ import app.campfire.common.screens.CollectionsScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.Collection
+import app.campfire.settings.api.CampfireSettings
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.foundation.NonPausablePresenter
 import com.slack.circuit.runtime.Navigator
@@ -26,6 +28,7 @@ import me.tatarka.inject.annotations.Inject
 class CollectionsPresenter(
   @Assisted private val navigator: Navigator,
   private val repository: CollectionsRepository,
+  private val settings: CampfireSettings,
   private val analytics: Analytics,
 ) : NonPausablePresenter<CollectionsUiState> {
 
@@ -38,11 +41,21 @@ class CollectionsPresenter(
         .catch<LoadState<out List<Collection>>> { emit(LoadState.Error) }
     }.collectAsState(LoadState.Loading)
 
+    val displayState by remember {
+      settings.observeCollectionsDisplayState()
+    }.collectAsState()
+
     return CollectionsUiState(
       collectionContentState = collectionContentState,
+      displayState = displayState,
     ) { event ->
       when (event) {
         CollectionsUiEvent.Back -> navigator.pop()
+
+        CollectionsUiEvent.ToggleDisplayState -> {
+          analytics.send(ActionEvent("collections_display_state", "toggle"))
+          settings.collectionsDisplayState = displayState.next()
+        }
 
         is CollectionsUiEvent.CollectionClick -> {
           analytics.send(ContentSelected(ContentType.Collection))

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUi.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUi.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -20,26 +20,34 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.extensions.plus
+import app.campfire.common.compose.layout.DefaultAdaptiveColumnSize
 import app.campfire.common.compose.layout.LargeAdaptiveColumnSize
 import app.campfire.common.compose.layout.LazyCampfireGrid
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.FilterBar
 import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemCollectionCard
+import app.campfire.common.compose.widgets.ItemCollectionGridCard
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.screens.CollectionsScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.Collection
+import app.campfire.core.settings.GroupDisplayState
+import app.campfire.core.settings.ItemDisplayState
 import campfire.features.collections.ui.generated.resources.Res
 import campfire.features.collections.ui.generated.resources.action_back
 import campfire.features.collections.ui.generated.resources.collections_title
 import campfire.features.collections.ui.generated.resources.empty_collection_items_message
 import campfire.features.collections.ui.generated.resources.error_collection_items_message
+import campfire.features.collections.ui.generated.resources.filter_bar_collection_count
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 
 @CircuitInject(CollectionsScreen::class, UserScope::class)
@@ -79,7 +87,9 @@ fun Collections(
 
       is LoadState.Loaded -> LoadedState(
         items = state.collectionContentState.data,
+        displayState = state.displayState,
         onCollectionClick = { state.eventSink(CollectionsUiEvent.CollectionClick(it)) },
+        onToggleDisplayState = { state.eventSink(CollectionsUiEvent.ToggleDisplayState) },
         contentPadding = paddingValues,
         state = gridState,
       )
@@ -90,38 +100,73 @@ fun Collections(
 @Composable
 private fun LoadedState(
   items: List<Collection>,
+  displayState: GroupDisplayState,
   onCollectionClick: (Collection) -> Unit,
+  onToggleDisplayState: () -> Unit,
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = PaddingValues(),
   state: LazyGridState = rememberLazyGridState(),
 ) {
+  val adaptiveColumnSize: Dp = when (displayState) {
+    GroupDisplayState.List -> LargeAdaptiveColumnSize
+    GroupDisplayState.Grid -> DefaultAdaptiveColumnSize
+  }
+
   Box(
     modifier = modifier.fillMaxSize(),
   ) {
     LazyCampfireGrid(
-      columns = GridCells.Adaptive(LargeAdaptiveColumnSize),
+      columns = GridCells.Adaptive(adaptiveColumnSize),
       state = state,
       contentPadding = contentPadding +
-        PaddingValues(ContentPadding) +
+        PaddingValues(horizontal = ContentPadding) +
         PaddingValues(bottom = FabBottomOffset),
       verticalArrangement = Arrangement.spacedBy(8.dp),
       horizontalArrangement = Arrangement.spacedBy(8.dp),
       modifier = Modifier.fillMaxSize(),
     ) {
-      items(
-        items = items,
-        key = { it.id },
-      ) { collection ->
-        ItemCollectionCard(
-          sharedTransitionKey = collection.id,
-          name = collection.name,
-          description = collection.description,
-          items = collection.books,
-          onClick = { onCollectionClick(collection) },
-          modifier = Modifier
-            .fillMaxWidth()
-            .animateItem(),
+      item(
+        span = { GridItemSpan(maxLineSpan) },
+        key = "filter-bar",
+      ) {
+        FilterBar(
+          count = {
+            Text(pluralStringResource(Res.plurals.filter_bar_collection_count, items.size, items.size))
+          },
+          itemDisplayState = when (displayState) {
+            GroupDisplayState.List -> ItemDisplayState.List
+            GroupDisplayState.Grid -> ItemDisplayState.Grid
+          },
+          onDisplayStateClick = onToggleDisplayState,
         )
+      }
+
+      items(
+        count = items.size,
+        key = { items[it].id },
+      ) { index ->
+        val collection = items[index]
+        when (displayState) {
+          GroupDisplayState.List -> ItemCollectionCard(
+            sharedTransitionKey = collection.id,
+            name = collection.name,
+            description = collection.description,
+            items = collection.books,
+            onClick = { onCollectionClick(collection) },
+            modifier = Modifier
+              .fillMaxWidth()
+              .animateItem(),
+          )
+          GroupDisplayState.Grid -> ItemCollectionGridCard(
+            sharedTransitionKey = collection.id,
+            name = collection.name,
+            items = collection.books,
+            onClick = { onCollectionClick(collection) },
+            modifier = Modifier
+              .fillMaxWidth()
+              .animateItem(),
+          )
+        }
       }
     }
 

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUiState.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUiState.kt
@@ -2,15 +2,18 @@ package app.campfire.collections.ui.list
 
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.Collection
+import app.campfire.core.settings.GroupDisplayState
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 
 data class CollectionsUiState(
   val collectionContentState: LoadState<out List<Collection>>,
+  val displayState: GroupDisplayState,
   val eventSink: (CollectionsUiEvent) -> Unit,
 ) : CircuitUiState
 
 sealed interface CollectionsUiEvent : CircuitUiEvent {
   data object Back : CollectionsUiEvent
+  data object ToggleDisplayState : CollectionsUiEvent
   data class CollectionClick(val collection: Collection) : CollectionsUiEvent
 }

--- a/features/playlists/ui/src/commonMain/composeResources/values/playlists_ui_strings.xml
+++ b/features/playlists/ui/src/commonMain/composeResources/values/playlists_ui_strings.xml
@@ -1,5 +1,10 @@
 <resources>
   <string name="playlists_title">Playlists</string>
+
+  <plurals name="filter_bar_playlist_count">
+    <item quantity="one">%1$d Playlist</item>
+    <item quantity="other">%1$d Playlists</item>
+  </plurals>
   <string name="empty_playlists_message">Doesn't look like you have any playlists. Try adding one now!</string>
   <string name="error_playlists_message">Something went wrong when trying to load this library's playlists</string>
   <string name="empty_playlist_detail_message">No items in this playlist, go add some!</string>

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/list/PlaylistsPresenter.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/list/PlaylistsPresenter.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import app.campfire.analytics.Analytics
+import app.campfire.analytics.events.ActionEvent
 import app.campfire.analytics.events.ContentSelected
 import app.campfire.analytics.events.ContentType
 import app.campfire.core.coroutines.LoadState
@@ -13,6 +14,7 @@ import app.campfire.core.model.Playlist
 import app.campfire.playlists.api.PlaylistsRepository
 import app.campfire.playlists.api.screen.PlaylistDetailScreen
 import app.campfire.playlists.api.screen.PlaylistsScreen
+import app.campfire.settings.api.CampfireSettings
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.foundation.NonPausablePresenter
 import com.slack.circuit.runtime.Navigator
@@ -26,6 +28,7 @@ import me.tatarka.inject.annotations.Inject
 class PlaylistsPresenter(
   @Assisted private val navigator: Navigator,
   private val playlistsRepository: PlaylistsRepository,
+  private val settings: CampfireSettings,
   private val analytics: Analytics,
 ) : NonPausablePresenter<PlaylistsUiState> {
 
@@ -37,11 +40,21 @@ class PlaylistsPresenter(
         .catch<LoadState<out List<Playlist>>> { emit(LoadState.Error) }
     }.collectAsState(LoadState.Loading)
 
+    val displayState by remember {
+      settings.observePlaylistsDisplayState()
+    }.collectAsState()
+
     return PlaylistsUiState(
       playlistContentState = playlistContentState,
+      displayState = displayState,
     ) { event ->
       when (event) {
         PlaylistsUiEvent.Back -> navigator.pop()
+
+        PlaylistsUiEvent.ToggleDisplayState -> {
+          analytics.send(ActionEvent("playlists_display_state", "toggle"))
+          settings.playlistsDisplayState = displayState.next()
+        }
 
         is PlaylistsUiEvent.PlaylistClick -> {
           analytics.send(ContentSelected(ContentType.Collection))

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/list/PlaylistsUi.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/list/PlaylistsUi.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
@@ -33,15 +33,20 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.extensions.plus
+import app.campfire.common.compose.layout.DefaultAdaptiveColumnSize
 import app.campfire.common.compose.layout.LargeAdaptiveColumnSize
 import app.campfire.common.compose.layout.LazyCampfireGrid
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.ErrorListState
+import app.campfire.common.compose.widgets.FilterBar
 import app.campfire.common.compose.widgets.ItemCollectionCard
+import app.campfire.common.compose.widgets.ItemCollectionGridCard
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.Playlist
+import app.campfire.core.settings.GroupDisplayState
+import app.campfire.core.settings.ItemDisplayState
 import app.campfire.playlists.api.screen.PlaylistsScreen
 import app.campfire.playlists.ui.sheets.EditPlaylistResult
 import app.campfire.playlists.ui.sheets.showEditPlaylistBottomSheet
@@ -51,9 +56,11 @@ import app.campfire.ui.navigation.bar.CampfireNavigationBarWindowInsets
 import campfire.features.playlists.ui.generated.resources.Res
 import campfire.features.playlists.ui.generated.resources.empty_playlists_message
 import campfire.features.playlists.ui.generated.resources.error_playlists_message
+import campfire.features.playlists.ui.generated.resources.filter_bar_playlist_count
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.overlay.LocalOverlayHost
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -116,7 +123,9 @@ fun Playlists(
 
       is LoadState.Loaded -> LoadedState(
         items = state.playlistContentState.data,
+        displayState = state.displayState,
         onPlaylistClick = { state.eventSink(PlaylistsUiEvent.PlaylistClick(it)) },
+        onToggleDisplayState = { state.eventSink(PlaylistsUiEvent.ToggleDisplayState) },
         contentPadding = paddingValues,
         state = gridState,
       )
@@ -127,38 +136,73 @@ fun Playlists(
 @Composable
 private fun LoadedState(
   items: List<Playlist>,
+  displayState: GroupDisplayState,
   onPlaylistClick: (Playlist) -> Unit,
+  onToggleDisplayState: () -> Unit,
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = PaddingValues(),
   state: LazyGridState = rememberLazyGridState(),
 ) {
+  val adaptiveColumnSize = when (displayState) {
+    GroupDisplayState.List -> LargeAdaptiveColumnSize
+    GroupDisplayState.Grid -> DefaultAdaptiveColumnSize
+  }
+
   Box(
     modifier = modifier.fillMaxSize(),
   ) {
     LazyCampfireGrid(
-      columns = GridCells.Adaptive(LargeAdaptiveColumnSize),
+      columns = GridCells.Adaptive(adaptiveColumnSize),
       state = state,
       contentPadding = contentPadding +
-        PaddingValues(ContentPadding) +
+        PaddingValues(horizontal = ContentPadding) +
         PaddingValues(bottom = FabBottomOffset),
       verticalArrangement = Arrangement.spacedBy(8.dp),
       horizontalArrangement = Arrangement.spacedBy(8.dp),
       modifier = Modifier.fillMaxSize(),
     ) {
-      items(
-        items = items,
-        key = { it.id },
-      ) { playlist ->
-        ItemCollectionCard(
-          sharedTransitionKey = playlist.id,
-          name = playlist.name,
-          description = playlist.description,
-          items = playlist.items.map { it.libraryItem },
-          onClick = { onPlaylistClick(playlist) },
-          modifier = Modifier
-            .fillMaxWidth()
-            .animateItem(),
+      item(
+        span = { GridItemSpan(maxLineSpan) },
+        key = "filter-bar",
+      ) {
+        FilterBar(
+          count = {
+            Text(pluralStringResource(Res.plurals.filter_bar_playlist_count, items.size, items.size))
+          },
+          itemDisplayState = when (displayState) {
+            GroupDisplayState.List -> ItemDisplayState.List
+            GroupDisplayState.Grid -> ItemDisplayState.Grid
+          },
+          onDisplayStateClick = onToggleDisplayState,
         )
+      }
+
+      items(
+        count = items.size,
+        key = { items[it].id },
+      ) { index ->
+        val playlist = items[index]
+        when (displayState) {
+          GroupDisplayState.List -> ItemCollectionCard(
+            sharedTransitionKey = playlist.id,
+            name = playlist.name,
+            description = playlist.description,
+            items = playlist.items.map { it.libraryItem },
+            onClick = { onPlaylistClick(playlist) },
+            modifier = Modifier
+              .fillMaxWidth()
+              .animateItem(),
+          )
+          GroupDisplayState.Grid -> ItemCollectionGridCard(
+            sharedTransitionKey = playlist.id,
+            name = playlist.name,
+            items = playlist.items.map { it.libraryItem },
+            onClick = { onPlaylistClick(playlist) },
+            modifier = Modifier
+              .fillMaxWidth()
+              .animateItem(),
+          )
+        }
       }
     }
 

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/list/PlaylistsUiState.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/list/PlaylistsUiState.kt
@@ -3,16 +3,19 @@ package app.campfire.playlists.ui.list
 import androidx.compose.runtime.Stable
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.Playlist
+import app.campfire.core.settings.GroupDisplayState
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 
 @Stable
 data class PlaylistsUiState(
   val playlistContentState: LoadState<out List<Playlist>>,
+  val displayState: GroupDisplayState,
   val eventSink: (PlaylistsUiEvent) -> Unit,
 ) : CircuitUiState
 
 sealed interface PlaylistsUiEvent : CircuitUiEvent {
   data object Back : PlaylistsUiEvent
+  data object ToggleDisplayState : PlaylistsUiEvent
   data class PlaylistClick(val playlist: Playlist) : PlaylistsUiEvent
 }

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/list/SeriesPresenter.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/list/SeriesPresenter.kt
@@ -63,6 +63,10 @@ class SeriesPresenter(
       settings.observeSeriesSortDirection()
     }.collectAsState()
 
+    val displayState by remember {
+      settings.observeSeriesDisplayState()
+    }.collectAsState()
+
     val currentUser by userRepository.userFlow.collectAsState()
 
     val lazyPagingItems = rememberRetained(
@@ -94,6 +98,7 @@ class SeriesPresenter(
       filter = filter,
       sortMode = sortMode,
       sortDirection = sortDirection,
+      displayState = displayState,
     ) { event ->
       when (event) {
         is SeriesUiEvent.SeriesClicked -> {
@@ -112,6 +117,11 @@ class SeriesPresenter(
             settings.seriesSortDirection = sortDirection.flip()
           }
           settings.seriesSortMode = event.mode
+        }
+
+        SeriesUiEvent.ToggleDisplayState -> {
+          analytics.send(ActionEvent("series_display_state", "toggle"))
+          settings.seriesDisplayState = displayState.next()
         }
       }
     }

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/list/SeriesUi.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/list/SeriesUi.kt
@@ -5,11 +5,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.exclude
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridItemScope
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.Scaffold
@@ -19,22 +19,27 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.extensions.plus
+import app.campfire.common.compose.layout.DefaultAdaptiveColumnSize
 import app.campfire.common.compose.layout.LargeAdaptiveColumnSize
 import app.campfire.common.compose.layout.LazyCampfireGrid
 import app.campfire.common.compose.widgets.ContentPagingScaffold
+import app.campfire.common.compose.widgets.ContentPagingScaffoldScope
 import app.campfire.common.compose.widgets.FilterBar
 import app.campfire.common.compose.widgets.ItemCollectionCard
+import app.campfire.common.compose.widgets.ItemCollectionGridCard
 import app.campfire.common.screens.SeriesScreen
 import app.campfire.core.di.UserScope
 import app.campfire.core.filter.ContentFilter
 import app.campfire.core.model.Series
 import app.campfire.core.settings.ContentSortMode
+import app.campfire.core.settings.GroupDisplayState
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SeriesSortModes
 import app.campfire.core.settings.SortDirection
@@ -85,6 +90,7 @@ fun Series(
       filter = state.filter,
       sortMode = state.sortMode,
       sortDirection = state.sortDirection,
+      displayState = state.displayState,
       onSeriesClick = { state.eventSink(SeriesUiEvent.SeriesClicked(it)) },
       onFilterClick = {
         scope.launch {
@@ -111,6 +117,9 @@ fun Series(
           }
         }
       },
+      onDisplayStateClick = {
+        state.eventSink(SeriesUiEvent.ToggleDisplayState)
+      },
       contentPadding = paddingValues,
     )
   }
@@ -124,9 +133,11 @@ private fun LoadedState(
   filter: ContentFilter?,
   sortMode: ContentSortMode,
   sortDirection: SortDirection,
+  displayState: GroupDisplayState,
   onSeriesClick: (Series) -> Unit,
   onFilterClick: () -> Unit,
   onSortClick: () -> Unit,
+  onDisplayStateClick: () -> Unit,
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = PaddingValues(),
   state: LazyGridState = rememberLazyGridState(),
@@ -137,46 +148,29 @@ private fun LoadedState(
     emptyMessage = stringResource(Res.string.empty_series_items_message),
     indicatorPadding = contentPadding.calculateTopPadding(),
   ) {
-    LazyCampfireGrid(
-      columns = GridCells.Adaptive(LargeAdaptiveColumnSize),
+    SeriesGrid(
+      totalCount = totalCount,
+      lazyPagingItems = lazyPagingItems,
+      filter = filter,
+      sortMode = sortMode,
+      sortDirection = sortDirection,
+      filterBarDisplayState = when (displayState) {
+        GroupDisplayState.List -> ItemDisplayState.List
+        GroupDisplayState.Grid -> ItemDisplayState.Grid
+      },
+      onFilterClick = onFilterClick,
+      onSortClick = onSortClick,
+      onDisplayStateClick = onDisplayStateClick,
+      modifier = modifier,
+      contentPadding = contentPadding,
+      adaptiveColumnSize = when (displayState) {
+        GroupDisplayState.List -> LargeAdaptiveColumnSize
+        GroupDisplayState.Grid -> DefaultAdaptiveColumnSize
+      },
       state = state,
-      contentPadding = contentPadding + PaddingValues(horizontal = ContentPadding),
-      modifier = Modifier.fillMaxSize(),
-      verticalArrangement = Arrangement.spacedBy(8.dp),
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-      item(
-        span = { GridItemSpan(this.maxLineSpan) },
-        key = "filter-bar",
-      ) {
-        FilterBar(
-          count = {
-            if (totalCount != INVALID_SERIES_COUNT) {
-              Text(
-                text = pluralStringResource(Res.plurals.filter_bar_series_count, totalCount, totalCount),
-              )
-            } else {
-              Text("--")
-            }
-          },
-          itemDisplayState = ItemDisplayState.Grid,
-          isFiltered = filter != null,
-          onFilterClick = onFilterClick,
-          sortMode = sortMode,
-          sortDirection = sortDirection,
-          onSortClick = onSortClick,
-        )
-      }
-
-      items(
-        count = lazyPagingItems.itemCount,
-        key = lazyPagingItems.itemKey { it.id },
-        contentType = lazyPagingItems.itemContentType { "series-item" },
-      ) { index ->
-        val series = lazyPagingItems[index]
-        if (series == null) {
-          PlaceholderItem()
-        } else {
+    ) { series ->
+      when (displayState) {
+        GroupDisplayState.List -> {
           ItemCollectionCard(
             sharedTransitionKey = series.id,
             name = series.name,
@@ -190,10 +184,87 @@ private fun LoadedState(
               .animateItem(),
           )
         }
+        GroupDisplayState.Grid -> {
+          ItemCollectionGridCard(
+            sharedTransitionKey = series.id,
+            name = series.name,
+            items = series.books
+              ?.sortedBy { it.media.metadata.seriesSequence?.sequence }
+              ?: emptyList(),
+            onClick = { onSeriesClick(series) },
+            modifier = Modifier
+              .fillMaxWidth()
+              .animateItem(),
+          )
+        }
       }
-
-      appendingIndicatorItem()
     }
+  }
+}
+
+@Composable
+private fun ContentPagingScaffoldScope.SeriesGrid(
+  totalCount: Int,
+  lazyPagingItems: LazyPagingItems<Series>,
+  filter: ContentFilter?,
+  sortMode: ContentSortMode,
+  sortDirection: SortDirection,
+  filterBarDisplayState: ItemDisplayState,
+  onFilterClick: () -> Unit,
+  onSortClick: () -> Unit,
+  onDisplayStateClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  adaptiveColumnSize: Dp = LargeAdaptiveColumnSize,
+  contentPadding: PaddingValues = PaddingValues(),
+  state: LazyGridState = rememberLazyGridState(),
+  seriesItem: @Composable LazyGridItemScope.(Series) -> Unit,
+) {
+  LazyCampfireGrid(
+    columns = GridCells.Adaptive(adaptiveColumnSize),
+    state = state,
+    contentPadding = contentPadding + PaddingValues(horizontal = ContentPadding),
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    item(
+      span = { GridItemSpan(this.maxLineSpan) },
+      key = "filter-bar",
+    ) {
+      FilterBar(
+        count = {
+          if (totalCount != INVALID_SERIES_COUNT) {
+            Text(
+              text = pluralStringResource(Res.plurals.filter_bar_series_count, totalCount, totalCount),
+            )
+          } else {
+            Text("--")
+          }
+        },
+        itemDisplayState = filterBarDisplayState,
+        isFiltered = filter != null,
+        onFilterClick = onFilterClick,
+        sortMode = sortMode,
+        sortDirection = sortDirection,
+        onSortClick = onSortClick,
+        onDisplayStateClick = onDisplayStateClick,
+      )
+    }
+
+    items(
+      count = lazyPagingItems.itemCount,
+      key = lazyPagingItems.itemKey { it.id },
+      contentType = lazyPagingItems.itemContentType { "series-item" },
+    ) { index ->
+      val series = lazyPagingItems[index]
+      if (series == null) {
+        PlaceholderItem()
+      } else {
+        seriesItem(series)
+      }
+    }
+
+    appendingIndicatorItem()
   }
 }
 

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/list/SeriesUiState.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/list/SeriesUiState.kt
@@ -5,6 +5,7 @@ import androidx.paging.compose.LazyPagingItems
 import app.campfire.core.filter.ContentFilter
 import app.campfire.core.model.Series
 import app.campfire.core.settings.ContentSortMode
+import app.campfire.core.settings.GroupDisplayState
 import app.campfire.core.settings.SortDirection
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
@@ -16,6 +17,7 @@ data class SeriesUiState(
   val filter: ContentFilter?,
   val sortMode: ContentSortMode,
   val sortDirection: SortDirection,
+  val displayState: GroupDisplayState,
   val eventSink: (SeriesUiEvent) -> Unit,
 ) : CircuitUiState
 
@@ -23,4 +25,5 @@ sealed interface SeriesUiEvent : CircuitUiEvent {
   data class SeriesClicked(val series: Series) : SeriesUiEvent
   data class FilterChanged(val filter: ContentFilter?) : SeriesUiEvent
   data class SortModeChanged(val mode: ContentSortMode) : SeriesUiEvent
+  data object ToggleDisplayState : SeriesUiEvent
 }

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/CampfireSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/CampfireSettings.kt
@@ -2,6 +2,7 @@ package app.campfire.settings.api
 
 import app.campfire.core.model.UserId
 import app.campfire.core.settings.ContentSortMode
+import app.campfire.core.settings.GroupDisplayState
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SortDirection
 import kotlinx.coroutines.flow.StateFlow
@@ -48,6 +49,15 @@ interface CampfireSettings {
 
   var seriesSortDirection: SortDirection
   fun observeSeriesSortDirection(): StateFlow<SortDirection>
+
+  var seriesDisplayState: GroupDisplayState
+  fun observeSeriesDisplayState(): StateFlow<GroupDisplayState>
+
+  var collectionsDisplayState: GroupDisplayState
+  fun observeCollectionsDisplayState(): StateFlow<GroupDisplayState>
+
+  var playlistsDisplayState: GroupDisplayState
+  fun observePlaylistsDisplayState(): StateFlow<GroupDisplayState>
 
   var currentUserId: UserId?
   fun observeCurrentUserId(): StateFlow<UserId?>

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/CampfireSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/CampfireSettingsImpl.kt
@@ -5,6 +5,7 @@ import app.campfire.core.di.SingleIn
 import app.campfire.core.di.qualifier.ForScope
 import app.campfire.core.model.UserId
 import app.campfire.core.settings.ContentSortMode
+import app.campfire.core.settings.GroupDisplayState
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SortDirection
 import app.campfire.settings.api.CampfireSettings
@@ -86,6 +87,20 @@ class CampfireSettingsImpl(
   override var seriesSortDirection: SortDirection by seriesSortDirectionProperty
   override fun observeSeriesSortDirection(): StateFlow<SortDirection> = seriesSortDirectionProperty.observe()
 
+  private val seriesDisplayStateProperty = enumSetting(KEY_SERIES_DISPLAY_STATE, GroupDisplayState)
+  override var seriesDisplayState: GroupDisplayState by seriesDisplayStateProperty
+  override fun observeSeriesDisplayState(): StateFlow<GroupDisplayState> = seriesDisplayStateProperty.observe()
+
+  private val collectionsDisplayStateProperty = enumSetting(KEY_COLLECTIONS_DISPLAY_STATE, GroupDisplayState)
+  override var collectionsDisplayState: GroupDisplayState by collectionsDisplayStateProperty
+  override fun observeCollectionsDisplayState(): StateFlow<GroupDisplayState> =
+    collectionsDisplayStateProperty.observe()
+
+  private val playlistsDisplayStateProperty = enumSetting(KEY_PLAYLISTS_DISPLAY_STATE, GroupDisplayState)
+  override var playlistsDisplayState: GroupDisplayState by playlistsDisplayStateProperty
+  override fun observePlaylistsDisplayState(): StateFlow<GroupDisplayState> =
+    playlistsDisplayStateProperty.observe()
+
   private val currentUserIdProperty = stringOrNullSetting(KEY_CURRENT_USER_ID)
   override var currentUserId: UserId? by currentUserIdProperty
   override fun observeCurrentUserId(): StateFlow<UserId?> = currentUserIdProperty.observe()
@@ -126,6 +141,9 @@ internal const val KEY_AUTHOR_SORT_MODE = "pref_authors_sort_mode"
 internal const val KEY_AUTHORS_SORT_DIRECTION = "pref_authors_sort_direction"
 internal const val KEY_SERIES_SORT_MODE = "pref_series_sort_mode"
 internal const val KEY_SERIES_SORT_DIRECTION = "pref_series_sort_direction"
+internal const val KEY_SERIES_DISPLAY_STATE = "pref_series_display_state"
+internal const val KEY_COLLECTIONS_DISPLAY_STATE = "pref_collections_display_state"
+internal const val KEY_PLAYLISTS_DISPLAY_STATE = "pref_playlists_display_state"
 internal const val KEY_CURRENT_USER_ID = "pref_current_user_id"
 internal const val KEY_SHOW_CONFIRM_DOWNLOAD = "pref_show_confirm_download"
 internal const val KEY_SHOW_WIDGET_PINNING = "pref_show_widget_pinning"

--- a/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/TestCampfireSettings.kt
+++ b/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/TestCampfireSettings.kt
@@ -2,6 +2,7 @@ package app.campfire.settings.test
 
 import app.campfire.core.model.UserId
 import app.campfire.core.settings.ContentSortMode
+import app.campfire.core.settings.GroupDisplayState
 import app.campfire.core.settings.ItemDisplayState
 import app.campfire.core.settings.SortDirection
 import app.campfire.settings.api.CampfireSettings
@@ -85,6 +86,21 @@ class TestCampfireSettings(
   override fun observeSeriesSortDirection(): StateFlow<SortDirection> =
     observeEnum<SortDirection>(::seriesSortDirection)
       .stateIn(testScope, SharingStarted.Lazily, seriesSortDirection)
+
+  override var seriesDisplayState: GroupDisplayState by enum()
+  override fun observeSeriesDisplayState(): StateFlow<GroupDisplayState> =
+    observeEnum<GroupDisplayState>(::seriesDisplayState)
+      .stateIn(testScope, SharingStarted.Lazily, seriesDisplayState)
+
+  override var collectionsDisplayState: GroupDisplayState by enum()
+  override fun observeCollectionsDisplayState(): StateFlow<GroupDisplayState> =
+    observeEnum<GroupDisplayState>(::collectionsDisplayState)
+      .stateIn(testScope, SharingStarted.Lazily, collectionsDisplayState)
+
+  override var playlistsDisplayState: GroupDisplayState by enum()
+  override fun observePlaylistsDisplayState(): StateFlow<GroupDisplayState> =
+    observeEnum<GroupDisplayState>(::playlistsDisplayState)
+      .stateIn(testScope, SharingStarted.Lazily, playlistsDisplayState)
 
   override var currentUserId: UserId? by stringOrNull()
   override fun observeCurrentUserId(): StateFlow<UserId?> =


### PR DESCRIPTION
## Summary

Extends the Series screen's group list/grid display-state pattern to the **Collections** and **Playlists** screens, and adds a grid-friendly collection card.

- **Collections & Playlists** each get a filter bar with a **count + list/grid toggle** (no filter/sort actions, per design). The chosen layout is persisted independently per screen via new `collectionsDisplayState` / `playlistsDisplayState` settings.
- New **`ItemCollectionGridCard`** — a grid-friendly variant of `ItemCollectionCard`, visually consistent with `LibraryItemCard`. Supports two cover styles via `CollectionCoverStyle`:
  - `Mosaic` (default): a dynamic cover that adapts to the item count (1 = single, 2 = split, 3 = feature + stack, 4+ = 2×2 grid)
  - `FirstItem`: a single cover using the first item
- A **count badge** now appears in the corner of the cover on both `ItemCollectionGridCard` and the existing `ItemCollectionCard` (shown only when a group has more than one item). The badge helper is shared, no duplication.
- `FilterBar`'s sort action (`sortMode` / `sortDirection` / `onSortClick`) is now **optional**, so screens without sorting can reuse the widget. All existing callers use named args and are unaffected.

Default display state remains `List`, so all three screens look unchanged by default — users just gain a toggle into the mosaic grid.

## Changes
- `settings` api/impl/test: add `collectionsDisplayState` + `playlistsDisplayState`
- `FilterBar`: make sort params optional
- `ItemCollectionGridCard`: new widget; `CollectionCountBadge` shared with `ItemCollectionCard`
- Collections/Playlists state + presenter + UI: display state, toggle event, filter bar header, list/grid card switching
- New `filter_bar_collection_count` / `filter_bar_playlist_count` plural strings

## Test plan
- [x] JVM compiles clean (`common:compose`, `settings:impl/test`, `collections:ui`, `playlists:ui`, `series:ui`)
- [ ] Toggle list ↔ grid on Series / Collections / Playlists; verify each remembers its own choice
- [ ] Verify count badge appears on multi-item collections and is hidden for single-item ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)