### PR TITLE
Request local network permission when custom DNS resolves to a LAN address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Offline playback of downloaded audiobooks failing when the server is unreachable
 - Crash on launch when more than one account on the device had listening progress for the same book
+- Server addresses that resolve to a local IP through custom DNS being rejected on Android 16+ (the local network permission is now requested for them)
 
 ### Other Notes & Contributions
 

--- a/app/android/src/main/java/app/campfire/android/permission/AndroidLocalNetworkPermissionController.kt
+++ b/app/android/src/main/java/app/campfire/android/permission/AndroidLocalNetworkPermissionController.kt
@@ -3,14 +3,20 @@ package app.campfire.android.permission
 import android.app.Application
 import android.content.pm.PackageManager
 import android.os.Build
+import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
 import app.campfire.core.logging.bark
 import app.campfire.core.permission.LocalNetworkPermissionController
+import app.campfire.core.permission.extractUrlHost
 import app.campfire.core.permission.isPrivateNetworkAddress
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.UnknownHostException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 
 /**
@@ -24,6 +30,7 @@ import me.tatarka.inject.annotations.Inject
 class AndroidLocalNetworkPermissionController(
   private val application: Application,
   private val launcher: LocalNetworkPermissionLauncher,
+  private val dispatcherProvider: DispatcherProvider,
 ) : LocalNetworkPermissionController {
 
   private val mutex = Mutex()
@@ -32,8 +39,8 @@ class AndroidLocalNetworkPermissionController(
   override suspend fun requestIfNeeded(serverUrl: String): Boolean {
     // LNP only applies on Android 16+; older versions have no such gate.
     if (Build.VERSION.SDK_INT < LNP_MIN_SDK) return true
-    if (!isPrivateNetworkAddress(serverUrl)) return true
     if (isGranted()) return true
+    if (!pointsAtPrivateNetwork(serverUrl)) return true
 
     mutex.withLock {
       // Re-check inside the lock in case a concurrent request already resolved it.
@@ -48,6 +55,29 @@ class AndroidLocalNetworkPermissionController(
     bark { "ACCESS_LOCAL_NETWORK permission ${if (granted) "granted" else "denied"}" }
     return granted
   }
+
+  /**
+   * A public-looking hostname can still resolve to a LAN address via split-horizon DNS
+   * (e.g. `abs.example.com` overridden to `192.168.x.x` on the local resolver), which LNP
+   * gates all the same. DNS resolution itself goes through the system resolver and is exempt,
+   * so when the string heuristic says "public" we resolve the host and check where it lands.
+   */
+  private suspend fun pointsAtPrivateNetwork(serverUrl: String): Boolean {
+    if (isPrivateNetworkAddress(serverUrl)) return true
+    val host = extractUrlHost(serverUrl) ?: return false
+    return withContext(dispatcherProvider.io) {
+      try {
+        InetAddress.getAllByName(host).any { it.isPrivateAddress() }
+      } catch (e: UnknownHostException) {
+        false
+      }
+    }
+  }
+
+  private fun InetAddress.isPrivateAddress(): Boolean =
+    isSiteLocalAddress || isLinkLocalAddress || isLoopbackAddress ||
+      // ULA fc00::/7 isn't covered by isSiteLocalAddress
+      (this is Inet6Address && (address[0].toInt() and 0xFE) == 0xFC)
 
   private fun isGranted(): Boolean =
     application.checkSelfPermission(ACCESS_LOCAL_NETWORK) == PackageManager.PERMISSION_GRANTED

--- a/core/src/commonMain/kotlin/app/campfire/core/permission/PrivateNetworkAddress.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/permission/PrivateNetworkAddress.kt
@@ -9,7 +9,7 @@ package app.campfire.core.permission
  * library so it can live in `:core`. Unknown/public hosts return `false`.
  */
 fun isPrivateNetworkAddress(serverUrl: String): Boolean {
-  val host = extractHost(serverUrl)?.lowercase() ?: return false
+  val host = extractUrlHost(serverUrl)?.lowercase() ?: return false
 
   if (host == "localhost" ||
     host.endsWith(".local") ||
@@ -46,7 +46,7 @@ fun isPrivateNetworkAddress(serverUrl: String): Boolean {
 }
 
 /** Pulls the bare host out of a possibly-schemed `host:port/path` string. */
-private fun extractHost(serverUrl: String): String? {
+fun extractUrlHost(serverUrl: String): String? {
   var s = serverUrl.trim()
   if (s.isEmpty()) return null
 

--- a/core/src/commonTest/kotlin/app/campfire/core/permission/PrivateNetworkAddressTest.kt
+++ b/core/src/commonTest/kotlin/app/campfire/core/permission/PrivateNetworkAddressTest.kt
@@ -1,7 +1,9 @@
 package app.campfire.core.permission
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import kotlin.test.Test
 
@@ -54,5 +56,15 @@ class PrivateNetworkAddressTest {
   fun blank_or_garbage_is_not_private() {
     assertThat(isPrivateNetworkAddress("")).isFalse()
     assertThat(isPrivateNetworkAddress("   ")).isFalse()
+  }
+
+  @Test
+  fun extractUrlHost_pulls_bare_host_from_url_forms() {
+    assertThat(extractUrlHost("https://abs.example.com")).isEqualTo("abs.example.com")
+    assertThat(extractUrlHost("https://abs.example.com:13378/status?x=1")).isEqualTo("abs.example.com")
+    assertThat(extractUrlHost("http://user:pass@abs.example.com:80/path")).isEqualTo("abs.example.com")
+    assertThat(extractUrlHost("abs.example.com:13378")).isEqualTo("abs.example.com")
+    assertThat(extractUrlHost("http://[fd00::1]:8080")).isEqualTo("fd00::1")
+    assertThat(extractUrlHost("")).isNull()
   }
 }


### PR DESCRIPTION
## Summary

Fixes #892

A public-looking hostname (e.g. `abs.example.com`) can resolve to a private IP (e.g. `192.168.1.254`) via split-horizon DNS — a local resolver override pointing the domain at the LAN server while the public record goes through a proxy. Android 16+ Local Network Protection gates connections to private addresses behind the runtime `ACCESS_LOCAL_NETWORK` permission regardless of what the hostname looks like, so on the alpha build (targetSdk 37) the connection test failed with a 10s timeout / `ECONNABORTED` and the login screen reported "Invalid address".

The existing permission prompt only fired when `isPrivateNetworkAddress()` — a pure string heuristic — recognized the URL as local, which a public-looking domain never triggers.

## Fix

- `AndroidLocalNetworkPermissionController.requestIfNeeded` now falls back to a real DNS lookup when the string heuristic says "public": the host is resolved via `InetAddress.getAllByName` on the IO dispatcher and checked against private ranges (RFC 1918, loopback, link-local, IPv6 ULA). DNS resolution goes through the system resolver, which is LNP-exempt — confirmed by the reporter's log where the hostname resolved fine and only the socket connect was blocked.
- `isGranted()` is checked before the address check, so once the permission is granted no DNS lookup happens at all.
- Exposed `extractUrlHost` from `:core` (previously the private `extractHost`) for the controller to use, with new test coverage.

Both call sites — the login connection probe and the `MainActivity` upgrade path — route through this controller, so both are covered.

## Testing

- `:core:jvmTest` — `PrivateNetworkAddressTest` passes, including new `extractUrlHost` cases
- `:app:android:compileAlphaDebugKotlin` — builds clean

## Not in scope

Scheme auto-detection (`https://` → `http://` fallback when no scheme is typed) from the issue's side request is deliberately left for a follow-up — it involves a persistence change and an https→http downgrade UX/security decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)