### PR TITLE
Fix socket never connecting after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash on launch when more than one account on the device had listening progress for the same book
 - Server addresses that resolve to a local IP through custom DNS being rejected on Android 16+ (the local network permission is now requested for them)
 - Campfire logo flame flickering during the Welcome to Login screen transition
+- Real-time sync socket not connecting after logging in until the app was restarted
 
 ### Other Notes & Contributions
 

--- a/infra/socket/impl/src/commonMain/kotlin/app/campfire/socket/impl/DefaultSocketManager.kt
+++ b/infra/socket/impl/src/commonMain/kotlin/app/campfire/socket/impl/DefaultSocketManager.kt
@@ -56,6 +56,7 @@ import com.r0adkll.kimchi.annotations.ContributesMultibinding
 import kotlin.concurrent.Volatile
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -153,8 +154,12 @@ class DefaultSocketManager(
   @Volatile
   private var socket: Socket? = null
 
-  internal suspend fun start() {
-    val session = userSessionManager.current as? UserSession.LoggedIn ?: return
+  /** Foreground/background observer for the currently active socket; cancelled on [stop] so a
+   * replaced socket's observer can't reopen the stale connection alongside the new one. */
+  @Volatile
+  private var appLifecycleJob: Job? = null
+
+  internal suspend fun start(session: UserSession.LoggedIn) {
     if (accountManager.getToken(session.user.id)?.accessToken == null) {
       wbark { "No access token for user ${session.user.id}; skipping socket connect" }
       return
@@ -280,7 +285,8 @@ class DefaultSocketManager(
 
       newSocket.open()
 
-      coroutineScope.launch {
+      appLifecycleJob?.cancel()
+      appLifecycleJob = coroutineScope.launch {
         appLifecycleObserver.state.collectLatest { lifecycleState ->
           when (lifecycleState) {
             AppLifecycleState.Background -> {
@@ -305,6 +311,8 @@ class DefaultSocketManager(
   }
 
   internal suspend fun stop() {
+    appLifecycleJob?.cancel()
+    appLifecycleJob = null
     val current = socket
     socket = null
     if (current != null) {
@@ -327,7 +335,12 @@ class DefaultSocketManager(
     }
     coroutineScope.launch {
       stop()
-      start()
+      val session = userSessionManager.current as? UserSession.LoggedIn
+      if (session == null) {
+        ibark { "retryConnection called without a logged-in session; ignoring" }
+        return@launch
+      }
+      start(session)
     }
   }
 
@@ -349,14 +362,23 @@ class DefaultSocketManager(
   @Inject
   class Lifecycle(
     private val socketManager: DefaultSocketManager,
+    // The session this UserScope was built for. During login the global
+    // UserSessionManager.current is still Loading when onCreate fires (changeSession only
+    // publishes it after the graph is created), so reading the global here races and the
+    // socket would silently never connect. The graph-bound session is always correct.
+    private val userSession: UserSession,
   ) : Scoped {
+
+    private var observerJob: Job? = null
+
     override suspend fun onCreate() {
+      val session = userSession as? UserSession.LoggedIn ?: return
       // collectLatest cancels the previous start when the setting flips, so toggling off
       // mid-connection cleanly disconnects and toggling back on spins up a fresh socket.
-      socketManager.coroutineScope.launch {
+      observerJob = socketManager.coroutineScope.launch {
         socketManager.settings.observeSocketEnabled().collectLatest { enabled ->
           if (enabled) {
-            socketManager.start()
+            socketManager.start(session)
           } else {
             socketManager.stopForDisable()
           }
@@ -365,6 +387,10 @@ class DefaultSocketManager(
     }
 
     override suspend fun onDestroy() {
+      // Cancel the settings observer so destroyed UserScopes don't accumulate collectors
+      // on the app scope, each restarting the socket whenever the setting flips.
+      observerJob?.cancel()
+      observerJob = null
       socketManager.stop()
     }
   }


### PR DESCRIPTION
## Summary

The realtime sync socket never connected after logging in — it only came alive after an app restart or toggling the setting.

**Root cause:** a startup race. `DefaultAccountManager.changeSession()` sets the session to `Loading`, creates the new `UserScope` graph, and only *afterwards* publishes `userSessionManager.current = LoggedIn`. But `UserComponentManager.create()` launches every `Scoped.onCreate()` on the app scope (`Dispatchers.Default`), so `DefaultSocketManager.start()` frequently ran before the publish, saw `Loading` in `userSessionManager.current as? UserSession.LoggedIn ?: return`, and silently bailed with nothing to retry.

**Fix:** the socket `Lifecycle` now injects the graph-bound `UserSession` (the one passed to `UserComponent.Factory.create()`, always correct at `onCreate` time) and hands it to `start(session)` instead of racing the global mutable state. `retryConnection()` keeps reading the global (fine for a user-initiated retry) but now no-ops with a log when no session is logged in.

Also fixes two collector leaks that caused ghost-socket behavior across re-logins:

- The settings observer launched in `Lifecycle.onCreate` lived on the app scope forever, stacking a new collector on every login/logout; it's now cancelled in `onDestroy`.
- Each `start()` launched an immortal foreground/background observer bound to its specific socket — a stale one could reopen a replaced, closed socket when the app foregrounded. `stop()` now cancels it.

## Test plan

- [x] `:infra:socket:impl:jvmTest` passes
- [x] `:infra:socket:impl` compiles for JVM + Android; full `:app:desktop` compile validates the DI graph resolves the new `UserSession` injection
- [x] ktlint clean
- [ ] Manual: fresh login connects the socket immediately (state reaches `Authenticated` without restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)