### PR TITLE
Fix duplicate LazyColumn key crashes from mediaProgress join fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Offline playback of downloaded audiobooks failing when the server is unreachable
+- Crash on launch when more than one account on the device had listening progress for the same book
 
 ### Other Notes & Contributions
 

--- a/app/android/src/main/java/app/campfire/android/CampfireApplication.kt
+++ b/app/android/src/main/java/app/campfire/android/CampfireApplication.kt
@@ -1,6 +1,8 @@
 package app.campfire.android
 
 import android.app.Application
+import androidx.compose.runtime.Composer
+import androidx.compose.runtime.tooling.ComposeStackTraceMode
 import app.campfire.android.di.AndroidAppComponent
 import app.campfire.android.logging.AndroidBark
 import app.campfire.core.di.ComponentHolder
@@ -26,5 +28,8 @@ class CampfireApplication : Application() {
 
     // Call startup initializers
     component.startupInitializer.initialize()
+
+    // Enable more useful compose stack traces in crashes
+    Composer.setDiagnosticStackTraceMode(ComposeStackTraceMode.Auto)
   }
 }

--- a/data/db/core/src/commonMain/sqldelight/app/campfire/data/libraryItemPage.sq
+++ b/data/db/core/src/commonMain/sqldelight/app/campfire/data/libraryItemPage.sq
@@ -97,7 +97,9 @@ SELECT libraryItem.*,media.*,mediaProgress.* FROM libraryItem
 INNER JOIN libraryItemPageJoin ON libraryItemPageJoin.libraryItemId = libraryItem.id
 INNER JOIN media ON media.libraryItemId = libraryItem.id
 LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
-WHERE libraryItemPageJoin.pageId = ?
+  AND mediaProgress.episodeId = ''
+  AND mediaProgress.userId = :userId
+WHERE libraryItemPageJoin.pageId = :pageId
 ORDER BY libraryItemPageJoin.pageIndex ASC;
 
 -- Returns the bare libraryItem rows in page order. Media (book or podcast) and progress

--- a/data/db/core/src/commonMain/sqldelight/app/campfire/data/libraryItems.sq
+++ b/data/db/core/src/commonMain/sqldelight/app/campfire/data/libraryItems.sq
@@ -44,7 +44,8 @@ SELECT libraryItem.*, media.*, mediaProgress.* FROM libraryItem
 INNER JOIN media ON media.libraryItemId = libraryItem.id
 LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
   AND mediaProgress.episodeId = ''
-WHERE libraryItem.id = ?;
+  AND mediaProgress.userId = :userId
+WHERE libraryItem.id = :id;
 
 -- Used by the source-of-truth to decide which join to run for an item.
 selectMediaTypeForId:
@@ -64,7 +65,8 @@ SELECT libraryItem.*, podcastMedia.*, mediaProgress.* FROM libraryItem
 INNER JOIN podcastMedia ON podcastMedia.libraryItemId = libraryItem.id
 LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
   AND mediaProgress.episodeId = ''
-WHERE libraryItem.id = ?;
+  AND mediaProgress.userId = :userId
+WHERE libraryItem.id = :id;
 
 selectForLibrary:
 SELECT * FROM libraryItem
@@ -84,7 +86,8 @@ INNER JOIN shelfJoin ON shelfJoin.entityId = libraryItem.id
 INNER JOIN media ON media.libraryItemId = libraryItem.id
 LEFT JOIN mediaProgress ON mediaProgress.libraryItemId = libraryItem.id
   AND mediaProgress.episodeId = ''
-WHERE shelfJoin.shelfId = ?
+  AND mediaProgress.userId = :userId
+WHERE shelfJoin.shelfId = :shelfId
 ORDER BY shelfJoin.shelfOrder ASC;
 
 -- Podcast variant: same shape as selectForShelf but joins podcastMedia. Used by

--- a/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/dao/LibraryItemDao.kt
+++ b/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/dao/LibraryItemDao.kt
@@ -11,6 +11,7 @@ import app.campfire.core.model.Media
 import app.campfire.core.model.MediaType
 import app.campfire.core.model.loggableId
 import app.campfire.core.session.UserSession
+import app.campfire.core.session.requiredUserId
 import app.campfire.core.session.serverUrl
 import app.campfire.data.LibraryItem as DbLibraryItem
 import app.campfire.data.MediaAudioFiles
@@ -156,7 +157,11 @@ class SqlDelightLibraryItemDao(
     MediaType.Book -> {
       val full = withContext(dispatcherProvider.databaseRead) {
         db.libraryItemsQueries
-          .selectForIdFull(item.id, ::mapToLibraryItemWithProgress)
+          .selectForIdFull(
+            userId = userSession.requiredUserId,
+            id = item.id,
+            mapper = ::mapToLibraryItemWithProgress,
+          )
           .awaitAsOne()
       }
       hydrateItem(full)
@@ -164,7 +169,11 @@ class SqlDelightLibraryItemDao(
     MediaType.Podcast -> {
       val full = withContext(dispatcherProvider.databaseRead) {
         db.libraryItemsQueries
-          .selectForPodcastIdFull(item.id, ::mapToPodcastLibraryItemWithProgress)
+          .selectForPodcastIdFull(
+            userId = userSession.requiredUserId,
+            id = item.id,
+            mapper = ::mapToPodcastLibraryItemWithProgress,
+          )
           .awaitAsOne()
       }
       hydratePodcastItem(full)
@@ -181,7 +190,11 @@ class SqlDelightLibraryItemDao(
       MediaType.Book -> {
         val full = withContext(dispatcherProvider.databaseRead) {
           db.libraryItemsQueries
-            .selectForIdFull(id, ::mapToLibraryItemWithProgress)
+            .selectForIdFull(
+              userId = userSession.requiredUserId,
+              id = id,
+              mapper = ::mapToLibraryItemWithProgress,
+            )
             .awaitAsOneOrNull()
         } ?: return null
         hydrateItem(full)
@@ -189,7 +202,11 @@ class SqlDelightLibraryItemDao(
       MediaType.Podcast -> {
         val full = withContext(dispatcherProvider.databaseRead) {
           db.libraryItemsQueries
-            .selectForPodcastIdFull(id, ::mapToPodcastLibraryItemWithProgress)
+            .selectForPodcastIdFull(
+              userId = userSession.requiredUserId,
+              id = id,
+              mapper = ::mapToPodcastLibraryItemWithProgress,
+            )
             .awaitAsOneOrNull()
         } ?: return null
         hydratePodcastItem(full)

--- a/data/network/api/src/commonMain/kotlin/app/campfire/network/models/LibrarySettings.kt
+++ b/data/network/api/src/commonMain/kotlin/app/campfire/network/models/LibrarySettings.kt
@@ -18,8 +18,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class LibrarySettings(
-  val coverAspectRatio: Int,
-  val disableWatcher: Boolean,
+  val coverAspectRatio: Int = 1,
+  val disableWatcher: Boolean = false,
   val skipMatchingMediaWithAsin: Boolean = false,
   val skipMatchingMediaWithIsbn: Boolean = false,
   val autoScanCronExpression: String? = null,

--- a/features/home/impl/build.gradle.kts
+++ b/features/home/impl/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
       dependencies {
         implementation(projects.features.settings.api)
         implementation(projects.core)
+        implementation(projects.data.crashreporting.api)
         implementation(projects.data.db.core)
         implementation(projects.data.db.mapping)
         implementation(projects.data.network.api)

--- a/features/home/impl/src/commonMain/kotlin/app/campfire/home/store/shelf/ShelfSourceOfTruthFactory.kt
+++ b/features/home/impl/src/commonMain/kotlin/app/campfire/home/store/shelf/ShelfSourceOfTruthFactory.kt
@@ -10,6 +10,7 @@ import app.campfire.core.model.ShelfEntity
 import app.campfire.core.model.ShelfType
 import app.campfire.core.session.UserSession
 import app.campfire.core.session.requiredUserId
+import app.campfire.crashreporting.CrashReporter
 import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.dao.LibraryItemDao
 import app.campfire.data.mapping.model.mapToEpisodeShelfRow
@@ -61,6 +62,7 @@ class ShelfSourceOfTruthFactory(
       .asFlow()
       .mapToList(dispatcherProvider.databaseRead)
       .mapLatest { items -> items.map { libraryItemDao.hydrateItem(it) } }
+      .mapLatest { items -> items.dropDuplicates(shelfId) { it.id } }
   }
 
   /**
@@ -72,6 +74,7 @@ class ShelfSourceOfTruthFactory(
       .asFlow()
       .mapToList(dispatcherProvider.databaseRead)
       .mapLatest { items -> items.map { libraryItemDao.hydratePodcastItem(it) } }
+      .mapLatest { items -> items.dropDuplicates(shelfId) { it.id } }
   }
 
   /**
@@ -83,6 +86,10 @@ class ShelfSourceOfTruthFactory(
       .asFlow()
       .mapToList(dispatcherProvider.databaseRead)
       .mapLatest { rows -> rows.map { it.asDomainModel(urlHydrator) } }
+      .mapLatest { entries ->
+        // Match the UI's key: libraryItemId + recentEpisodeId
+        entries.dropDuplicates(shelfId) { it.libraryItem.id to it.recentEpisode.id }
+      }
   }
 
   private fun readSeries(shelfId: ShelfId): Flow<List<Series>> {
@@ -102,7 +109,7 @@ class ShelfSourceOfTruthFactory(
             .sortedBy { it.media.metadata.seriesSequence?.sequence }
 
           s.asDomainModel(sortedBooks)
-        }
+        }.dropDuplicates(shelfId) { it.id }
       }
   }
 
@@ -111,7 +118,26 @@ class ShelfSourceOfTruthFactory(
       .asFlow()
       .mapToList(dispatcherProvider.databaseRead)
       .mapLatest { authors ->
-        authors.map { it.asDomainModel() }
+        authors.map { it.asDomainModel() }.dropDuplicates(shelfId) { it.id }
       }
   }
 }
+
+/**
+ * The home UI keys its LazyRow items by entity id, so duplicate entities within a
+ * single shelf are fatal. Duplicates should be impossible (the queries are scoped and
+ * the join tables have composite PKs), so rather than let a data bug crash every app
+ * launch, drop the duplicates and record a non-fatal to keep the bug visible.
+ */
+private inline fun <T, K> List<T>.dropDuplicates(shelfId: ShelfId, keySelector: (T) -> K): List<T> {
+  val distinct = distinctBy(keySelector)
+  if (distinct.size != size) {
+    CrashReporter.record(DuplicateShelfEntitiesException(shelfId, size - distinct.size))
+  }
+  return distinct
+}
+
+class DuplicateShelfEntitiesException(
+  shelfId: ShelfId,
+  count: Int,
+) : IllegalStateException("Shelf [$shelfId] emitted $count duplicate entities; duplicates were dropped")

--- a/features/home/impl/src/commonMain/kotlin/app/campfire/home/store/shelf/ShelfSourceOfTruthFactory.kt
+++ b/features/home/impl/src/commonMain/kotlin/app/campfire/home/store/shelf/ShelfSourceOfTruthFactory.kt
@@ -8,6 +8,8 @@ import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.Series
 import app.campfire.core.model.ShelfEntity
 import app.campfire.core.model.ShelfType
+import app.campfire.core.session.UserSession
+import app.campfire.core.session.requiredUserId
 import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.dao.LibraryItemDao
 import app.campfire.data.mapping.model.mapToEpisodeShelfRow
@@ -29,6 +31,7 @@ class ShelfSourceOfTruthFactory(
   private val libraryItemDao: LibraryItemDao,
   private val urlHydrator: UrlHydrator,
   private val dispatcherProvider: DispatcherProvider,
+  private val userSession: UserSession,
 ) {
 
   fun create(): SourceOfTruth<Key, Unit, List<ShelfEntity>> {
@@ -49,7 +52,12 @@ class ShelfSourceOfTruthFactory(
   }
 
   private fun readLibraryItems(shelfId: ShelfId): Flow<List<LibraryItem>> {
-    return db.libraryItemsQueries.selectForShelf(shelfId, ::mapToLibraryItemWithProgress)
+    return db.libraryItemsQueries
+      .selectForShelf(
+        userId = userSession.requiredUserId,
+        shelfId = shelfId,
+        mapper = ::mapToLibraryItemWithProgress,
+      )
       .asFlow()
       .mapToList(dispatcherProvider.databaseRead)
       .mapLatest { items -> items.map { libraryItemDao.hydrateItem(it) } }

--- a/features/home/impl/src/commonMain/kotlin/app/campfire/home/store/shelf/ShelfStore.kt
+++ b/features/home/impl/src/commonMain/kotlin/app/campfire/home/store/shelf/ShelfStore.kt
@@ -6,6 +6,7 @@ import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.logging.Cork
 import app.campfire.core.model.ShelfEntity
 import app.campfire.core.model.ShelfType
+import app.campfire.core.session.UserSession
 import app.campfire.data.mapping.dao.LibraryItemDao
 import app.campfire.home.api.model.ShelfId
 import kotlin.time.Duration.Companion.minutes
@@ -27,6 +28,7 @@ object ShelfStore : Cork {
     libraryItemDao: LibraryItemDao,
     urlHydrator: UrlHydrator,
     dispatcherProvider: DispatcherProvider,
+    userSession: UserSession,
   ) {
 
     private val sourceOfTruthFactory = ShelfSourceOfTruthFactory(
@@ -34,6 +36,7 @@ object ShelfStore : Cork {
       libraryItemDao = libraryItemDao,
       urlHydrator = urlHydrator,
       dispatcherProvider = dispatcherProvider,
+      userSession = userSession,
     )
 
     fun create(): Store<Key, List<ShelfEntity>> {

--- a/infra/socket/impl/src/commonMain/kotlin/app/campfire/socket/impl/DefaultSocketManager.kt
+++ b/infra/socket/impl/src/commonMain/kotlin/app/campfire/socket/impl/DefaultSocketManager.kt
@@ -174,7 +174,7 @@ class DefaultSocketManager(
       socket = newSocket
 
       newSocket.on(Socket.EVENT_CONNECT) {
-        ibark { "Socket connected to $url; reading token and sending auth" }
+        ibark { "Socket connected; reading token and sending auth" }
         _state.value = SocketState.Authenticating
         coroutineScope.launch {
           val freshToken = accountManager.getToken(userId)?.accessToken
@@ -194,7 +194,7 @@ class DefaultSocketManager(
         val authedUserId = payload?.string("userId")
         val username = payload?.string("username")
         if (authedUserId != null && username != null) {
-          ibark { "Socket authenticated as $username ($authedUserId)" }
+          ibark { "Socket authenticated!" }
           _state.value = SocketState.Authenticated(authedUserId, username)
         }
       }


### PR DESCRIPTION
## Summary

Fixes the top Crashlytics crash [`159e25351be7042db517f3af684684db`](https://console.firebase.google.com/v1/appid/project/campfire-a9687/crashlytics/app/1:524630200499:android:1b5178780e730a271260c6/issues/159e25351be7042db517f3af684684db):

> `IllegalArgumentException: Key "<uuid>" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.`

### Root cause

`mediaProgress` is keyed by `(libraryItemId, userId, episodeId)` and the app shares one `campfire.db` across all accounts, but several read queries LEFT JOINed progress on `libraryItemId` alone. When more than one account on a device had listening progress for the same library item, the join fanned each item out into one row per progress row — and the UI keys `LazyRow`/`LazyColumn` items by `item.id`, so the duplicate crashed on first composition (home shelves at launch, hence the `backstack: EmptyScreen` in every event).

### Changes

- `libraryItems.sq`: `selectForIdFull`, `selectForPodcastIdFull`, `selectForShelf` now filter the join with `mediaProgress.userId = :userId` (matching the pattern `podcastEpisodePage.sq` already uses)
- `libraryItemPage.sq`: `selectLibraryItemsForPage` gets the `userId` filter plus the missing `episodeId = ''` filter
- `LibraryItemDao` / `ShelfStore` / `ShelfSourceOfTruthFactory`: thread the current user id (`UserSession`) through to those queries
- `ShelfSourceOfTruthFactory`: defense-in-depth — shelf readers now `distinctBy` their UI key and record a `DuplicateShelfEntitiesException` non-fatal to Crashlytics if duplicates are ever dropped, so a future data bug degrades to a visible non-fatal instead of a crash loop on launch
- `CampfireApplication`: enable Compose diagnostic stack-trace mode so future Compose crashes point at the owning composable
- `DefaultSocketManager`: drop username/server URL from socket logs (they were landing in Crashlytics breadcrumbs)

No schema change — query shapes only, so no `.sqm` migration.

### Testing

- `:data:db:mapping:jvmTest` and `:features:home:impl:jvmTest` pass
- Full `:app:desktop:compileKotlin` builds clean
- Note: `:features:home:ui:compileTestKotlinJvm` fails on `main` too (`HomePresenterTest` missing `mediaProgressRepository` arg) — pre-existing, not touched here

### Related

Closes #893 

🤖 Generated with [Claude Code](https://claude.com/claude-code)