### PR TITLE
Guard against eBook-only library items

### DIFF
--- a/.claude/agent-memory/audiobookshelf-server-explorer/MEMORY.md
+++ b/.claude/agent-memory/audiobookshelf-server-explorer/MEMORY.md
@@ -7,3 +7,4 @@
 - [Podcast Model & API](podcast-model.md) — Full podcast/episode shapes, serialization variants, endpoints, progress model, sort/filter keys
 - [Socket.IO Surface](socketio-surface.md) — Complete inventory: connection path, post-connect auth flow, all client→server and server→client events, broadcast scoping rules
 - [Auth Token Lifecycle](auth-token-lifecycle.md) — Access/refresh TTLs, /auth/refresh contract, rotation race condition, socket never re-validates JWT after initial auth, Campfire client gap
+- [Book Media Shapes](book-media-shapes.md) — Exact minified/basic/expanded field lists for Book media, ebookFile shape, numMissingParts doesn't exist

--- a/.claude/agent-memory/audiobookshelf-server-explorer/book-media-shapes.md
+++ b/.claude/agent-memory/audiobookshelf-server-explorer/book-media-shapes.md
@@ -1,0 +1,56 @@
+---
+name: Book Media Shapes (minified vs basic vs expanded)
+description: Exact field lists for Book media JSON across the three serialization variants, plus ebookFile shape and which endpoint returns which variant
+type: reference
+---
+
+Source: `server/models/Book.js` (Sequelize model, current — the old `server/objects/Book.js` plain-object class no longer exists in the DB-backed rewrite). Confirmed against server v2.34.0 both by source reading and live requests to a real "The Way of Kings" item that has both audio tracks and a PDF ebookFile.
+
+## Three distinct Book media serializations — not just two
+1. **`toOldJSONMinified()`** — used in library item LISTS (`GET /api/libraries/:id/items`, always, regardless of `?minified=` query param — that param controls something else internally, not this choice of serializer per `LibraryItem.getByFilterAndSort` in `server/models/LibraryItem.js`).
+2. **`toOldJSON()`** ("basic") — used by `GET /api/items/:id` **without** `?expanded=1`. This is NOT the minified shape and NOT the expanded shape — it's a third, distinct shape.
+3. **`toOldJSONExpanded(libraryItemId)`** — used by `GET /api/items/:id?expanded=1`.
+
+Router: `server/controllers/LibraryItemController.js` `findOne()` — `req.query.expanded == 1` branches to `toOldJSONExpanded()`, otherwise plain `toOldJSON()`. Minified is never an option on the single-item detail endpoint.
+
+## Field lists (media object only)
+
+**Minified** (`oldMetadataToJSONMinified` + flat counts):
+`id, metadata{title,titleIgnorePrefix,subtitle,authorName,authorNameLF,narratorName,seriesName,genres,publishedYear,publishedDate,publisher,description,isbn,asin,language,explicit,abridged}, coverPath, tags, numTracks, numAudioFiles, numChapters, duration, size, ebookFormat`
+- metadata here is FLATTENED (authorName/seriesName as pre-joined strings, no arrays of author/series objects).
+- `ebookFormat` is a flat string (e.g. `"pdf"`), not an object — pulled from `this.ebookFile?.ebookFormat`.
+
+**Basic** (`toOldJSON`, i.e. detail endpoint without `?expanded=1`):
+`id, libraryItemId, metadata{title,subtitle,authors[{id,name}],narrators[],series[{id,name,sequence}],genres,publishedYear,publishedDate,publisher,description,isbn,asin,language,explicit,abridged}, coverPath, tags, audioFiles[], chapters[], ebookFile{...}`
+- metadata here uses `oldMetadataToJSON()` — structured authors/series arrays, no authorName/seriesName/titleIgnorePrefix/descriptionPlain strings.
+- Full `audioFiles[]` and `ebookFile` object included, but NO `duration`, `size`, or `tracks` convenience fields, and NO `numTracks`/`numAudioFiles`/`numChapters`/`ebookFormat` flat fields.
+
+**Expanded** (`toOldJSONExpanded`, `?expanded=1`):
+`id, libraryItemId, metadata{...+titleIgnorePrefix,authorName,authorNameLF,narratorName,seriesName,descriptionPlain}, coverPath, tags, audioFiles[], chapters[], ebookFile{...}, duration, size, tracks[]`
+- metadata uses `oldMetadataToJSONExpanded()` — has BOTH the structured authors/series arrays AND the flattened authorName/seriesName strings AND `descriptionPlain` (HTML-stripped description).
+- Adds `duration`, `size`, and `tracks[]` (the playable AudioTrack list with `contentUrl`/`startOffset` computed via `getTracklist(libraryItemId)`).
+- **Does NOT include `numTracks`, `numAudioFiles`, `numChapters`, or flat `ebookFormat`** — those are minified-only convenience fields. Clients needing counts on the expanded/basic shape must derive them (`audioFiles.length`, `chapters.length`, `ebookFile?.ebookFormat`).
+
+## `numMissingParts` / `numInvalidAudioFiles` — DO NOT EXIST
+Confirmed via `grep -rn "numMissingParts|numInvalidAudioFiles" server/ client/` → zero hits anywhere in current server or client source (v2.34.0). These are not present on ANY Book media serialization (minified, basic, or expanded). If they ever existed it was in a pre-Sequelize-rewrite version; do not rely on them. The nearest analogues live on the LibraryItem level, not media: `isMissing`, `isInvalid` (booleans on the LibraryItem itself, in all three LibraryItem serializations).
+
+## ebookFile object shape (identical on basic and expanded — confirmed byte-identical live)
+Source: `server/objects/files/EBookFile.js` `toJSON()`:
+```
+ebookFile: {
+  ino: string,
+  metadata: { filename, ext, path, relPath, size, mtimeMs, ctimeMs, birthtimeMs },  // FileMetadata.toJSON()
+  ebookFormat: string,   // e.g. "pdf", "epub" — falls back to metadata.format if not set explicitly
+  addedAt: number,       // epoch ms
+  updatedAt: number      // epoch ms
+}
+```
+`ebookFile.ebookFormat` is the canonical field for format — NOT nested under `ebookFile.metadata`. `EBookFile.isEpub` getter (`ebookFormat === 'epub'`) exists server-side but is not serialized.
+
+## Live-confirmed example (server v2.34.0, item "The Way of Kings", has audio + PDF ebook)
+Minified media top-level keys: `id, metadata, coverPath, tags, numTracks, numAudioFiles, numChapters, duration, size, ebookFormat`
+Basic media top-level keys: `id, libraryItemId, metadata, coverPath, tags, audioFiles, chapters, ebookFile`
+Expanded media top-level keys: `id, libraryItemId, metadata, coverPath, tags, audioFiles, chapters, ebookFile, duration, size, tracks`
+ebookFile.ebookFormat = `"pdf"` on both basic and expanded, identical object.
+
+See also [[podcast-model]] for the podcast-side equivalents (Podcast/PodcastEpisode have their own minified/expanded rules, different field names).

--- a/.claude/agent-memory/audiobookshelf-server-explorer/server-location-auth.md
+++ b/.claude/agent-memory/audiobookshelf-server-explorer/server-location-auth.md
@@ -1,14 +1,17 @@
 ---
 name: Server Location & Auth
-description: ABS server runs in Docker container jolly_saha; source in /workspaces/audiobookshelf; uses global.ConfigPath for DB path
+description: How to reach the local ABS dev server - host source clone, Docker container quirks, no published port, and login flow
 type: reference
 ---
 
-- Server: http://localhost:3333 (Docker dev container named `jolly_saha`)
-- Source root: `/workspaces/audiobookshelf/` inside the container
+- Live server: http://localhost:3333 is only reachable from INSIDE the Docker container's network namespace — the devcontainer publishes NO ports to the host (`docker inspect <name> --format '{{json .NetworkSettings.Ports}}'` returns `{}`). Host-side `curl http://localhost:3333/...` will hang/fail (000). Always do `docker exec <container> curl ...` (or a node one-liner via `docker exec`) to hit the API, and write intermediate JSON to files INSIDE the container (e.g. `/tmp/items.json`) — `docker exec` has no access to the host's `/tmp`.
+- Docker container name changes between sessions — do NOT trust a memorized name. Find it fresh each time: `docker ps -a --format "{{.Names}}\t{{.Image}}\t{{.Status}}"` and look for the `vsc-audiobookshelf-*` image. Seen names so far: `jolly_saha`, `thirsty_hopper`.
+- The container is often `Exited` (stopped) — check `docker info` first; if the Docker daemon itself isn't running, `open -a Docker` and poll `docker info` until it succeeds (few seconds). Then `docker start <container>`.
+- The container does NOT auto-run the ABS server on start — it just idles on a sleep loop. You must start it manually: `docker exec -d <container> sh -c "cd /workspaces/audiobookshelf && node index.js --dev > /tmp/abs.log 2>&1"`. Uses `dev.js` config: port 3333, ConfigPath=`config/`, MetadataPath=`metadata/`. Confirm startup via `docker exec <container> cat /tmp/abs.log` (look for "Listening on port :3333").
+- Clean up after testing: `docker exec <container> pkill -f "node index.js"` to stop the ad hoc server (exit code 143 from pkill itself is normal/expected, not an error).
+- Source root inside container: `/workspaces/audiobookshelf/`
+- **A host-side clone also exists** at `/Users/r0adkll/OpenSource/audiobookshelf` — read source directly from here with the Read tool instead of `docker exec cat`, much faster. It has two remotes: `origin` (advplyr/audiobookshelf) and `fork` (r0adkll/audiobookshelf), currently on `master`. Verify freshness with `git -C /Users/r0adkll/OpenSource/audiobookshelf describe --tags` before trusting it as current (seen `v2.34.0-4-ge39e8d8c`, HEAD commit `LOCAL DEV CONTAINER` which is a harmless local devcontainer-config commit, not upstream).
 - DB: `/workspaces/audiobookshelf/config/absdatabase.sqlite` (SQLite via Sequelize)
-- DB init requires `global.ConfigPath` and `global.MetadataPath` to be set before `require('./server/Database')`
-- Server version tested: 2.33.2
+- Server version tested most recently: 2.34.0 (2026-07 session). Earlier session tested 2.33.2 under container `jolly_saha`.
 - Auth: POST /login with {username: root, password: password} → user.token (JWT); use as `Authorization: Bearer <token>`
-- To read DB directly from host: `docker exec jolly_saha node -e "global.ConfigPath=...; require('./server/Database').init()..."`
-- sqlite3 CLI not installed in container; use Node or Sequelize to query
+- Seed data observed: libraries "Generated Books" (book, ~2997 items, mostly single-track placeholder audio, duration 300s each), "Real Books" (book, 5 items — Starship Troopers, Dune, The Way of Kings [has PDF ebookFile], Not Till We Are Lost, Fourth Wing), "Podcasts" (podcast).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Setting to disable the wavy playback seek bar animation
 - Quick-insert bar above the keyboard when typing the server address at login, with one-tap snippets for https://, http://, local network prefixes, and the default Audiobookshelf port
 - Server addresses no longer require typing http(s):// — the login screen detects the right scheme automatically and fills it in
+- eBook-only library items now show a format badge on their covers and their play, download, and queue actions are disabled since reading eBooks isn't supported yet
 
 ### Changed
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/LibraryItemCard.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/LibraryItemCard.kt
@@ -151,6 +151,12 @@ fun LibraryItemCard(
                 offlineStatus = offlineStatus,
                 isTransitioning = isTransitioning,
               )
+            } else if (item.isEbookOnly) {
+              // Render the ebook format decoration
+              EbookFormatDecorator(
+                format = item.media.ebookFormat.orEmpty(),
+                isTransitioning = isTransitioning,
+              )
             } else {
               // Render the offline status decoration
               OfflineStatusDecorator(
@@ -362,6 +368,47 @@ private fun BoxScope.PodcastEpisodeDecorator(
       )
     }
   }
+}
+
+@Composable
+private fun BoxScope.EbookFormatDecorator(
+  format: String,
+  isTransitioning: Boolean,
+) {
+  AnimatedVisibility(
+    visible = isTransitioning,
+    enter = fadeIn(),
+    exit = fadeOut(),
+    modifier = Modifier
+      .align(Alignment.TopEnd)
+      .padding(
+        end = 8.dp,
+        top = 8.dp,
+      ),
+  ) {
+    EbookFormatBadge(format = format)
+  }
+}
+
+@Composable
+fun EbookFormatBadge(
+  format: String,
+  modifier: Modifier = Modifier,
+) {
+  Text(
+    text = format.uppercase(),
+    style = MaterialTheme.typography.labelSmall,
+    color = Color.White,
+    modifier = modifier
+      .clip(CircleShape)
+      .background(
+        color = MaterialTheme.colorScheme.scrim.copy(0.68f),
+      )
+      .padding(
+        horizontal = 8.dp,
+        vertical = 4.dp,
+      ),
+  )
 }
 
 @Composable

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/LibraryItemListItem.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/LibraryItemListItem.kt
@@ -122,6 +122,15 @@ fun LibraryItemListItem(
             .padding(8.dp),
         )
 
+        if (libraryItem.isEbookOnly) {
+          EbookFormatBadge(
+            format = libraryItem.media.ebookFormat.orEmpty(),
+            modifier = Modifier
+              .align(Alignment.TopEnd)
+              .padding(8.dp),
+          )
+        }
+
         if (mediaProgress?.isFinished == true) {
           MediaFinishedIndicator(
             size = 18.dp,

--- a/core/src/commonMain/kotlin/app/campfire/core/model/LibraryItem.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/model/LibraryItem.kt
@@ -30,6 +30,12 @@ data class LibraryItem(
 ) : ShelfEntity {
 
   /**
+   * @see Media.isEbookOnly
+   */
+  val isEbookOnly: Boolean
+    get() = media.isEbookOnly
+
+  /**
    * Get the current chapter for the total duration of time passed in the
    * playback
    *

--- a/core/src/commonMain/kotlin/app/campfire/core/model/Media.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/model/Media.kt
@@ -28,6 +28,14 @@ sealed interface Media {
   val chapters: List<Chapter> get() = emptyList()
   val tracks: List<AudioTrack> get() = emptyList()
 
+  /**
+   * A book whose media only contains an ebook file with no audio content. Campfire
+   * doesn't support reading ebooks (yet), so playback and download actions are
+   * guarded for these items.
+   */
+  val isEbookOnly: Boolean
+    get() = this is Book && ebookFormat != null && numTracks == 0 && tracks.isEmpty()
+
   val durationInSeconds: Float
     get() = durationInMillis.milliseconds.asSeconds()
 

--- a/core/src/commonMain/kotlin/app/campfire/core/model/preview/LibraryItemPreview.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/model/preview/LibraryItemPreview.kt
@@ -30,6 +30,8 @@ fun libraryItem(
   tags: List<String> = listOf("Lit", "RPG", "NoPants", "Tootsies"),
   seriesSequence: SeriesSequence? = null,
   numOfChapters: Int = 20,
+  numTracks: Int = 10,
+  ebookFormat: String? = null,
   userMediaProgress: MediaProgress? = null,
 ) = LibraryItem(
   id = id,
@@ -75,11 +77,12 @@ fun libraryItem(
     coverImageUrl = "",
     coverPath = null,
     tags = tags,
-    numTracks = 10,
-    numAudioFiles = 10,
+    numTracks = numTracks,
+    numAudioFiles = numTracks,
     numChapters = 23,
     numMissingParts = 0,
     numInvalidAudioFiles = 0,
+    ebookFormat = ebookFormat,
     durationInMillis = duration.inWholeMilliseconds,
     sizeInBytes = 1L * 1024L * 1024L,
     chapters = (0 until numOfChapters).map { chapter ->

--- a/core/src/commonTest/kotlin/app/campfire/core/model/MediaEbookOnlyTest.kt
+++ b/core/src/commonTest/kotlin/app/campfire/core/model/MediaEbookOnlyTest.kt
@@ -1,0 +1,67 @@
+package app.campfire.core.model
+
+import app.campfire.core.model.preview.libraryItem
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class MediaEbookOnlyTest {
+
+  @Test
+  fun ebookOnlyBook_isEbookOnly() {
+    val item = libraryItem(numTracks = 0, numOfChapters = 0, ebookFormat = "epub")
+
+    assertThat(item.isEbookOnly).isTrue()
+    assertThat(item.media.isEbookOnly).isTrue()
+  }
+
+  @Test
+  fun bookWithAudioAndEbook_isNotEbookOnly() {
+    val item = libraryItem(numTracks = 10, ebookFormat = "epub")
+
+    assertThat(item.isEbookOnly).isFalse()
+  }
+
+  @Test
+  fun bookWithAudioOnly_isNotEbookOnly() {
+    val item = libraryItem(numTracks = 10, ebookFormat = null)
+
+    assertThat(item.isEbookOnly).isFalse()
+  }
+
+  @Test
+  fun bookWithNoTracksAndNoEbook_isNotEbookOnly() {
+    val item = libraryItem(numTracks = 0, numOfChapters = 0, ebookFormat = null)
+
+    assertThat(item.isEbookOnly).isFalse()
+  }
+
+  @Test
+  fun podcast_isNotEbookOnly() {
+    val podcast = Media.Podcast(
+      id = "podcast_media_id",
+      metadata = Media.Metadata.Podcast(
+        title = "Podcast",
+        author = null,
+        description = null,
+        releaseDate = null,
+        genres = emptyList(),
+        feedUrl = null,
+        imageUrl = null,
+        itunesPageUrl = null,
+        itunesId = null,
+        itunesArtistId = null,
+        isExplicit = false,
+        language = null,
+        podcastType = null,
+      ),
+      coverImageUrl = "",
+      coverPath = null,
+      tags = emptyList(),
+      sizeInBytes = 0L,
+    )
+
+    assertThat(podcast.isEbookOnly).isFalse()
+  }
+}

--- a/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/LibraryItemMapping.kt
+++ b/data/db/mapping/src/commonMain/kotlin/app/campfire/data/mapping/LibraryItemMapping.kt
@@ -134,9 +134,9 @@ fun <T : Media> T.asDbModel(
     mediaId = id,
     coverPath = coverPath,
     tags = tags,
-    numTracks = numTracks,
-    numAudioFiles = numAudioFiles,
-    numChapters = numChapters,
+    numTracks = resolvedNumTracks,
+    numAudioFiles = resolvedNumAudioFiles,
+    numChapters = resolvedNumChapters,
     numMissingParts = numMissingParts,
     numInvalidAudioFiles = numInvalidAudioFiles,
     durationInMillis = duration?.seconds?.inWholeMilliseconds ?: run {
@@ -157,7 +157,7 @@ fun <T : Media> T.asDbModel(
       } ?: 0L
     },
     propertySize = propertySize,
-    ebookFormat = ebookFormat,
+    ebookFormat = resolvedEbookFormat,
 
     metadata_title = metadata.title,
     metadata_subtitle = metadata.subtitle,
@@ -309,14 +309,14 @@ private fun LibraryItemExpanded.Book.asDomainModelBook(
         coverImageUrl = urlHydrator.hydrateLibraryItem(id),
         coverPath = coverPath,
         tags = tags ?: emptyList(),
-        numTracks = numTracks,
-        numAudioFiles = numAudioFiles,
-        numChapters = numChapters,
+        numTracks = resolvedNumTracks,
+        numAudioFiles = resolvedNumAudioFiles,
+        numChapters = resolvedNumChapters,
         numMissingParts = numMissingParts,
         numInvalidAudioFiles = numInvalidAudioFiles,
         durationInMillis = duration?.seconds?.inWholeMilliseconds ?: 0,
         sizeInBytes = size ?: -1,
-        ebookFormat = ebookFormat,
+        ebookFormat = resolvedEbookFormat,
 
         audioFiles = audioFiles.map {
           it.asDomainModel()

--- a/data/network/api/src/commonMain/kotlin/app/campfire/network/models/EBookFile.kt
+++ b/data/network/api/src/commonMain/kotlin/app/campfire/network/models/EBookFile.kt
@@ -1,0 +1,22 @@
+package app.campfire.network.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The ebook file attached to a book library item. Only serialized on the basic and
+ * expanded media shapes — the minified shape flattens it to `ebookFormat`.
+ *
+ * @param ino The inode of the file.
+ * @param metadata The file's metadata.
+ * @param ebookFormat The format of the ebook, e.g. "epub", "pdf".
+ * @param addedAt The time (in ms since POSIX epoch) when the file was added.
+ * @param updatedAt The time (in ms since POSIX epoch) when the file was last updated.
+ */
+@Serializable
+data class EBookFile(
+  val ino: String,
+  val metadata: FileMetadata,
+  val ebookFormat: String? = null,
+  val addedAt: Long = 0L,
+  val updatedAt: Long = 0L,
+)

--- a/data/network/api/src/commonMain/kotlin/app/campfire/network/models/Media.kt
+++ b/data/network/api/src/commonMain/kotlin/app/campfire/network/models/Media.kt
@@ -26,6 +26,23 @@ abstract class Media {
 
   abstract val propertySize: Int?
   abstract val ebookFormat: String?
+
+  // The server only serializes numTracks/numAudioFiles/numChapters/ebookFormat on the
+  // MINIFIED media shape. The expanded shape carries the full tracks/audioFiles/chapters
+  // arrays and an ebookFile object instead, leaving the flat fields at their 0/null
+  // defaults. Map from these resolved accessors so an expanded fetch doesn't clobber
+  // good minified values already stored locally.
+  val resolvedNumTracks: Int
+    get() = if (this is MediaExpanded) tracks.size else numTracks
+
+  val resolvedNumAudioFiles: Int
+    get() = if (this is MediaExpanded) audioFiles.size else numAudioFiles
+
+  val resolvedNumChapters: Int
+    get() = if (this is MediaExpanded) chapters.size else numChapters
+
+  val resolvedEbookFormat: String?
+    get() = ebookFormat ?: (this as? MediaExpanded)?.ebookFile?.ebookFormat
 }
 
 @Serializable
@@ -63,4 +80,5 @@ data class MediaExpanded(
   val audioFiles: List<AudioFile> = emptyList(),
   val chapters: List<BookChapter> = emptyList(),
   val tracks: List<AudioTrack> = emptyList(),
+  val ebookFile: EBookFile? = null,
 ) : Media()

--- a/data/network/api/src/commonTest/kotlin/app/campfire/network/models/MediaExpandedTest.kt
+++ b/data/network/api/src/commonTest/kotlin/app/campfire/network/models/MediaExpandedTest.kt
@@ -1,0 +1,119 @@
+package app.campfire.network.models
+
+import app.campfire.network.TestJson
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import kotlin.test.Test
+
+class MediaExpandedTest {
+
+  @Test
+  fun expandedEbookOnlyMedia_resolvesEbookFormatFromEbookFile() {
+    // The expanded shape has no flat numTracks/ebookFormat fields — the format
+    // lives on the ebookFile object and counts come from the arrays.
+    val json = """
+      {
+        "id": "media_id",
+        "libraryItemId": "item_id",
+        "coverPath": null,
+        "tags": [],
+        "metadata": { "title": "An eBook" },
+        "audioFiles": [],
+        "chapters": [],
+        "tracks": [],
+        "ebookFile": {
+          "ino": "ino_1",
+          "metadata": {
+            "filename": "book.epub",
+            "ext": ".epub",
+            "path": "/books/book.epub",
+            "relPath": "book.epub",
+            "size": 1024,
+            "mtimeMs": 0,
+            "ctimeMs": 0,
+            "birthtimeMs": 0
+          },
+          "ebookFormat": "epub",
+          "addedAt": 0,
+          "updatedAt": 0
+        }
+      }
+    """.trimIndent()
+
+    val media = TestJson.decodeFromString<MediaExpanded>(json)
+
+    assertThat(media.ebookFormat).isNull()
+    assertThat(media.resolvedEbookFormat).isEqualTo("epub")
+    assertThat(media.resolvedNumTracks).isEqualTo(0)
+    assertThat(media.resolvedNumAudioFiles).isEqualTo(0)
+    assertThat(media.resolvedNumChapters).isEqualTo(0)
+  }
+
+  @Test
+  fun expandedMedia_resolvesCountsFromArrays() {
+    val json = """
+      {
+        "id": "media_id",
+        "libraryItemId": "item_id",
+        "coverPath": null,
+        "tags": [],
+        "metadata": { "title": "An Audiobook" },
+        "audioFiles": [],
+        "chapters": [
+          { "id": 0, "start": 0.0, "end": 100.0, "title": "Chapter 1" },
+          { "id": 1, "start": 100.0, "end": 200.0, "title": "Chapter 2" }
+        ],
+        "tracks": [
+          {
+            "index": 1,
+            "startOffset": 0.0,
+            "duration": 200.0,
+            "title": "track.mp3",
+            "contentUrl": "/hls/track.mp3",
+            "mimeType": "audio/mpeg",
+            "codec": "mp3",
+            "metadata": {
+              "filename": "track.mp3",
+              "ext": ".mp3",
+              "path": "/books/track.mp3",
+              "relPath": "track.mp3",
+              "size": 1024,
+              "mtimeMs": 0,
+              "ctimeMs": 0,
+              "birthtimeMs": 0
+            }
+          }
+        ],
+        "ebookFile": null
+      }
+    """.trimIndent()
+
+    val media = TestJson.decodeFromString<MediaExpanded>(json)
+
+    assertThat(media.numTracks).isEqualTo(0)
+    assertThat(media.resolvedNumTracks).isEqualTo(1)
+    assertThat(media.resolvedNumChapters).isEqualTo(2)
+    assertThat(media.resolvedEbookFormat).isNull()
+  }
+
+  @Test
+  fun minifiedMedia_passesThroughFlatFields() {
+    val json = """
+      {
+        "id": "media_id",
+        "coverPath": null,
+        "metadata": { "title": "An eBook" },
+        "numTracks": 0,
+        "numAudioFiles": 0,
+        "numChapters": 0,
+        "ebookFormat": "pdf"
+      }
+    """.trimIndent()
+
+    val media = TestJson.decodeFromString<MediaMinified>(json)
+
+    assertThat(media.resolvedNumTracks).isEqualTo(0)
+    assertThat(media.resolvedEbookFormat).isEqualTo("pdf")
+  }
+}

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -18,6 +18,7 @@
   <string name="action_resume_listening">Continue listening</string>
   <string name="action_currently_playing">Currently playing</string>
   <string name="action_play">Play</string>
+  <string name="action_ebook_not_supported">eBooks not supported</string>
   <string name="action_show_less">Show less</string>
   <string name="action_show_more">Show more</string>
   <string name="action_add_to_playlist_long">Add to playlist</string>

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/book/BookPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/book/BookPresenter.kt
@@ -204,6 +204,7 @@ class BookPresenter(
     ) { event ->
       when (event) {
         LibraryItemUiEvent.AddToQueue -> {
+          if (libraryItem.isEbookOnly) return@ContentUiState
           scope.launch {
             sessionQueue.add(libraryItem)
           }
@@ -216,6 +217,7 @@ class BookPresenter(
         }
 
         is LibraryItemUiEvent.PlayClick -> {
+          if (libraryItem.isEbookOnly) return@ContentUiState
           analytics.send(ActionEvent("play_item", Click))
           playbackController.startSession(libraryItem.id)
         }
@@ -310,6 +312,7 @@ class BookPresenter(
         }
 
         is LibraryItemUiEvent.DownloadClick -> {
+          if (libraryItem.isEbookOnly) return@ContentUiState
           analytics.send(ActionEvent("download", Click))
           settings.showConfirmDownload = !event.doNotShowAgain
 

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ExpressiveControlBar.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ExpressiveControlBar.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Backspace
+import androidx.compose.material.icons.automirrored.rounded.MenuBook
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.outlined.StopCircle
 import androidx.compose.material.icons.rounded.Delete
@@ -90,6 +91,7 @@ import campfire.features.libraries.ui.generated.resources.action_add_to_playlist
 import campfire.features.libraries.ui.generated.resources.action_currently_playing
 import campfire.features.libraries.ui.generated.resources.action_delete_download
 import campfire.features.libraries.ui.generated.resources.action_delete_offline
+import campfire.features.libraries.ui.generated.resources.action_ebook_not_supported
 import campfire.features.libraries.ui.generated.resources.action_play
 import campfire.features.libraries.ui.generated.resources.action_resume_listening
 import campfire.features.libraries.ui.generated.resources.action_retry_download
@@ -119,6 +121,7 @@ internal fun ExpressiveControlBar(
   onAddToQueueClick: () -> Unit,
   modifier: Modifier = Modifier,
   totalSizeInBytes: Long = -1L,
+  isEbookOnly: Boolean = false,
 ) {
   Surface(
     modifier = modifier
@@ -141,6 +144,7 @@ internal fun ExpressiveControlBar(
         onDownloadClick = onDownloadClick,
         hasProgress = hasProgress,
         isCurrentSession = isCurrentSession,
+        isEbookOnly = isEbookOnly,
       )
 
       if (!offlineDownload.isNullOrNone()) {
@@ -169,7 +173,7 @@ internal fun ExpressiveControlBar(
 
       AddToButtons(
         isQueued = isQueued,
-        canQueue = hasSession && !isCurrentSession,
+        canQueue = hasSession && !isCurrentSession && !isEbookOnly,
         onAddToPlaylistClick = onAddToPlaylistClick,
         onAddToQueueClick = onAddToQueueClick,
       )
@@ -690,6 +694,7 @@ private fun PlayAndDownloadButtons(
   onDownloadClick: () -> Unit,
   hasProgress: Boolean,
   isCurrentSession: Boolean,
+  isEbookOnly: Boolean,
 ) {
   Row(
     modifier = Modifier.fillMaxWidth(),
@@ -703,11 +708,11 @@ private fun PlayAndDownloadButtons(
     val pressedSplitButtonRadius = 6.dp
     val pressedCornerRadius = if (hasOfflineDownload) pressedSplitButtonRadius else 12.dp
     val endCornerRadius by animateDpAsState(
-      targetValue = if (hasOfflineDownload) size / 2 else splitButtonRadius,
+      targetValue = if (hasOfflineDownload || isEbookOnly) size / 2 else splitButtonRadius,
     )
 
     Button(
-      enabled = !isCurrentSession,
+      enabled = !isCurrentSession && !isEbookOnly,
       onClick = onPlayClick,
       modifier = Modifier
         .heightIn(size)
@@ -731,6 +736,7 @@ private fun PlayAndDownloadButtons(
     ) {
       Icon(
         when {
+          isEbookOnly -> Icons.AutoMirrored.Rounded.MenuBook
           isCurrentSession -> CampfireIcons.Rounded.MotionPlay
           hasProgress -> Icons.Outlined.Autoplay
           else -> Icons.Rounded.PlayArrow
@@ -741,6 +747,7 @@ private fun PlayAndDownloadButtons(
       Spacer(Modifier.size(ButtonDefaults.iconSpacingFor(size)))
       Text(
         text = when {
+          isEbookOnly -> stringResource(Res.string.action_ebook_not_supported)
           isCurrentSession -> stringResource(Res.string.action_currently_playing)
           hasProgress -> stringResource(Res.string.action_resume_listening)
           else -> stringResource(Res.string.action_play)
@@ -752,7 +759,7 @@ private fun PlayAndDownloadButtons(
     Spacer(Modifier.width(2.dp))
 
     AnimatedVisibility(
-      visible = !hasOfflineDownload,
+      visible = !hasOfflineDownload && !isEbookOnly,
       enter = expandHorizontally(),
       exit = shrinkHorizontally(),
     ) {
@@ -801,6 +808,16 @@ class ControlSlotProvider : PreviewParameterProvider<ExpressiveControlSlot> {
   override val values: Sequence<ExpressiveControlSlot> = sequenceOf(
     ExpressiveControlSlot(
       libraryItem = libraryItem(),
+      offlineDownload = null,
+      mediaProgress = null,
+      isCurrentSession = false,
+      hasSession = false,
+      isQueued = false,
+      showConfirmDownloadDialogSetting = false,
+      addToPlaylistDialog = AddToPlaylistDialog.NoOp,
+    ),
+    ExpressiveControlSlot(
+      libraryItem = libraryItem(numOfChapters = 0, numTracks = 0, ebookFormat = "epub"),
       offlineDownload = null,
       mediaProgress = null,
       isCurrentSession = false,

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/ExpressiveControlSlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/ExpressiveControlSlot.kt
@@ -85,6 +85,7 @@ class ExpressiveControlSlot(
       isQueued = isQueued,
       hasSession = hasSession,
       isCurrentSession = isCurrentSession,
+      isEbookOnly = libraryItem.isEbookOnly,
       offlineDownload = offlineDownload,
       totalSizeInBytes = libraryItem.media.sizeInBytes,
       mediaProgress = mediaProgress,

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
@@ -112,6 +112,8 @@ internal fun emptyLibraryItem(
   genres: List<String> = emptyList(),
   tags: List<String> = emptyList(),
   numOfChapters: Int = 0,
+  numTracks: Int = 10,
+  ebookFormat: String? = null,
 ) = libraryItem(
   id = id,
   description = description,
@@ -120,6 +122,8 @@ internal fun emptyLibraryItem(
   genres = genres,
   tags = tags,
   numOfChapters = numOfChapters,
+  numTracks = numTracks,
+  ebookFormat = ebookFormat,
 )
 
 /**

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenterEventsTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/LibraryItemPresenterEventsTest.kt
@@ -21,6 +21,7 @@ import app.cash.burst.burstValues
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
@@ -75,6 +76,29 @@ class LibraryItemPresenterEventsTest : BaseLibraryItemPresenterTest() {
       item.eventSink(eventTest.event)
 
       eventTest.assert(this@LibraryItemPresenterEventsTest)
+
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun ebookOnlyItem_ignoresPlayDownloadAndQueueEvents() = runTest {
+    val ebookItem = emptyLibraryItem(numTracks = 0, ebookFormat = "epub")
+    libraryItemRepository.libraryItemFlow.emit(ebookItem)
+
+    presenter.test {
+      skipItems(1)
+      val item = awaitItem()
+
+      item.eventSink(LibraryItemUiEvent.PlayClick)
+      item.eventSink(LibraryItemUiEvent.DownloadClick())
+      item.eventSink(LibraryItemUiEvent.AddToQueue)
+
+      assertThat(playbackController.session)
+        .isEqualTo(PlaybackControllerSession.None)
+      assertThat(offlineDownloadManager.invocations).isEmpty()
+      assertThat(sessionQueue.queue).isEmpty()
+      assertThat(analytics.events).isEmpty()
 
       cancelAndIgnoreRemainingEvents()
     }

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/session/DefaultPlaybackSessionManager.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/session/DefaultPlaybackSessionManager.kt
@@ -36,6 +36,15 @@ class DefaultPlaybackSessionManager(
   ) {
     withContext(dispatcherProvider.io) {
       val session = sessionsRepository.createSession(libraryItemId, episodeId)
+
+      // eBook-only items have no audio to prepare. Guarded here (not just in the UI) so
+      // media browser entry points like Android Auto can't hand the player an empty track list.
+      if (session.libraryItem.isEbookOnly) {
+        wbark { "Refusing playback session for ebook-only item ${libraryItemId.loggableId}" }
+        sessionsRepository.markDeleted(libraryItemId, episodeId)
+        return@withContext
+      }
+
       ibark { "Preparing playback session for ${libraryItemId.loggableId}: ${session.id}" }
 
       val player = audioPlayerHolder.currentPlayer.value


### PR DESCRIPTION
## Summary

Fixes #507

eBook-only library items (books with an ebook file and no audio tracks) are valid Audiobookshelf content, but Campfire can't play or download them. This PR takes the issue's option 2 — **detect and disable** — so the items stay visible but every action that can't work is guarded:

- **Core**: new `Media.isEbookOnly` / `LibraryItem.isEbookOnly` predicate (book with an `ebookFormat` and zero audio tracks; scoped to `Media.Book` so podcasts can never misfire).
- **Detail screen**: Play button is disabled and relabeled "eBooks not supported" with a book icon, Download is hidden, and Enqueue is disabled. `BookPresenter` also ignores `PlayClick` / `DownloadClick` / `AddToQueue` events as defense in depth.
- **Playback backstop**: `DefaultPlaybackSessionManager` refuses to prepare a session for an eBook-only item (covers Android Auto / media browser paths that bypass the UI, which previously fed the player an empty track list and generated a crash report).
- **Badges**: library item cards and list rows show the ebook format as a pill badge (e.g. `EPUB`) so users understand before tapping.

## Data-layer fix that made this work

The server only serializes `numTracks` / `numAudioFiles` / `numChapters` / `ebookFormat` on the **minified** media shape. The **expanded** shape (`GET /api/items/{id}?expanded=1`, used by the detail screen) omits them and carries `tracks[]` / `audioFiles[]` / `chapters[]` arrays and an `ebookFile` object instead — so the detail fetch's `INSERT OR REPLACE` was zeroing `numTracks` and nulling `ebookFormat` for every item visited. New `resolved*` accessors on the network `Media` model derive these values from the expanded arrays / `ebookFile`, and both the DB-write and domain mapping paths now use them. Verified against Audiobookshelf v2.34 server source and a live instance.

## Test plan

- [x] New unit tests: `MediaEbookOnlyTest` (core predicate, 5 cases), `MediaExpandedTest` (expanded/minified serialization + resolved accessors, 3 cases), and a `BookPresenter` test proving Play/Download/Queue events are no-ops for eBook-only items
- [x] `:core:jvmTest`, `:features:libraries:ui:jvmTest`, `:data:network:api:jvmTest` all green; touched modules compile on JVM
- [x] ktlint clean
- [x] Manually verified on a library containing an eBook-only item: badge shows in lists, detail screen disables Play/Download/Enqueue

🤖 Generated with [Claude Code](https://claude.com/claude-code)