### PR TITLE
Fix socket crash on payloads containing Unicode line terminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Offline playback of downloaded audiobooks failing when the server is unreachable
+- Crash when the server sends a real-time library update containing unusual line-break characters (seen with some podcast descriptions)
 
 ### Other Notes & Contributions
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ jb-compose-navigationevent = "1.1.0"
 junit = "4.13.2"
 kimchi = "0.7.0"
 kmp-socketio = "1.4.4"
+socketio-kotlin = "2.8.0"
 kotlin = "2.4.10"
 kotlin-inject = "0.9.0"
 kotlinpoet = "2.2.0"
@@ -235,6 +236,7 @@ connectivity-android = { module = "dev.jordond.connectivity:connectivity-android
 connectivity-apple = { module = "dev.jordond.connectivity:connectivity-apple", version.ref = "connectivity" }
 connectivity-http = { module = "dev.jordond.connectivity:connectivity-http", version.ref = "connectivity" }
 kmp-socketio = { module = "com.piasy:kmp-socketio", version.ref = "kmp-socketio" }
+socketio-kotlin = { module = "org.hildan.socketio:socketio-kotlin", version.ref = "socketio-kotlin" }
 oidc-crypto = { module = "io.github.kalinjul.kotlin.multiplatform:oidc-crypto", version = "0.16.5" }
 
 tools-desugarjdklibs = "com.android.tools:desugar_jdk_libs:2.1.5"

--- a/infra/socket/impl/build.gradle.kts
+++ b/infra/socket/impl/build.gradle.kts
@@ -17,8 +17,18 @@ kotlin {
         implementation(projects.data.account.api)
         implementation(projects.features.settings.api)
         implementation(libs.kmp.socketio)
+        // Forces kmp-socketio's transitive socketio-kotlin from 2.6.0 up to a version whose
+        // packet regex tolerates line-terminator chars (U+2028 etc.) inside JSON payloads;
+        // 2.6.0 throws InvalidSocketIOPacketException on such packets, crashing the app.
+        // Safe to remove once kmp-socketio depends on socketio-kotlin >= 2.8.0 itself.
+        implementation(libs.socketio.kotlin)
         implementation(libs.kotlinx.coroutines.core)
         implementation(libs.kotlinx.serialization.json)
+      }
+    }
+    commonTest {
+      dependencies {
+        implementation(libs.bundles.test.common)
       }
     }
   }

--- a/infra/socket/impl/src/commonTest/kotlin/app/campfire/socket/impl/SocketIOLineTerminatorTest.kt
+++ b/infra/socket/impl/src/commonTest/kotlin/app/campfire/socket/impl/SocketIOLineTerminatorTest.kt
@@ -1,0 +1,36 @@
+package app.campfire.socket.impl
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.hildan.socketio.SocketIO
+import org.hildan.socketio.SocketIOPacket
+
+/**
+ * Guards the forced socketio-kotlin upgrade in this module's build file.
+ *
+ * JavaScript's JSON.stringify leaves the line-terminator characters U+2028, U+2029, and U+0085
+ * unescaped inside strings, and the Audiobookshelf server emits them verbatim in socket payloads
+ * (e.g. podcast descriptions). socketio-kotlin 2.6.0 — the version kmp-socketio 1.4.4 pulls in —
+ * parses packets with a `.*` regex that stops at line terminators, so such payloads threw
+ * [org.hildan.socketio.InvalidSocketIOPacketException] and crashed the app
+ * (Crashlytics issue 4350da0dd8d479a67b4004bddebb06da). If a dependency change ever rolls the
+ * library back below 2.8.0, this test fails instead of the app crashing in the field.
+ */
+class SocketIOLineTerminatorTest {
+
+  @Test
+  fun decodesEventPayloadContainingLineTerminatorCharacters() {
+    val description = "We open at 6.\u2028Suddenly there is a diner.\u2029Somewhere new\u0085in the cosmos."
+    val encoded = """2["item_updated",{"id":"item-1","description":"$description"}]"""
+
+    val packet = SocketIO.decode(encoded) as SocketIOPacket.Event
+
+    assertThat(packet.payload[0].jsonPrimitive.content).isEqualTo("item_updated")
+    val item = packet.payload[1].jsonObject
+    assertThat(item.getValue("id").jsonPrimitive.content).isEqualTo("item-1")
+    assertThat(item.getValue("description").jsonPrimitive.content).isEqualTo(description)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes Crashlytics issue [`4350da0dd8d479a67b4004bddebb06da`](https://console.firebase.google.com/v1/appid/project/campfire-a9687/crashlytics/app/1:524630200499:android:1b5178780e730a271260c6/issues/4350da0dd8d479a67b4004bddebb06da) — a fatal `InvalidSocketIOPacketException` when the server pushes an `item_updated` socket event whose payload contains Unicode line terminators (first seen 0.13.0-beta).

## Root cause

- JavaScript's `JSON.stringify` leaves the line-terminator characters **U+2028 / U+2029 / U+0085** unescaped inside JSON strings, and Audiobookshelf emits them verbatim in socket payloads — most commonly in podcast descriptions sourced from iTunes.
- `socketio-kotlin` 2.6.0 (pulled in transitively by `kmp-socketio` 1.4.4) parses Socket.IO packets with a `.*` regex. In Kotlin/JVM regex, `.` stops at line terminators, so `matchEntire` fails and the decoder throws.
- `kmp-socketio`'s `WebSocket.onWsText` only catches the Engine.IO-level exception, so the Socket.IO-level one escapes into the library's private coroutine scope → uncaught exception → app crash.

## Fix

- Force the transitive `org.hildan.socketio:socketio-kotlin` dependency from 2.6.0 up to **2.8.0**, which [fixed the packet regex upstream](https://github.com/joffrey-bion/socketio-kotlin) to tolerate line terminators (`(.|[^.])*`). Diffing 2.6.0 → 2.8.0 shows the regex change is the only difference in the parsing API, so it's a safe drop-in.
- Add a regression test that decodes an `item_updated` packet containing all three line-terminator characters, so any future rollback below 2.8.0 fails in CI instead of crashing in the field.
- The direct dependency (and version catalog entry) can be removed once `kmp-socketio` itself depends on `socketio-kotlin` >= 2.8.0.

## Testing

- `:infra:socket:impl:jvmTest` passes; dependency resolution confirms `2.6.0 -> 2.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)