### PR TITLE
Prioritize expanded playback view in back handling

### DIFF
--- a/app/common/src/commonMain/kotlin/app/campfire/common/back/OverlayPriorityBackHandler.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/back/OverlayPriorityBackHandler.kt
@@ -1,0 +1,65 @@
+package app.campfire.common.back
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.navigationevent.NavigationEventDispatcher
+import androidx.navigationevent.NavigationEventHandler
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
+
+/**
+ * A back handler that registers with the [NavigationEventDispatcher] at
+ * [NavigationEventDispatcher.PRIORITY_OVERLAY].
+ *
+ * The convenience `NavigationBackHandler` composable always registers at
+ * `PRIORITY_DEFAULT`, which is the same tier Circuit's `GestureNavigationDecoration` uses for
+ * popping the main back stack. Within a tier the dispatcher picks the winner purely by
+ * composition order (LIFO), so whichever handler happens to compose last wins — a source of
+ * non-deterministic back ordering.
+ *
+ * All `PRIORITY_OVERLAY` handlers are dispatched before *any* `PRIORITY_DEFAULT` handler,
+ * regardless of composition order. Use this for "chrome" back consumers (overlays, an expanded
+ * player, a supporting/detail pane) that must always take precedence over a main back stack pop,
+ * while letting Circuit keep its predictive-back screen animation for the pop itself.
+ *
+ * When [enabled] is `false` the handler is skipped and the event falls through to the next enabled
+ * handler (e.g. Circuit's default-priority pop).
+ *
+ * This intentionally does not feed predictive-back progress; it mirrors the previous
+ * `NavigationBackHandler(state = rememberNavigationEventState(NavigationEventInfo.None), ...)`
+ * usage which also opted out of a predictive preview.
+ */
+@Composable
+fun OverlayPriorityBackHandler(
+  enabled: Boolean,
+  onBack: () -> Unit,
+) {
+  val dispatcher = LocalNavigationEventDispatcherOwner.current
+    ?.navigationEventDispatcher
+    ?: return
+
+  val currentOnBack by rememberUpdatedState(onBack)
+
+  val handler = remember {
+    object : NavigationEventHandler<NavigationEventInfo>(NavigationEventInfo.None, enabled) {
+      override fun onBackCompleted() {
+        currentOnBack()
+      }
+    }
+  }
+
+  SideEffect {
+    handler.isBackEnabled = enabled
+  }
+
+  DisposableEffect(dispatcher) {
+    dispatcher.addHandler(handler, NavigationEventDispatcher.PRIORITY_OVERLAY)
+    onDispose {
+      handler.remove()
+    }
+  }
+}

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
@@ -29,9 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastRoundToInt
-import androidx.navigationevent.NavigationEventInfo
-import androidx.navigationevent.compose.NavigationBackHandler
-import androidx.navigationevent.compose.rememberNavigationEventState
 import app.campfire.account.ui.picker.AccountPickerResult
 import app.campfire.account.ui.picker.showAccountPicker
 import app.campfire.account.ui.switcher.AccountSwitcher
@@ -40,6 +37,7 @@ import app.campfire.analytics.Analytics
 import app.campfire.analytics.events.ActionEvent
 import app.campfire.analytics.events.ScreenType
 import app.campfire.analytics.events.ScreenViewEvent
+import app.campfire.common.back.OverlayPriorityBackHandler
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.extensions.shouldUseDarkColors
 import app.campfire.common.compose.layout.AdaptiveCampfireLayout
@@ -247,13 +245,6 @@ private fun LoggedInUi(
   }
 
   val overlayHost = rememberOverlayHost()
-  NavigationBackHandler(
-    state = rememberNavigationEventState(NavigationEventInfo.None),
-    isBackEnabled = overlayHost.currentOverlayData != null || detailRootScreen !is EmptyScreen,
-    onBackCompleted = {
-      overlayHost.currentOverlayData?.finish(Unit) ?: detailNavigator.pop()
-    },
-  )
 
   val homeNavigator = remember(navigator, windowSizeClass) {
     HomeNavigator(
@@ -271,12 +262,27 @@ private fun LoggedInUi(
   }
 
   var playbackBarExpanded by rememberRetainedSaveable { mutableStateOf(false) }
-  NavigationBackHandler(
-    state = rememberNavigationEventState(NavigationEventInfo.None),
-    isBackEnabled = playbackBarExpanded,
-    onBackCompleted = {
-      Analytics.send(ActionEvent("playback_bar", "collapsed", "back_handler"))
-      playbackBarExpanded = false
+
+  // A single, deterministic back handler for all "chrome" back consumers. The order of the
+  // `when` below *is* the priority — read top to bottom. Registered at PRIORITY_OVERLAY (via
+  // OverlayPriorityBackHandler) so it always takes precedence over Circuit's main back stack
+  // pop, regardless of composition order. Circuit still animates the pop when nothing here is
+  // active.
+  OverlayPriorityBackHandler(
+    enabled = overlayHost.currentOverlayData != null ||
+      playbackBarExpanded ||
+      detailRootScreen !is EmptyScreen,
+    onBack = {
+      when {
+        overlayHost.currentOverlayData != null -> overlayHost.currentOverlayData?.finish(Unit)
+
+        playbackBarExpanded -> {
+          Analytics.send(ActionEvent("playback_bar", "collapsed", "back_handler"))
+          playbackBarExpanded = false
+        }
+
+        detailRootScreen !is EmptyScreen -> detailNavigator.pop()
+      }
     },
   )
 


### PR DESCRIPTION
Closes #539

## Problem

Back gestures didn't respect view ordering: with the playback view expanded (or an overlay showing), a swipe-to-back would pop the main nav stack instead of collapsing the player first. E.g. Item Detail → expand player → back went **Detail → Home**, then a second back closed the player.

## Root cause

All back consumers feed a single `androidx.navigationevent` dispatcher, and everything registered in the **same `PRIORITY_DEFAULT` tier**:

- the two chrome `NavigationBackHandler`s (overlay/detail pane, expanded player), and
- Circuit's `GestureNavigationDecoration` (main back stack pop).

Within a tier the dispatcher picks the winner by **composition-order LIFO**. Circuit's decoration composes deepest inside `NavigableCircuitContent`, so it registered last and won every gesture — regardless of whether the player was expanded. The player-collapse handler only worked when already at a root screen.

## Fix

- New `OverlayPriorityBackHandler` composable that registers on the dispatcher at `NavigationEventDispatcher.PRIORITY_OVERLAY`. Overlay-priority handlers are dispatched **before any** default-priority handler, independent of composition order.
- Consolidated the two chrome handlers in `LoggedIn.kt` into a single `OverlayPriorityBackHandler` whose `when` block **is** the priority order:

  ```
  overlay dialog  → finish()
  expanded player → collapse
  detail pane     → detailNavigator.pop()
  ```

`NavigableCircuitContent` is untouched — Circuit keeps its predictive-back screen animation and now only pops when no chrome consumer is active.

## Also fixes

A latent ordering bug: a dialog shown over the expanded player now dismisses the **dialog** first instead of collapsing the player, since ordering is explicit rather than registration-driven.

## Testing

- ✅ `:app:common:compileKotlinJvm`
- ✅ `./scripts/ktlint --check`
- ⏳ On-device runtime matrix (Android / iOS / desktop) not yet walked — the helper touches multiplatform dispatcher plumbing:
  - Item Detail → expand player → back collapses player (Detail stays); back again pops Detail → Home
  - Expanded player at a root screen → back collapses
  - Dialog over expanded player → back dismisses dialog first
  - Dual-pane: detail pane populated → back pops detail pane, not main stack
  - Nothing active, stack > 1 → back pops with Circuit's predictive animation intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)