### PR TITLE
Add book progress indicator and wavy seek bar toggle to playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - List/grid display toggle for the Series, Collections, and Playlists screens
+- Optional overall book progress indicator with time remaining in the player, toggleable in Playback settings
+- Setting to disable the wavy playback seek bar animation
 
 ### Changed
 

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackPresenter.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackPresenter.kt
@@ -194,6 +194,16 @@ class PlaybackPresenter(
         }
     }.collectAsState(Duration.ZERO)
 
+    val bookTime by remember {
+      snapshotFlow { player }
+        .filterNotNull()
+        .flatMapLatest {
+          it.overallTime.map { time ->
+            time.inWholeSeconds.seconds
+          }
+        }
+    }.collectAsState(Duration.ZERO)
+
     val duration by remember {
       snapshotFlow { player }
         .filterNotNull()
@@ -242,9 +252,20 @@ class PlaybackPresenter(
         }
     }.collectAsState(null)
 
+    val bookTimeEnabled by remember {
+      playbackSettings.observeBookTimeInPlaybackUi()
+    }.collectAsState()
+
+    val wavySliderEnabled by remember {
+      playbackSettings.observePlaybackWavyScrubber()
+    }.collectAsState()
+
     return PlayerUiState(
       time = time,
       duration = duration,
+      bookTime = bookTime,
+      bookTimeEnabled = bookTimeEnabled,
+      wavySliderEnabled = wavySliderEnabled,
       metadata = metadata,
       state = state,
       speed = speed,

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackUiState.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackUiState.kt
@@ -32,7 +32,10 @@ data class PlaybackUiState(
 @Immutable
 data class PlayerUiState(
   val time: Duration,
+  val bookTime: Duration,
+  val bookTimeEnabled: Boolean,
   val duration: Duration,
+  val wavySliderEnabled: Boolean,
   val metadata: Metadata,
   val state: AudioPlayer.State,
   val speed: Float,

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
@@ -504,7 +504,7 @@ private fun SharedTransitionScope.ExpandedPlaybackContent(
       val isDragged by interactionSource.collectIsDraggedAsState()
       val isInteracting = isPressed || isDragged
 
-      if (playerState.bookTimeEnabled) {
+      if (playerState.bookTimeEnabled && session?.episodeId == null) {
         BookTimeProgressIndicator(session, playerState)
         Spacer(Modifier.height(4.dp))
       }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
@@ -1,6 +1,7 @@
 package app.campfire.sessions.ui.playback.expanded
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
@@ -17,6 +18,7 @@ import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -25,14 +27,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.KeyboardDoubleArrowRight
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -59,8 +65,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import app.campfire.audioplayer.ui.cast.CastButton
 import app.campfire.common.compose.LocalWindowSizeClass
+import app.campfire.common.compose.extensions.readoutFormat
 import app.campfire.common.compose.layout.isLandscapePhone
 import app.campfire.common.compose.layout.isSupportingPaneEnabled
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
@@ -87,11 +95,13 @@ import app.campfire.sessions.ui.playback.collapsed.TonalElevation
 import app.campfire.sessions.ui.playback.expanded.composables.ActionRow
 import app.campfire.sessions.ui.playback.expanded.composables.AvailableSyncButton
 import app.campfire.sessions.ui.playback.expanded.composables.ClearQueueButton
+import app.campfire.sessions.ui.playback.expanded.composables.DefaultThumbSize
 import app.campfire.sessions.ui.playback.expanded.composables.ExpandedItemImage
 import app.campfire.sessions.ui.playback.expanded.composables.PlaybackActions
 import app.campfire.sessions.ui.playback.expanded.composables.PlaybackSeekBar
 import app.campfire.sessions.ui.playback.expanded.composables.QueueButton
 import app.campfire.sessions.ui.playback.expanded.composables.QueueContent
+import app.campfire.sessions.ui.playback.expanded.composables.SmallThumbSize
 import app.campfire.sessions.ui.playback.expanded.composables.TargetSyncContent
 import app.campfire.sessions.ui.sheets.bookmarks.BookmarkResult
 import app.campfire.sessions.ui.sheets.bookmarks.showBookmarksBottomSheet
@@ -113,6 +123,8 @@ import com.slack.circuit.overlay.ContentWithOverlays
 import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuit.overlay.rememberOverlayHost
 import com.slack.circuit.runtime.Navigator
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -394,7 +406,7 @@ private fun SharedTransitionScope.ExpandedPlaybackContent(
             if (session == null) return@clickable
             scope.launch {
               onClose()
-              delay(350L)
+              delay(350.milliseconds)
               navigator.goTo(
                 LibraryItemScreen(
                   libraryItemId = session.libraryItem.id,
@@ -414,6 +426,10 @@ private fun SharedTransitionScope.ExpandedPlaybackContent(
           fontWeight = FontWeight.SemiBold,
           fontFamily = PaytoneOneFontFamily,
           maxLines = 3,
+          autoSize = TextAutoSize.StepBased(
+            minFontSize = 24.sp,
+            maxFontSize = 28.sp,
+          ),
           overflow = TextOverflow.Ellipsis,
           modifier = Modifier
             .align(Alignment.CenterHorizontally)
@@ -488,6 +504,11 @@ private fun SharedTransitionScope.ExpandedPlaybackContent(
       val isDragged by interactionSource.collectIsDraggedAsState()
       val isInteracting = isPressed || isDragged
 
+      if (playerState.bookTimeEnabled) {
+        BookTimeProgressIndicator(session, playerState)
+        Spacer(Modifier.height(4.dp))
+      }
+
       PlaybackSeekBar(
         state = playerState.state,
         currentTime = playerState.time,
@@ -497,6 +518,12 @@ private fun SharedTransitionScope.ExpandedPlaybackContent(
           playerState.eventSink(PlayerUiEvent.Seek.Percent(percent))
         },
         interactionSource = interactionSource,
+        waveEnabled = playerState.wavySliderEnabled,
+        thumbSize = if (playerState.bookTimeEnabled) {
+          SmallThumbSize
+        } else {
+          DefaultThumbSize
+        },
       )
 
       Spacer(Modifier.height(24.dp))
@@ -617,6 +644,61 @@ private fun SharedTransitionScope.ExpandedPlaybackContent(
         }
       },
       showHistory = playbackHistoryEnabled,
+    )
+  }
+}
+
+@Composable
+private fun ColumnScope.BookTimeProgressIndicator(
+  session: Session?,
+  playerState: PlayerUiState,
+) {
+  val bookDuration = session?.duration ?: Duration.ZERO
+  if (bookDuration != Duration.ZERO) {
+    Row(
+      modifier = Modifier.align(Alignment.CenterHorizontally),
+    ) {
+      val isAccelerated = playerState.speed != 1f
+      AnimatedVisibility(
+        visible = isAccelerated,
+      ) {
+        Icon(
+          Icons.Rounded.KeyboardDoubleArrowRight,
+          contentDescription = null,
+          modifier = Modifier.size(16.dp),
+          tint = MaterialTheme.colorScheme.secondary,
+        )
+      }
+
+      val currentRemainingDuration = (bookDuration - playerState.bookTime).div(playerState.speed.toDouble())
+      Text(
+        text = "${currentRemainingDuration.readoutFormat()} left",
+        style = MaterialTheme.typography.labelSmall.fluentIf(isAccelerated) {
+          copy(
+            fontWeight = FontWeight.Bold,
+            fontStyle = FontStyle.Italic,
+            color = MaterialTheme.colorScheme.secondary,
+            fontSize = 12.sp,
+          )
+        },
+      )
+    }
+
+    Spacer(Modifier.height(4.dp))
+
+    LinearProgressIndicator(
+      progress = { (playerState.bookTime / bookDuration).toFloat() },
+      trackColor = MaterialTheme.colorScheme.surfaceContainer,
+      color = MaterialTheme.colorScheme.secondary,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 32.dp),
+    )
+  } else {
+    LinearProgressIndicator(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 32.dp),
     )
   }
 }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/PlaybackSeekBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/PlaybackSeekBar.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.campfire.audioplayer.AudioPlayer
@@ -35,6 +36,9 @@ import ir.mahozad.multiplatform.wavyslider.WaveDirection
 import ir.mahozad.multiplatform.wavyslider.material3.WavySlider
 import kotlin.time.Duration
 
+val DefaultThumbSize = DpSize(4.dp, 44.dp)
+val SmallThumbSize = DpSize(4.dp, 32.dp)
+
 @Composable
 internal fun PlaybackSeekBar(
   state: AudioPlayer.State,
@@ -43,6 +47,8 @@ internal fun PlaybackSeekBar(
   playbackSpeed: Float,
   onSeek: (Float) -> Unit,
   modifier: Modifier = Modifier,
+  waveEnabled: Boolean = true,
+  thumbSize: DpSize = DefaultThumbSize,
   interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
   Column(
@@ -66,25 +72,35 @@ internal fun PlaybackSeekBar(
       }
     }
 
-    val waveHeight = if (state == AudioPlayer.State.Playing) 16.dp else 0.dp
-    val waveVelocity = if (state == AudioPlayer.State.Playing) 40.dp else 0.dp
-    val waveThickness = if (state == AudioPlayer.State.Playing) 12.dp else 16.dp
+    val waveHeight = if (state == AudioPlayer.State.Playing && waveEnabled) 16.dp else 0.dp
+    val waveVelocity = if (state == AudioPlayer.State.Playing && waveEnabled) 40.dp else 0.dp
+    val waveThickness = if (state == AudioPlayer.State.Playing && waveEnabled) 12.dp else 16.dp
 
+    val colors = SliderDefaults.colors(
+      inactiveTrackColor = MaterialTheme.colorScheme.surfaceContainer,
+    )
+    val enabled = state == AudioPlayer.State.Playing || state == AudioPlayer.State.Paused
     WavySlider(
-      enabled = state == AudioPlayer.State.Playing || state == AudioPlayer.State.Paused,
+      enabled = enabled,
       value = softSliderValue,
       onValueChange = { sliderValue = it },
       onValueChangeFinished = {
         onSeek(sliderValue)
       },
       interactionSource = interactionSource,
-      colors = SliderDefaults.colors(
-        inactiveTrackColor = MaterialTheme.colorScheme.surfaceContainer,
-      ),
+      colors = colors,
       waveLength = 50.dp,
       waveHeight = waveHeight,
       waveVelocity = waveVelocity to WaveDirection.TAIL,
       waveThickness = waveThickness,
+      thumb = {
+        SliderDefaults.Thumb(
+          interactionSource = interactionSource,
+          colors = colors,
+          enabled = enabled,
+          thumbSize = thumbSize,
+        )
+      },
       modifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = 24.dp),

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/PlaybackSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/PlaybackSettings.kt
@@ -74,4 +74,17 @@ interface PlaybackSettings {
    * interrupted by the app being killed still rewinds when playback resumes. Null when no pause is pending.
    */
   var pendingResumeRewind: PendingResumeRewind?
+
+  /**
+   * When true, the book's overall time will display in a progress bar in
+   * in the playback ui.
+   */
+  var bookTimeInPlaybackUi: Boolean
+  fun observeBookTimeInPlaybackUi(): StateFlow<Boolean>
+
+  /**
+   * When true, the playback slider will be wavy
+   */
+  var playbackWavyScrubber: Boolean
+  fun observePlaybackWavyScrubber(): StateFlow<Boolean>
 }

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/PlaybackSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/PlaybackSettingsImpl.kt
@@ -129,6 +129,22 @@ class PlaybackSettingsImpl(
       }
     }
 
+  private val bookTimeInPlaybackUiProperty = booleanSetting(
+    PREF_BOOK_TIME_UI,
+    false,
+  )
+  override var bookTimeInPlaybackUi: Boolean by bookTimeInPlaybackUiProperty
+  override fun observeBookTimeInPlaybackUi(): StateFlow<Boolean> =
+    bookTimeInPlaybackUiProperty.observe()
+
+  private val playbackWavyScrubberProperty = booleanSetting(
+    PREF_WAVY_SLIDER,
+    true,
+  )
+  override var playbackWavyScrubber: Boolean by playbackWavyScrubberProperty
+  override fun observePlaybackWavyScrubber(): StateFlow<Boolean> =
+    playbackWavyScrubberProperty.observe()
+
   private fun String.asFloatList(): List<Float> = split(PLAYBACK_RATES_SEPARATOR).mapNotNull { it.toFloatOrNull() }
 
   private fun PendingResumeRewind.serialize(): String =
@@ -149,6 +165,17 @@ internal const val PREF_PLAYBACK_RATES = "pref_playback_rates"
 internal const val PREF_PLAYBACK_SPEED = "pref_playback_speed"
 internal const val PREF_SYNC = "pref_synchronization"
 internal const val PREF_AUTO_SYNC = "pref_auto_sync"
+internal const val PREF_REMOTE_NEXT_PREV_SKIPS_CHAPTERS = "pref_playback_remote_next_prev_skips_chapters"
+internal const val PREF_PLAYBACK_HISTORY = "pref_playback_history_enabled"
+internal const val PREF_MIN_PAUSE_THRESHOLD = "pref_playback_resume_rewind_min_pause_threshold"
+internal const val PREF_MIN_RESUME_REWIND = "pref_playback_resume_rewind_min"
+internal const val PREF_MAX_RESUME_REWIND = "pref_playback_resume_rewind_max"
+internal const val PREF_PENDING_RESUME_REWIND = "pref_playback_pending_resume_rewind"
+internal const val PENDING_RESUME_REWIND_SEPARATOR = "|"
+internal const val PREF_AUTO_REWIND_STOP_AT_CHAPTER = "pref_playback_auto_rewind_stop_at_chapter"
+internal const val PREF_AUTO_REWIND_ON_RESUME = "pref_playback_auto_rewind_on_resume"
+internal const val PREF_BOOK_TIME_UI = "pref_book_time_playback_ui"
+internal const val PREF_WAVY_SLIDER = "pref_wavy_playback_slider"
 
 internal const val PLAYBACK_RATES_SEPARATOR = "::"
 
@@ -157,19 +184,8 @@ internal const val DEFAULT_BACKWARD_TIME_MS = 10L * 1000L // 15s
 internal const val DEFAULT_TRACK_RESET_THRESHOLD_SECONDS = 5.0 // 5s
 internal val DEFAULT_PLAYBACK_RATES = listOf(1f, 1.1f, 1.25f, 1.5f, 2f)
 internal const val DEFAULT_PLAYBACK_SPEED = 1f
-internal const val PREF_REMOTE_NEXT_PREV_SKIPS_CHAPTERS = "pref_playback_remote_next_prev_skips_chapters"
 internal const val DEFAULT_REMOTE_NEXT_PREV_SKIPS_CHAPTERS = true
-internal const val DEFAULT_SYNCHRONIZATION = true
 internal const val DEFAULT_AUTO_SYNC = true
-internal const val PREF_PLAYBACK_HISTORY = "pref_playback_history_enabled"
 internal const val DEFAULT_PLAYBACK_HISTORY = true
-
-internal const val PREF_AUTO_REWIND_ON_RESUME = "pref_playback_auto_rewind_on_resume"
 internal const val DEFAULT_AUTO_REWIND_ON_RESUME = false
-internal const val PREF_MIN_PAUSE_THRESHOLD = "pref_playback_resume_rewind_min_pause_threshold"
-internal const val PREF_MIN_RESUME_REWIND = "pref_playback_resume_rewind_min"
-internal const val PREF_MAX_RESUME_REWIND = "pref_playback_resume_rewind_max"
-internal const val PREF_PENDING_RESUME_REWIND = "pref_playback_pending_resume_rewind"
-internal const val PENDING_RESUME_REWIND_SEPARATOR = "|"
-internal const val PREF_AUTO_REWIND_STOP_AT_CHAPTER = "pref_playback_auto_rewind_stop_at_chapter"
 internal const val DEFAULT_AUTO_REWIND_STOP_AT_CHAPTER = true

--- a/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/FakePlaybackSettings.kt
+++ b/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/FakePlaybackSettings.kt
@@ -90,4 +90,19 @@ class FakePlaybackSettings : PlaybackSettings {
     _autoRewindStopAtChapterBoundary.asStateFlow()
 
   override var pendingResumeRewind: PendingResumeRewind? = null
+
+  private val _bookTimeInPlaybackUi = MutableStateFlow(false)
+  override var bookTimeInPlaybackUi: Boolean
+    get() = _bookTimeInPlaybackUi.value
+    set(value) { _bookTimeInPlaybackUi.value = value }
+  override fun observeBookTimeInPlaybackUi(): StateFlow<Boolean> =
+    _bookTimeInPlaybackUi.asStateFlow()
+
+  private val _playbackWavyScrubber = MutableStateFlow(true)
+  override var playbackWavyScrubber: Boolean
+    get() = _playbackWavyScrubber.value
+    set(value) { _playbackWavyScrubber.value = value }
+
+  override fun observePlaybackWavyScrubber(): StateFlow<Boolean> =
+    _playbackWavyScrubber.asStateFlow()
 }

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -67,6 +67,11 @@
   <string name="setting_playback_track_reset_subtitle">How far into a track that skip previous will just restart it</string>
   <string name="setting_playback_remote_skip_title">Bluetooth next/prev skips chapters</string>
   <string name="setting_playback_remote_skip_subtitle">When enabled, Bluetooth next/previous buttons skip to next/previous chapter. When disabled, they seek forward/backward by the configured time.</string>
+  <string name="header_player_interface">Player interface</string>
+  <string name="setting_playback_book_time_title">Show book progress</string>
+  <string name="setting_playback_book_time_subtitle">Display the overall book progress and time remaining above the seek bar in the player</string>
+  <string name="setting_playback_wavy_scrubber_title">Wavy seek bar</string>
+  <string name="setting_playback_wavy_scrubber_subtitle">Animate the player seek bar as a wave while playing</string>
   <string name="header_auto_rewind_on_resume">Auto-rewind on resume</string>
   <string name="setting_playback_auto_rewind_on_resume_title">Rewind when resuming</string>
   <string name="setting_playback_auto_rewind_on_resume_subtitle">After a pause, rewind by an amount that scales with how long playback was paused — even if the app was closed while paused.</string>

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -57,10 +57,12 @@ import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.AutoRewindO
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.AutoRewindStopAtChapterBoundary
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.AutoSyncEnabled
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.BackwardTime
+import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.BookTimeInPlaybackUi
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ForwardTime
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.MinPauseThreshold
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.Mp3IndexSeeking
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.PlaybackHistoryEnabled
+import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.PlaybackWavyScrubber
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.RemoteNextPrevSkipsChapters
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ResumeRewindRange
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.SyncEnabled
@@ -155,6 +157,8 @@ class SettingsPresenter(
     val autoRewindStopAtChapterBoundary by remember {
       playbackSettings.observeAutoRewindStopAtChapterBoundary()
     }.collectAsState()
+    val bookTimeInPlaybackUi by remember { playbackSettings.observeBookTimeInPlaybackUi() }.collectAsState()
+    val playbackWavyScrubber by remember { playbackSettings.observePlaybackWavyScrubber() }.collectAsState()
 
     // Downloads Settings
     val showDownloadConfirmation by remember { settings.observeShowConfirmDownload() }
@@ -250,6 +254,8 @@ class SettingsPresenter(
         resumeRewindConfig = resumeRewindConfig,
         resumeRewindPreview = resumeRewindPreview,
         autoRewindStopAtChapterBoundary = autoRewindStopAtChapterBoundary,
+        bookTimeInPlaybackUi = bookTimeInPlaybackUi,
+        playbackWavyScrubber = playbackWavyScrubber,
       ),
       sleepSettings = SleepSettingsInfo(
         shakeToReset = shakeToResetEnabled,
@@ -363,6 +369,8 @@ class SettingsPresenter(
           }
           is AutoRewindStopAtChapterBoundary ->
             playbackSettings.autoRewindStopAtChapterBoundary = event.enabled
+          is BookTimeInPlaybackUi -> playbackSettings.bookTimeInPlaybackUi = event.enabled
+          is PlaybackWavyScrubber -> playbackSettings.playbackWavyScrubber = event.enabled
         }
 
         is SettingsUiEvent.SleepSettingEvent -> when (event) {

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -88,6 +88,8 @@ data class PlaybackSettingsInfo(
   val resumeRewindConfig: ResumeRewindConfig,
   val resumeRewindPreview: List<ResumeRewindTier>,
   val autoRewindStopAtChapterBoundary: Boolean,
+  val bookTimeInPlaybackUi: Boolean,
+  val playbackWavyScrubber: Boolean,
 )
 
 @Immutable
@@ -200,6 +202,8 @@ sealed interface SettingsUiEvent : CircuitUiEvent {
       val maxRewind: Duration,
     ) : PlaybackSettingEvent
     data class AutoRewindStopAtChapterBoundary(val enabled: Boolean) : PlaybackSettingEvent
+    data class BookTimeInPlaybackUi(val enabled: Boolean) : PlaybackSettingEvent
+    data class PlaybackWavyScrubber(val enabled: Boolean) : PlaybackSettingEvent
   }
 
   // Sleep Setting Events

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
@@ -101,6 +101,10 @@ class SettingsAnalyticUiEventHandler(
       )
       is SettingsUiEvent.PlaybackSettingEvent.AutoRewindStopAtChapterBoundary ->
         send("resume_rewind_stop_at_chapter", Updated, event.enabled)
+      is SettingsUiEvent.PlaybackSettingEvent.BookTimeInPlaybackUi ->
+        send("book_time_playback_ui", Updated, event.enabled)
+      is SettingsUiEvent.PlaybackSettingEvent.PlaybackWavyScrubber ->
+        send("wavy_playback_slider", Updated, event.enabled)
     }
 
     is SettingsUiEvent.SleepSettingEvent -> when (event) {

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/PlaybackPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/PlaybackPane.kt
@@ -19,6 +19,7 @@ import app.campfire.ui.settings.composables.TimeJumps
 import campfire.features.settings.ui.generated.resources.Res
 import campfire.features.settings.ui.generated.resources.header_auto_rewind_on_resume
 import campfire.features.settings.ui.generated.resources.header_playback_history
+import campfire.features.settings.ui.generated.resources.header_player_interface
 import campfire.features.settings.ui.generated.resources.header_synchronization
 import campfire.features.settings.ui.generated.resources.setting_playback_auto_rewind_on_resume_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_auto_rewind_on_resume_title
@@ -26,6 +27,8 @@ import campfire.features.settings.ui.generated.resources.setting_playback_auto_s
 import campfire.features.settings.ui.generated.resources.setting_playback_auto_sync_title
 import campfire.features.settings.ui.generated.resources.setting_playback_backward_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_backward_title
+import campfire.features.settings.ui.generated.resources.setting_playback_book_time_subtitle
+import campfire.features.settings.ui.generated.resources.setting_playback_book_time_title
 import campfire.features.settings.ui.generated.resources.setting_playback_forward_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_forward_title
 import campfire.features.settings.ui.generated.resources.setting_playback_history_subtitle
@@ -46,6 +49,8 @@ import campfire.features.settings.ui.generated.resources.setting_playback_sync_t
 import campfire.features.settings.ui.generated.resources.setting_playback_title
 import campfire.features.settings.ui.generated.resources.setting_playback_track_reset_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_track_reset_title
+import campfire.features.settings.ui.generated.resources.setting_playback_wavy_scrubber_subtitle
+import campfire.features.settings.ui.generated.resources.setting_playback_wavy_scrubber_title
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import org.jetbrains.compose.resources.stringResource
@@ -107,6 +112,28 @@ internal fun PlaybackPane(
       },
       headlineContent = { Text(stringResource(Res.string.setting_playback_remote_skip_title)) },
       supportingContent = { Text(stringResource(Res.string.setting_playback_remote_skip_subtitle)) },
+    )
+
+    Header(
+      title = { Text(stringResource(Res.string.header_player_interface)) },
+    )
+
+    SwitchSetting(
+      value = state.playbackSettings.bookTimeInPlaybackUi,
+      onValueChange = {
+        state.eventSink(PlaybackSettingEvent.BookTimeInPlaybackUi(it))
+      },
+      headlineContent = { Text(stringResource(Res.string.setting_playback_book_time_title)) },
+      supportingContent = { Text(stringResource(Res.string.setting_playback_book_time_subtitle)) },
+    )
+
+    SwitchSetting(
+      value = state.playbackSettings.playbackWavyScrubber,
+      onValueChange = {
+        state.eventSink(PlaybackSettingEvent.PlaybackWavyScrubber(it))
+      },
+      headlineContent = { Text(stringResource(Res.string.setting_playback_wavy_scrubber_title)) },
+      supportingContent = { Text(stringResource(Res.string.setting_playback_wavy_scrubber_subtitle)) },
     )
 
     Header(


### PR DESCRIPTION
## Summary

- Adds an optional **overall book progress indicator** to the expanded player, shown above the seek bar with a speed-adjusted time-remaining readout (off by default)
- Adds a setting to **disable the wavy seek bar animation** for anyone who finds it distracting (on by default, matching current behavior)
- Both toggles live in a new **Player interface** section under Settings → Playback, with analytics events wired up

Closes #888
Closes #553

## Test plan

- [ ] Toggle "Show book progress" in Settings → Playback and confirm the progress indicator with time remaining appears above the seek bar in the expanded player
- [ ] Change playback speed and confirm the time remaining adjusts (with the accelerated icon shown)
- [ ] Toggle "Wavy seek bar" off and confirm the seek bar renders as a flat line during playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)