### PR TITLE
Fix offline playback of downloaded audiobooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ExoPlayer cache evictor causing downloads to be evicted by streaming playback.
+
 ### Other Notes & Contributions
 
 ## [0.13.1-beta]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- ExoPlayer cache evictor causing downloads to be evicted by streaming playback.
+- Offline playback of downloaded audiobooks failing when the server is unreachable
 
 ### Other Notes & Contributions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,10 @@ fun MyUi(state: MyUiState, modifier: Modifier = Modifier) { /* ... */ }
 - `@Parcelize` is multiplatform via expect/actual (see `ParcelizeConventionPlugin`)
 - Package structure: `app.campfire.[module].[submodule]`
 
+## Changelog
+
+Every PR that changes app behavior must include an entry in `CHANGELOG.md` under `## [Unreleased]`, in the most appropriate [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) category (Added / Changed / Deprecated / Removed / Fixed / Other Notes & Contributions). Write a single concise, user-facing line describing the change — no implementation details (e.g. "Offline playback failing when the server is unreachable", not "Split the ExoPlayer SimpleCache into download and streaming caches"). Update the changelog before opening the PR.
+
 ## Database Migrations
 
 Schema lives in `data/db/core/src/commonMain/sqldelight/app/campfire/data/*.sq`; migrations live alongside in `migrations/{N}.sqm` and the baseline schema dump is `app/campfire/databases/1.db`. SQLDelight's `verifyCommonMainCampfireDatabaseMigration` task compares the migrated database against the fresh `.sq` schema — any drift fails the build.

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/di/CacheQualifiers.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/di/CacheQualifiers.kt
@@ -1,0 +1,9 @@
+package app.campfire.audioplayer.impl.di
+
+import me.tatarka.inject.annotations.Qualifier
+
+@Qualifier
+annotation class DownloadCache
+
+@Qualifier
+annotation class StreamingCache

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/di/ExoPlayerAppComponent.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/di/ExoPlayerAppComponent.kt
@@ -10,6 +10,7 @@ import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.NoOpCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -48,13 +49,32 @@ interface ExoPlayerAppComponent {
   @OptIn(UnstableApi::class)
   @SingleIn(AppScope::class)
   @Provides
-  fun provideSimpleCache(
+  @DownloadCache
+  fun provideDownloadCache(
     application: Application,
     databaseProvider: DatabaseProvider,
   ): SimpleCache {
     val downloadDirectory = File(application.filesDir, "exoPlayerDownloads")
     return SimpleCache(
       downloadDirectory,
+      // Downloads must never be evicted, otherwise downloaded items silently lose their bytes
+      // and offline playback falls through to the network.
+      NoOpCacheEvictor(),
+      databaseProvider,
+    )
+  }
+
+  @OptIn(UnstableApi::class)
+  @SingleIn(AppScope::class)
+  @Provides
+  @StreamingCache
+  fun provideStreamingCache(
+    application: Application,
+    databaseProvider: DatabaseProvider,
+  ): SimpleCache {
+    val streamingCacheDirectory = File(application.cacheDir, "exoPlayerStreamingCache")
+    return SimpleCache(
+      streamingCacheDirectory,
       LeastRecentlyUsedCacheEvictor(512 * 1024 * 1024L), // 512 MB disk cap
       databaseProvider,
     )
@@ -68,7 +88,7 @@ interface ExoPlayerAppComponent {
     sessionManager: UserSessionManager,
     accountManager: AccountManager,
     databaseProvider: DatabaseProvider,
-    simpleCache: SimpleCache,
+    @DownloadCache downloadCache: SimpleCache,
     appInfo: ApplicationInfo,
     @UserClient userClient: HttpClient,
   ): DownloadManager {
@@ -79,7 +99,7 @@ interface ExoPlayerAppComponent {
     return DownloadManager(
       application,
       databaseProvider,
-      simpleCache,
+      downloadCache,
       createAuthenticatingDataSource(
         userSessionProvider = { sessionManager.current },
         accountManager = accountManager,
@@ -96,7 +116,8 @@ interface ExoPlayerAppComponent {
   fun provideMediaSourceFactory(
     application: Application,
     settings: PlaybackSettings,
-    simpleCache: SimpleCache,
+    @DownloadCache downloadCache: SimpleCache,
+    @StreamingCache streamingCache: SimpleCache,
     sessionManager: UserSessionManager,
     accountManager: AccountManager,
     appInfo: ApplicationInfo,
@@ -108,9 +129,16 @@ interface ExoPlayerAppComponent {
 
     val authRetryFactory = AuthRefreshingHttpDataSource.Factory(httpDataSourceFactory, userClient)
 
-    val cacheDataSourceFactory = CacheDataSource.Factory()
-      .setCache(simpleCache)
+    val streamingCacheDataSourceFactory = CacheDataSource.Factory()
+      .setCache(streamingCache)
       .setUpstreamDataSourceFactory(authRetryFactory)
+
+    val cacheDataSourceFactory = CacheDataSource.Factory()
+      .setCache(downloadCache)
+      // Read-only: only the DownloadManager writes into the download cache. Streamed
+      // (non-downloaded) content is cached in the size-capped streaming cache instead.
+      .setCacheWriteDataSinkFactory(null)
+      .setUpstreamDataSourceFactory(streamingCacheDataSourceFactory)
 
     val extractorsFactory = DefaultExtractorsFactory()
 


### PR DESCRIPTION
## Summary

- Fixes offline playback of downloaded audiobooks, broken since v0.13 when the memory tuning in #779 put a 512 MB `LeastRecentlyUsedCacheEvictor` on the ExoPlayer `SimpleCache` shared by the `DownloadManager` and playback. LRU eviction doesn't protect downloaded content (a single book can exceed 512 MB), so download bytes were silently evicted and playback fell through to the network — fine online, but failing in airplane mode with a misleading "format may not be supported" error.
- Splits the cache in two: downloads keep their original `filesDir/exoPlayerDownloads` directory (existing downloads stay valid) with a `NoOpCacheEvictor` so they are never evicted, per media3 guidance for download caches. Streamed content now writes to a new 512 MB LRU cache in `cacheDir`, preserving the disk bound #779 intended.
- Playback reads the download cache read-only (`setCacheWriteDataSinkFactory(null)`) and falls through to the streaming cache, then the network.

> [!NOTE]
> Users already bitten on v0.13.x may have evicted download bytes with a download index still claiming "complete" — those books need to be deleted and re-downloaded. Worth a release-note line, or a follow-up that validates download spans.

## Related issues

Closes #883

## Test plan

- [x] `:infra:audioplayer:impl:compileAndroidMain` and `:app:android:compileAlphaDebugKotlin` (kotlin-inject/Kimchi codegen resolves both qualified caches)
- [x] ktlint on changed files
- [ ] Download a book, enable airplane mode, relaunch the app, and confirm playback works offline
- [ ] Stream (without downloading) and confirm playback still works and caches to `cacheDir/exoPlayerStreamingCache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)