### PR TITLE
Android Auto media tree enhancements: podcast support, adaptive tabs, and paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quick-insert bar above the keyboard when typing the server address at login, with one-tap snippets for https://, http://, local network prefixes, and the default Audiobookshelf port
 - Server addresses no longer require typing http(s):// — the login screen detects the right scheme automatically and fills it in
 - eBook-only library items now show a format badge on their covers and their play, download, and queue actions are disabled since reading eBooks isn't supported yet
+- Android Auto tabs now adapt to the active library: podcast libraries get a Shows tab for browsing every podcast and its episodes, hide the book-only Series, Authors, and Collections tabs, and the tab list refreshes live when switching libraries or changing Android Auto settings
 
 ### Changed
 
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Campfire logo flame flickering during the Welcome to Login screen transition
 - Real-time sync socket not connecting after logging in until the app was restarted
 - Podcasts in Android Auto can now be browsed into their episode list, and episode entries show the episode's title, artwork, and duration and play the correct episode instead of failing to start
+- Android Auto category tabs hanging indefinitely instead of showing an empty list when the library has no playlists, series, authors, or downloads
 
 ### Other Notes & Contributions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Real-time sync socket not connecting after logging in until the app was restarted
 - Podcasts in Android Auto can now be browsed into their episode list, and episode entries show the episode's title, artwork, and duration and play the correct episode instead of failing to start
 - Android Auto category tabs hanging indefinitely instead of showing an empty list when the library has no playlists, series, authors, or downloads
+- Android Auto browse and search lists now respect the head unit's requested page size instead of returning every item at once, fixing truncated lists in large libraries
 
 ### Other Notes & Contributions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server addresses that resolve to a local IP through custom DNS being rejected on Android 16+ (the local network permission is now requested for them)
 - Campfire logo flame flickering during the Welcome to Login screen transition
 - Real-time sync socket not connecting after logging in until the app was restarted
+- Podcasts in Android Auto can now be browsed into their episode list, and episode entries show the episode's title, artwork, and duration and play the correct episode instead of failing to start
 
 ### Other Notes & Contributions
 

--- a/data/db/core/src/commonMain/sqldelight/app/campfire/data/libraryItems.sq
+++ b/data/db/core/src/commonMain/sqldelight/app/campfire/data/libraryItems.sq
@@ -73,6 +73,13 @@ SELECT * FROM libraryItem
 INNER JOIN media ON media.libraryItemId = libraryItem.id
 WHERE libraryItem.libraryId = ?;
 
+-- Bare rows for every item in a library regardless of media type (selectForLibrary
+-- joins the book `media` table and silently drops podcasts). Callers dispatch on
+-- `mediaType` per row to hydrate the matching media variant.
+selectAllForLibrary:
+SELECT * FROM libraryItem
+WHERE libraryItem.libraryId = ?;
+
 selectForSeries:
 SELECT libraryItem.*,media.* FROM libraryItem
 INNER JOIN media ON media.libraryItemId = libraryItem.id

--- a/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryRepository.kt
+++ b/features/libraries/api/src/commonMain/kotlin/app/campfire/libraries/api/LibraryRepository.kt
@@ -3,6 +3,7 @@ package app.campfire.libraries.api
 import app.campfire.core.filter.ContentFilter
 import app.campfire.core.model.Library
 import app.campfire.core.model.LibraryId
+import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.User
 import app.campfire.core.settings.ContentSortMode
 import app.campfire.core.settings.SortDirection
@@ -20,6 +21,16 @@ interface LibraryRepository {
    * Observe all libraries for the current server
    */
   fun observeAllLibraries(refresh: Boolean = true): Flow<List<Library>>
+
+  /**
+   * Observe every library item in the currently selected library as a flat list, sorted by
+   * title. Refreshes from the network when [refresh] is true.
+   *
+   * Intended for whole-library consumers such as the Android Auto "Shows" tab for podcast
+   * libraries — it materializes the entire library in memory, so prefer
+   * [createLibraryItemPager] for UI listing of potentially large book libraries.
+   */
+  fun observeCurrentLibraryItems(refresh: Boolean = true): Flow<List<LibraryItem>>
 
   fun createLibraryItemPager(
     user: User,

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryRepository.kt
@@ -1,12 +1,14 @@
 package app.campfire.libraries
 
 import app.campfire.CampfireDatabase
+import app.campfire.account.api.UrlHydrator
 import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.filter.ContentFilter
 import app.campfire.core.model.Library
 import app.campfire.core.model.LibraryId
+import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.User
 import app.campfire.core.model.UserId
 import app.campfire.core.session.UserSession
@@ -17,6 +19,7 @@ import app.campfire.data.Library as DbLibrary
 import app.campfire.data.mapping.asDbModel
 import app.campfire.data.mapping.asDomainModel
 import app.campfire.data.mapping.asFetcherResult
+import app.campfire.data.mapping.dao.LibraryItemDao
 import app.campfire.data.mapping.store.debugLogging
 import app.campfire.libraries.api.AddPodcastContext
 import app.campfire.libraries.api.LibraryFolder
@@ -24,7 +27,9 @@ import app.campfire.libraries.api.LibraryRepository
 import app.campfire.libraries.api.paging.LibraryItemPager
 import app.campfire.libraries.paging.LibraryItemPagerFactory
 import app.campfire.libraries.paging.LibraryItemPagingInput
+import app.campfire.libraries.paging.fetchAllLibraryItems
 import app.campfire.network.AudioBookShelfApi
+import app.campfire.network.models.LibraryItemMinified
 import app.campfire.user.api.UserRepository
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
@@ -55,10 +60,18 @@ class StoreLibraryRepository(
   private val db: CampfireDatabase,
   private val userRepository: UserRepository,
   private val libraryItemPagingFactory: LibraryItemPagerFactory,
+  private val libraryItemDao: LibraryItemDao,
+  private val urlHydrator: UrlHydrator,
   private val dispatcherProvider: DispatcherProvider,
 ) : LibraryRepository {
 
   data class SingleLibraryRequest(val userId: UserId, val libraryId: LibraryId)
+
+  data class LibraryItemsRequest(
+    val userId: UserId,
+    val libraryId: LibraryId,
+    val serverUrl: String,
+  )
 
   private val singleLibraryStore = StoreBuilder.from(
     fetcher = Fetcher.ofResult { request: SingleLibraryRequest ->
@@ -145,6 +158,47 @@ class StoreLibraryRepository(
       .build(),
   ).build()
 
+  private val currentLibraryItemsStore = StoreBuilder.from(
+    fetcher = Fetcher.ofResult { request: LibraryItemsRequest ->
+      fetchAllLibraryItems(api, request.libraryId).asFetcherResult()
+    },
+    sourceOfTruth = SourceOfTruth.of(
+      reader = { request: LibraryItemsRequest ->
+        db.libraryItemsQueries.selectAllForLibrary(request.libraryId)
+          .asFlow()
+          .mapToList(dispatcherProvider.databaseRead)
+          .map { rows ->
+            rows
+              .map { libraryItemDao.hydratePagedItem(it) }
+              .sortedBy { it.media.metadata.title?.lowercase() }
+          }
+      },
+      writer = { request: LibraryItemsRequest, data ->
+        withContext(dispatcherProvider.databaseWrite) {
+          db.transaction {
+            data.forEach { item ->
+              when (item) {
+                is LibraryItemMinified.Book -> {
+                  db.libraryItemsQueries.insertOrIgnore(item.asDbModel(request.serverUrl))
+                  db.mediaQueries.insertOrIgnore(item.media.asDbModel(item.id))
+                }
+                is LibraryItemMinified.Podcast -> {
+                  db.libraryItemsQueries.insertOrIgnore(item.asDbModel(request.serverUrl))
+                  db.podcastMediaQueries.insertOrIgnore(item.media.asDbModel(item.id, urlHydrator))
+                }
+              }
+            }
+          }
+        }
+      },
+    ),
+  ).cachePolicy(
+    MemoryPolicy.builder<LibraryItemsRequest, List<LibraryItem>>()
+      .setMaxSize(4)
+      .setExpireAfterAccess(30.minutes)
+      .build(),
+  ).build()
+
   override fun observeCurrentLibrary(refresh: Boolean): Flow<Library> {
     return userRepository.userFlow
       .flatMapLatest { user ->
@@ -154,6 +208,17 @@ class StoreLibraryRepository(
         singleLibraryStore
           .stream(StoreReadRequest.cached(request, refresh = refresh))
           .debugLogging("SingleLibraryStore")
+          .mapNotNull { it.dataOrNull() }
+      }
+  }
+
+  override fun observeCurrentLibraryItems(refresh: Boolean): Flow<List<LibraryItem>> {
+    return userRepository.userFlow
+      .flatMapLatest { user ->
+        val request = LibraryItemsRequest(user.id, user.selectedLibraryId, user.serverUrl)
+        currentLibraryItemsStore
+          .stream(StoreReadRequest.cached(request, refresh = refresh))
+          .debugLogging("CurrentLibraryItemsStore")
           .mapNotNull { it.dataOrNull() }
       }
   }

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/paging/FetchAllLibraryItems.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/paging/FetchAllLibraryItems.kt
@@ -1,0 +1,47 @@
+package app.campfire.libraries.paging
+
+import app.campfire.core.model.LibraryId
+import app.campfire.network.AudioBookShelfApi
+import app.campfire.network.PagedResponse
+import app.campfire.network.models.LibraryItemMinified
+import app.campfire.network.nextPage
+
+/**
+ * Page through the server's minified library item listing until exhaustion, accumulating
+ * every item in the library.
+ */
+suspend fun fetchAllLibraryItems(
+  api: AudioBookShelfApi,
+  libraryId: LibraryId,
+  pageSize: Int = DEFAULT_FETCH_PAGE_SIZE,
+): Result<List<LibraryItemMinified>> {
+  return fetchAllPages { page ->
+    api.getLibraryItemsMinified(
+      libraryId = libraryId,
+      page = page,
+      limit = pageSize,
+    )
+  }
+}
+
+/**
+ * Accumulate every page of a paged endpoint starting from page 0, following [nextPage]
+ * until the server reports exhaustion. [maxPages] bounds misbehaving servers so a bad
+ * `nextPage` chain can't loop forever — hitting the cap returns what was accumulated.
+ */
+internal suspend fun <T> fetchAllPages(
+  maxPages: Int = MAX_FETCH_PAGES,
+  fetchPage: suspend (page: Int) -> Result<PagedResponse<T>>,
+): Result<List<T>> {
+  val items = mutableListOf<T>()
+  var page = 0
+  repeat(maxPages) {
+    val response = fetchPage(page).getOrElse { return Result.failure(it) }
+    items += response.data
+    page = response.nextPage ?: return Result.success(items)
+  }
+  return Result.success(items)
+}
+
+private const val DEFAULT_FETCH_PAGE_SIZE = 100
+private const val MAX_FETCH_PAGES = 50

--- a/features/libraries/impl/src/commonTest/kotlin/app/campfire/libraries/paging/FetchAllPagesTest.kt
+++ b/features/libraries/impl/src/commonTest/kotlin/app/campfire/libraries/paging/FetchAllPagesTest.kt
@@ -1,0 +1,80 @@
+package app.campfire.libraries.paging
+
+import app.campfire.network.PagedResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class FetchAllPagesTest {
+
+  private fun page(page: Int, data: List<Int>, total: Int, pageSize: Int = 2) = PagedResponse(
+    data = data,
+    page = page,
+    limit = pageSize,
+    total = total,
+    offset = page * pageSize,
+  )
+
+  @Test
+  fun `accumulates all pages until exhaustion`() = runTest {
+    val pages = listOf(
+      page(0, listOf(1, 2), total = 5),
+      page(1, listOf(3, 4), total = 5),
+      page(2, listOf(5), total = 5),
+    )
+
+    val result = fetchAllPages { p -> Result.success(pages[p]) }
+
+    assertEquals(listOf(1, 2, 3, 4, 5), result.getOrThrow())
+  }
+
+  @Test
+  fun `single page returns immediately`() = runTest {
+    var calls = 0
+    val result = fetchAllPages { p ->
+      calls++
+      Result.success(page(p, listOf(1, 2), total = 2))
+    }
+
+    assertEquals(listOf(1, 2), result.getOrThrow())
+    assertEquals(1, calls)
+  }
+
+  @Test
+  fun `empty library returns empty list`() = runTest {
+    val result = fetchAllPages { p ->
+      Result.success(page(p, emptyList(), total = 0))
+    }
+
+    assertEquals(emptyList(), result.getOrThrow())
+  }
+
+  @Test
+  fun `page failure propagates as failure`() = runTest {
+    val boom = IllegalStateException("boom")
+    val result = fetchAllPages<Int> { p ->
+      if (p == 0) {
+        Result.success(page(0, listOf(1, 2), total = 10))
+      } else {
+        Result.failure(boom)
+      }
+    }
+
+    assertTrue(result.isFailure)
+    assertEquals(boom, result.exceptionOrNull())
+  }
+
+  @Test
+  fun `page cap bounds a misbehaving server`() = runTest {
+    var calls = 0
+    // total never satisfied by returned data -> nextPage never null
+    val result = fetchAllPages(maxPages = 3) { p ->
+      calls++
+      Result.success(page(p, listOf(p), total = Int.MAX_VALUE, pageSize = 1))
+    }
+
+    assertEquals(3, calls)
+    assertEquals(listOf(0, 1, 2), result.getOrThrow())
+  }
+}

--- a/features/podcasts/ui/src/commonTest/kotlin/app/campfire/podcasts/ui/FakeLibraryRepository.kt
+++ b/features/podcasts/ui/src/commonTest/kotlin/app/campfire/podcasts/ui/FakeLibraryRepository.kt
@@ -3,6 +3,7 @@ package app.campfire.podcasts.ui
 import app.campfire.core.filter.ContentFilter
 import app.campfire.core.model.Library
 import app.campfire.core.model.LibraryId
+import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.User
 import app.campfire.core.settings.ContentSortMode
 import app.campfire.core.settings.SortDirection
@@ -23,6 +24,7 @@ class FakeLibraryRepository(
 
   override fun observeCurrentLibrary(refresh: Boolean): Flow<Library> = emptyFlow()
   override fun observeAllLibraries(refresh: Boolean): Flow<List<Library>> = flowOf(emptyList())
+  override fun observeCurrentLibraryItems(refresh: Boolean): Flow<List<LibraryItem>> = flowOf(emptyList())
   override fun createLibraryItemPager(
     user: User,
     filter: ContentFilter?,

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/AndroidAutoSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/AndroidAutoSettings.kt
@@ -1,25 +1,33 @@
 package app.campfire.settings.api
 
+import app.campfire.core.model.MediaType
 import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Stable, platform-agnostic identifiers for top-level categories shown in Android Auto.
  * Storage keys are decoupled from the media IDs used by the Android Auto browser so the
  * browser can rename its internal IDs without invalidating user preferences.
+ *
+ * [supportedMediaTypes] restricts which library types a category applies to — the Android
+ * Auto browser filters the root tabs by the active library's media type at browse time.
  */
 enum class AndroidAutoCategory(
   val storageKey: String,
   val defaultGridLayout: Boolean = false,
   val alwaysVisible: Boolean = false,
   val pinned: Boolean = false,
+  val supportedMediaTypes: Set<MediaType> = MediaType.entries.toSet(),
 ) {
   Home(storageKey = "home", defaultGridLayout = true, alwaysVisible = true, pinned = true),
-  Series(storageKey = "series"),
-  Authors(storageKey = "authors"),
+  Shows(storageKey = "shows", defaultGridLayout = true, supportedMediaTypes = setOf(MediaType.Podcast)),
+  Series(storageKey = "series", supportedMediaTypes = setOf(MediaType.Book)),
+  Authors(storageKey = "authors", supportedMediaTypes = setOf(MediaType.Book)),
   Playlists(storageKey = "playlists"),
-  Collections(storageKey = "collections"),
+  Collections(storageKey = "collections", supportedMediaTypes = setOf(MediaType.Book)),
   Downloads(storageKey = "downloads"),
   ;
+
+  fun isAvailableFor(mediaType: MediaType): Boolean = mediaType in supportedMediaTypes
 
   companion object {
     fun fromStorageKey(key: String): AndroidAutoCategory? =

--- a/features/settings/impl/src/commonTest/kotlin/app/campfire/settings/AndroidAutoCategoryTest.kt
+++ b/features/settings/impl/src/commonTest/kotlin/app/campfire/settings/AndroidAutoCategoryTest.kt
@@ -1,0 +1,68 @@
+package app.campfire.settings
+
+import app.campfire.core.model.MediaType
+import app.campfire.settings.api.AndroidAutoCategory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AndroidAutoCategoryTest {
+
+  @Test
+  fun `podcast libraries see home shows playlists and downloads`() {
+    val podcastCategories = AndroidAutoCategory.entries
+      .filter { it.isAvailableFor(MediaType.Podcast) }
+
+    assertEquals(
+      listOf(
+        AndroidAutoCategory.Home,
+        AndroidAutoCategory.Shows,
+        AndroidAutoCategory.Playlists,
+        AndroidAutoCategory.Downloads,
+      ),
+      podcastCategories,
+    )
+  }
+
+  @Test
+  fun `book libraries see the legacy categories and no shows tab`() {
+    val bookCategories = AndroidAutoCategory.entries
+      .filter { it.isAvailableFor(MediaType.Book) }
+
+    assertEquals(
+      listOf(
+        AndroidAutoCategory.Home,
+        AndroidAutoCategory.Series,
+        AndroidAutoCategory.Authors,
+        AndroidAutoCategory.Playlists,
+        AndroidAutoCategory.Collections,
+        AndroidAutoCategory.Downloads,
+      ),
+      bookCategories,
+    )
+  }
+
+  @Test
+  fun `every category supports at least one media type`() {
+    AndroidAutoCategory.entries.forEach { category ->
+      assertTrue(
+        category.supportedMediaTypes.isNotEmpty(),
+        "${category.name} supports no media types",
+      )
+    }
+  }
+
+  @Test
+  fun `shows storage key round trips`() {
+    assertEquals(
+      AndroidAutoCategory.Shows,
+      AndroidAutoCategory.fromStorageKey("shows"),
+    )
+  }
+
+  @Test
+  fun `storage keys are unique`() {
+    val keys = AndroidAutoCategory.entries.map { it.storageKey }
+    assertEquals(keys.size, keys.toSet().size)
+  }
+}

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -153,6 +153,7 @@
   <string name="android_auto_header_categories">Categories</string>
   <string name="android_auto_categories_description">Drag to reorder. Toggle each category's visibility and choose whether its contents appear as a grid or list.</string>
   <string name="android_auto_category_home">Home</string>
+  <string name="android_auto_category_shows">Shows</string>
   <string name="android_auto_category_series">Series</string>
   <string name="android_auto_category_authors">Authors</string>
   <string name="android_auto_category_playlists">Playlists</string>

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/AndroidAutoPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/AndroidAutoPane.kt
@@ -55,6 +55,7 @@ import campfire.features.settings.ui.generated.resources.android_auto_category_d
 import campfire.features.settings.ui.generated.resources.android_auto_category_home
 import campfire.features.settings.ui.generated.resources.android_auto_category_playlists
 import campfire.features.settings.ui.generated.resources.android_auto_category_series
+import campfire.features.settings.ui.generated.resources.android_auto_category_shows
 import campfire.features.settings.ui.generated.resources.android_auto_drag_handle_description
 import campfire.features.settings.ui.generated.resources.android_auto_header_categories
 import campfire.features.settings.ui.generated.resources.android_auto_layout_grid
@@ -308,6 +309,7 @@ private fun AnnotatedString.Builder.appendBulletedList(vararg items: String) {
 private val AndroidAutoCategory.label: StringResource
   get() = when (this) {
     AndroidAutoCategory.Home -> Res.string.android_auto_category_home
+    AndroidAutoCategory.Shows -> Res.string.android_auto_category_shows
     AndroidAutoCategory.Series -> Res.string.android_auto_category_series
     AndroidAutoCategory.Authors -> Res.string.android_auto_category_authors
     AndroidAutoCategory.Playlists -> Res.string.android_auto_category_playlists

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/AudioPlayerService.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/AudioPlayerService.kt
@@ -23,7 +23,9 @@ import app.campfire.core.di.UserScope
 import app.campfire.core.logging.LogPriority
 import app.campfire.core.logging.bark
 import app.campfire.infra.audioplayer.impl.R
+import app.campfire.libraries.api.LibraryRepository
 import app.campfire.sessions.api.SessionsRepository
+import app.campfire.settings.api.AndroidAutoSettings
 import app.campfire.settings.api.DevSettings
 import app.campfire.settings.api.PlaybackSettings
 import com.r0adkll.kimchi.annotations.ContributesTo
@@ -31,6 +33,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @ContributesTo(AppScope::class)
 interface AudioPlayerComponent {
@@ -39,6 +47,7 @@ interface AudioPlayerComponent {
   val devSettings: DevSettings // AppScope
   val activityIntentProvider: ActivityIntentProvider // AppScope
   val exoPlayerFactory: ExoPlayerAudioPlayer.Factory // AppScope
+  val androidAutoSettings: AndroidAutoSettings // AppScope
 }
 
 @ContributesTo(UserScope::class)
@@ -46,6 +55,7 @@ interface AudioPlayerUserComponent {
   val mediaTree: MediaTree
   val sessionsRepository: SessionsRepository
   val playbackSessionManager: PlaybackSessionManager
+  val libraryRepository: LibraryRepository
 }
 
 @SuppressLint("UnsafeOptInUsageError")
@@ -117,6 +127,35 @@ class AudioPlayerService : MediaLibraryService() {
         setSmallIcon(R.drawable.ic_notification)
       }
     setMediaNotificationProvider(mediaNotificationProvider)
+
+    observeBrowseTreeInvalidation()
+  }
+
+  /**
+   * Re-notify connected browsers (Android Auto head units, etc.) when the inputs to the
+   * browse tree change — the active library (switching libraries changes the root tabs and
+   * every tab's contents) or the Android Auto category settings (order/visibility/layout).
+   */
+  private fun observeBrowseTreeInvalidation() {
+    serviceScope.launch {
+      combine(
+        userComponent.libraryRepository.observeCurrentLibrary(refresh = false)
+          .map { it.id to it.mediaType }
+          .distinctUntilChanged(),
+        component.androidAutoSettings.observeCategoryConfigs(),
+      ) { library, configs -> library to configs }
+        // Browsers that connect later query a fresh tree anyway; only notify on change.
+        .drop(1)
+        .collect {
+          // Media3 requires the session be accessed on the thread it was created on.
+          withContext(Dispatchers.Main) {
+            val session = session ?: return@withContext
+            userComponent.mediaTree.invalidationParentIds.forEach { parentId ->
+              session.notifyChildrenChanged(parentId, Int.MAX_VALUE, null)
+            }
+          }
+        }
+    }
   }
 
   override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = session

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
@@ -17,6 +17,7 @@ import androidx.media3.session.MediaSession.ConnectionResult.AcceptedResultBuild
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
+import app.campfire.audioplayer.impl.browse.BrowseMediaId
 import app.campfire.audioplayer.impl.browse.SuspendingMediaLibrarySessionCallback
 import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.core.logging.LogPriority
@@ -254,7 +255,13 @@ internal class MediaSessionCallback(
   ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
     if (mediaItems.size == 1) {
       return serviceScope.future {
-        userComponent.playbackSessionManager.startSession(mediaItems.first().mediaId)
+        // Podcast episode entries from the media tree encode their episode id into the
+        // mediaId, so decode it to start the session against the right episode.
+        val browseId = BrowseMediaId.decode(mediaItems.first().mediaId)
+        userComponent.playbackSessionManager.startSession(
+          libraryItemId = browseId.libraryItemId,
+          episodeId = browseId.episodeId,
+        )
 
         // Return an error from this response as we've take responsibility for starting playback and
         // resolving / setting the media item(s).

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
@@ -197,7 +197,8 @@ internal class MediaSessionCallback(
     params: LibraryParams?,
   ): LibraryResult<ImmutableList<MediaItem>> {
     val children = userComponent.mediaTree.getChildren(parentId, page, pageSize)
-    if (children.isNotEmpty()) {
+    // An empty page past the first is a valid end-of-pagination signal, not an error.
+    if (children.isNotEmpty() || page > 0) {
       return LibraryResult.ofItemList(children, params)
     }
     return LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
@@ -233,7 +234,7 @@ internal class MediaSessionCallback(
     pageSize: Int,
     params: LibraryParams?,
   ): LibraryResult<ImmutableList<MediaItem>> {
-    return userComponent.mediaTree.search(query).let {
+    return userComponent.mediaTree.getSearchResults(query, page, pageSize).let {
       LibraryResult.ofItemList(it, params)
     }
   }

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
@@ -27,8 +27,11 @@ import app.campfire.core.model.Collection
 import app.campfire.core.model.CollectionId
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.Media
 import app.campfire.core.model.Playlist
 import app.campfire.core.model.PlaylistId
+import app.campfire.core.model.PodcastEpisode
+import app.campfire.core.model.PodcastEpisodeId
 import app.campfire.core.model.Series
 import app.campfire.core.model.SeriesId
 import app.campfire.core.model.ShelfEntity
@@ -105,19 +108,27 @@ class MediaTree(
         parentId.startsWith(PLAYLISTS_PREFIX) -> getPlaylistItems(parentId.removePrefix(PLAYLISTS_PREFIX))
         parentId.startsWith(COLLECTIONS_PREFIX) -> getCollectionItems(parentId.removePrefix(COLLECTIONS_PREFIX))
         parentId.startsWith(AUTHORS_PREFIX) -> getAuthorItems(parentId.removePrefix(AUTHORS_PREFIX))
+        parentId.startsWith(PODCAST_PREFIX) -> getPodcastEpisodes(parentId.removePrefix(PODCAST_PREFIX))
 
         else -> emptyList()
       }
     }
   }
 
-  suspend fun resolveMediaItem(libraryItemId: LibraryItemId): List<MediaItem> {
+  suspend fun resolveMediaItem(mediaId: String): List<MediaItem> {
     return try {
-      val item = libraryItemRepository.getLibraryItem(libraryItemId)
-      MediaItemBuilder.build(item).map { it.asPlatformMediaItem(application) }
+      val browseId = BrowseMediaId.decode(mediaId)
+      val item = libraryItemRepository.getLibraryItem(browseId.libraryItemId)
+      val episode = item.findEpisode(browseId.episodeId)
+      val mediaItems = if (episode != null) {
+        MediaItemBuilder.buildPodcastEpisode(item, episode)
+      } else {
+        MediaItemBuilder.build(item)
+      }
+      mediaItems.map { it.asPlatformMediaItem(application) }
     } catch (e: Throwable) {
       bark(LogPriority.ERROR, throwable = e) {
-        "Unable to find item for ${libraryItemId.loggableId}"
+        "Unable to find item for ${mediaId.loggableId}"
       }
       emptyList()
     }
@@ -146,9 +157,10 @@ class MediaTree(
             is Series -> item.asBrowsableMediaItem(titleHint = shelf.label)
             is Author -> item.asBrowsableMediaItem(titleHint = shelf.label)
 
-            // TODO: This doesn't properly account for the episode information
-            //  and we should adapt the media item better
-            is ShelfEntity.EpisodeShelfEntry -> item.libraryItem.asBrowsableMediaItem(titleHint = shelf.label)
+            is ShelfEntity.EpisodeShelfEntry -> item.libraryItem.asBrowsableMediaItem(
+              titleHint = shelf.label,
+              episode = item.recentEpisode,
+            )
           }
         }
       }
@@ -206,10 +218,8 @@ class MediaTree(
       .firstOrNull()
       ?: return emptyList()
 
-    // Browse currently surfaces the parent library item; podcast episodes within a
-    // playlist still resolve to the parent podcast for Android Auto navigation.
     return items.map { item ->
-      item.libraryItem.asBrowsableMediaItem()
+      item.libraryItem.asBrowsableMediaItem(episode = item.episode)
     }
   }
 
@@ -231,6 +241,22 @@ class MediaTree(
     }
   }
 
+  private suspend fun getPodcastEpisodes(libraryItemId: LibraryItemId): List<MediaItem> {
+    return try {
+      val item = libraryItemRepository.getLibraryItem(libraryItemId)
+      (item.media as? Media.Podcast)
+        ?.episodes
+        .orEmpty()
+        .sortedByDescending { it.publishedAtMillis ?: it.addedAtMillis }
+        .map { episode -> item.asBrowsableMediaItem(episode = episode) }
+    } catch (e: Throwable) {
+      bark(LogPriority.ERROR, throwable = e) {
+        "Unable to load episodes for ${libraryItemId.loggableId}"
+      }
+      emptyList()
+    }
+  }
+
   private suspend fun loadDownloads(): List<MediaItem> {
     val downloadItems = offlineDownloadManager.observeAll()
       .map { downloads ->
@@ -244,6 +270,9 @@ class MediaTree(
     return downloadItems.map { (download, libraryItem) ->
       libraryItem.asBrowsableMediaItem(
         download = download,
+        episode = download.episodeId?.let { episodeId ->
+          (libraryItem.media as? Media.Podcast)?.episodes?.find { it.id == episodeId }
+        },
       )
     }
   }
@@ -253,15 +282,19 @@ class MediaTree(
     if (
       mediaId != ROOT_ID ||
       mediaId.startsWith(SERIES_PREFIX) ||
+      mediaId.startsWith(PLAYLISTS_PREFIX) ||
       mediaId.startsWith(COLLECTIONS_PREFIX) ||
       mediaId.startsWith(AUTHORS_PREFIX) ||
+      mediaId.startsWith(PODCAST_PREFIX) ||
       TopLevelMediaItem.All.any { it.mediaId == mediaId }
     ) {
       return null
     }
 
     try {
-      return libraryItemRepository.getLibraryItem(mediaId).asBrowsableMediaItem()
+      val browseId = BrowseMediaId.decode(mediaId)
+      val item = libraryItemRepository.getLibraryItem(browseId.libraryItemId)
+      return item.asBrowsableMediaItem(episode = item.findEpisode(browseId.episodeId))
     } catch (e: Throwable) {
       bark(LogPriority.ERROR, throwable = e) {
         "Error getting item for ${mediaId.loggableId}"
@@ -287,53 +320,95 @@ class MediaTree(
   private fun LibraryItem.asBrowsableMediaItem(
     titleHint: String? = null,
     download: OfflineDownload? = null,
-  ) = MediaItem.Builder()
-    .setMediaId(id)
-    .setMediaMetadata(
-      MediaMetadata.Builder()
-        .setTitle(media.metadata.title)
-        .setArtist(media.metadata.authorName)
-        .setArtworkUri(coverContentUriForItem(application, id))
-        .setDescription(media.metadata.description)
-        .setDurationMs(media.durationInMillis)
-        .setGenre(media.metadata.genres.firstOrNull())
-        .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
-        .setTotalTrackCount(media.numChapters)
-        .setExtras(
-          Bundle().apply {
-            if (titleHint != null) {
-              putString(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE, titleHint)
+    episode: PodcastEpisode? = null,
+  ): MediaItem {
+    val podcast = media as? Media.Podcast
+
+    // Podcast items without a specific episode (library lists, downloads of a whole show)
+    // present as browsable folders whose children are the podcast's episodes. The episode
+    // listing re-fetches the full item, so this works even when this item's media is
+    // minified and doesn't carry the episode list itself.
+    val isPodcastFolder = podcast != null && episode == null
+
+    return MediaItem.Builder()
+      .setMediaId(
+        when {
+          episode != null -> BrowseMediaId(id, episode.id).encoded()
+          isPodcastFolder -> "$PODCAST_PREFIX$id"
+          else -> id
+        },
+      )
+      .setMediaMetadata(
+        MediaMetadata.Builder()
+          .apply {
+            when {
+              episode != null -> {
+                setTitle(episode.title)
+                setSubtitle(media.metadata.title)
+                setAlbumTitle(media.metadata.title)
+                setArtist(media.metadata.author ?: media.metadata.title)
+                setDescription(episode.description)
+                setDurationMs(episode.durationInMillis)
+                setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE)
+              }
+
+              podcast != null -> {
+                setTitle(media.metadata.title)
+                setArtist(media.metadata.author)
+                setDescription(media.metadata.description)
+                setDurationMs(media.durationInMillis)
+                setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST)
+                setTotalTrackCount(podcast.numEpisodes)
+              }
+
+              else -> {
+                setTitle(media.metadata.title)
+                setArtist(media.metadata.authorName)
+                setDescription(media.metadata.description)
+                setDurationMs(media.durationInMillis)
+                setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
+                setTotalTrackCount(media.numChapters)
+              }
             }
+          }
+          .setArtworkUri(coverContentUriForItem(application, id))
+          .setGenre(media.metadata.genres.firstOrNull())
+          .setExtras(
+            Bundle().apply {
+              if (titleHint != null) {
+                putString(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE, titleHint)
+              }
 
-            if (download != null) {
-              putLong(
-                MediaConstants.EXTRAS_KEY_DOWNLOAD_STATUS,
-                when (download.state) {
-                  OfflineDownload.State.Stopped,
-                  OfflineDownload.State.Failed,
-                  OfflineDownload.State.None,
-                  -> MediaConstants.EXTRAS_VALUE_STATUS_NOT_DOWNLOADED
+              if (download != null) {
+                putLong(
+                  MediaConstants.EXTRAS_KEY_DOWNLOAD_STATUS,
+                  when (download.state) {
+                    OfflineDownload.State.Stopped,
+                    OfflineDownload.State.Failed,
+                    OfflineDownload.State.None,
+                    -> MediaConstants.EXTRAS_VALUE_STATUS_NOT_DOWNLOADED
 
-                  OfflineDownload.State.Queued,
-                  OfflineDownload.State.Downloading,
-                  -> MediaConstants.EXTRAS_VALUE_STATUS_DOWNLOADING
+                    OfflineDownload.State.Queued,
+                    OfflineDownload.State.Downloading,
+                    -> MediaConstants.EXTRAS_VALUE_STATUS_DOWNLOADING
 
-                  OfflineDownload.State.Completed -> MediaConstants.EXTRAS_VALUE_STATUS_DOWNLOADED
-                },
-              )
+                    OfflineDownload.State.Completed -> MediaConstants.EXTRAS_VALUE_STATUS_DOWNLOADED
+                  },
+                )
 
-              putFloat(
-                MediaConstants.EXTRAS_KEY_DOWNLOAD_PROGRESS,
-                download.progress.percent.coerceIn(0f..1f),
-              )
-            }
-          },
-        )
-        .setIsBrowsable(false)
-        .setIsPlayable(true)
-        .build(),
-    )
-    .build()
+                putFloat(
+                  MediaConstants.EXTRAS_KEY_DOWNLOAD_PROGRESS,
+                  download.progress.percent.coerceIn(0f..1f),
+                )
+              }
+            },
+          )
+          .setIsBrowsable(isPodcastFolder)
+          .setIsPlayable(!isPodcastFolder)
+          .build(),
+      )
+      .build()
+  }
 
   @OptIn(UnstableApi::class)
   private fun Series.asBrowsableMediaItem(
@@ -419,6 +494,11 @@ class MediaTree(
     .build()
 }
 
+private fun LibraryItem.findEpisode(episodeId: PodcastEpisodeId?): PodcastEpisode? {
+  if (episodeId == null) return null
+  return (media as? Media.Podcast)?.episodes?.find { it.id == episodeId }
+}
+
 private fun AndroidAutoCategory.toTopLevelMediaItem(): TopLevelMediaItem? = when (this) {
   AndroidAutoCategory.Home -> TopLevelMediaItem.Home
   AndroidAutoCategory.Series -> TopLevelMediaItem.Series
@@ -484,3 +564,4 @@ private const val PLAYLISTS_PREFIX = "playlists_"
 private const val COLLECTIONS_ID = "collections-campfire"
 private const val COLLECTIONS_PREFIX = "collections_"
 private const val DOWNLOADS_ID = "downloads-campfire"
+private const val PODCAST_PREFIX = "podcast_"

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
@@ -28,6 +28,7 @@ import app.campfire.core.model.CollectionId
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.Media
+import app.campfire.core.model.MediaType
 import app.campfire.core.model.Playlist
 import app.campfire.core.model.PlaylistId
 import app.campfire.core.model.PodcastEpisode
@@ -40,6 +41,7 @@ import app.campfire.home.api.FeedResponse
 import app.campfire.home.api.HomeRepository
 import app.campfire.infra.audioplayer.impl.R
 import app.campfire.libraries.api.LibraryItemRepository
+import app.campfire.libraries.api.LibraryRepository
 import app.campfire.playlists.api.PlaylistsRepository
 import app.campfire.search.api.SearchRepository
 import app.campfire.search.api.SearchResult
@@ -47,11 +49,15 @@ import app.campfire.series.api.SeriesRepository
 import app.campfire.settings.api.AndroidAutoCategory
 import app.campfire.settings.api.AndroidAutoSettings
 import kotlin.collections.firstOrNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.withTimeoutOrNull
 import me.tatarka.inject.annotations.Inject
 
 @Inject
@@ -59,6 +65,7 @@ import me.tatarka.inject.annotations.Inject
 class MediaTree(
   private val application: Application,
   private val homeRepository: HomeRepository,
+  private val libraryRepository: LibraryRepository,
   private val libraryItemRepository: LibraryItemRepository,
   private val seriesRepository: SeriesRepository,
   private val playlistsRepository: PlaylistsRepository,
@@ -87,16 +94,20 @@ class MediaTree(
     pageSize: Int,
   ): List<MediaItem> {
     return when (parentId) {
-      ROOT_ID -> androidAutoSettings.observeCategoryConfigs().value
-        .filter { it.visible }
-        .mapNotNull { config ->
-          config.category.toTopLevelMediaItem()?.asBrowsableMediaItem(
-            context = application,
-            isGridLayout = config.isGridLayout,
-          )
-        }
+      ROOT_ID -> {
+        val mediaType = currentMediaType()
+        androidAutoSettings.observeCategoryConfigs().value
+          .filter { it.visible && it.category.isAvailableFor(mediaType) }
+          .mapNotNull { config ->
+            config.category.toTopLevelMediaItem()?.asBrowsableMediaItem(
+              context = application,
+              isGridLayout = config.isGridLayout,
+            )
+          }
+      }
 
       HOME_ID -> loadHome()
+      SHOWS_ID -> loadShows()
       SERIES_ID -> loadSeries()
       AUTHORS_ID -> loadAuthors()
       PLAYLISTS_ID -> loadPlaylists()
@@ -113,6 +124,23 @@ class MediaTree(
         else -> emptyList()
       }
     }
+  }
+
+  /**
+   * The parent ids the media session should invalidate when the browse tree's inputs
+   * change (active library switch, Android Auto category settings edits).
+   */
+  val invalidationParentIds: List<String>
+    get() = listOf(ROOT_ID) + TopLevelMediaItem.All.map { it.mediaId }
+
+  /**
+   * Resolve the active library's media type, falling back to [MediaType.Book] (today's
+   * behavior) when nothing is cached yet — a cold cache store stream may never emit.
+   */
+  private suspend fun currentMediaType(): MediaType {
+    return withTimeoutOrNull(MediaTypeTimeout) {
+      libraryRepository.observeCurrentLibrary(refresh = false).firstOrNull()?.mediaType
+    } ?: MediaType.Book
   }
 
   suspend fun resolveMediaItem(mediaId: String): List<MediaItem> {
@@ -166,10 +194,16 @@ class MediaTree(
       }
   }
 
+  private suspend fun loadShows(): List<MediaItem> {
+    return libraryRepository.observeCurrentLibraryItems()
+      .firstNonEmptyOrEmpty()
+      .filter { it.media is Media.Podcast }
+      .map { it.asBrowsableMediaItem() }
+  }
+
   private suspend fun loadSeries(): List<MediaItem> {
     val series = seriesRepository.observeAllSeries()
-      .firstOrNull { it.isNotEmpty() }
-      ?: return emptyList()
+      .firstNonEmptyOrEmpty()
 
     return series.map { item ->
       item.asBrowsableMediaItem()
@@ -187,7 +221,7 @@ class MediaTree(
   }
 
   private suspend fun loadAuthors(): List<MediaItem> {
-    val authors = authorRepository.observeAuthors().firstOrNull { it.isNotEmpty() } ?: return emptyList()
+    val authors = authorRepository.observeAuthors().firstNonEmptyOrEmpty()
 
     return authors.map { author ->
       author.asBrowsableMediaItem()
@@ -206,7 +240,7 @@ class MediaTree(
   }
 
   private suspend fun loadPlaylists(): List<MediaItem> {
-    val playlists = playlistsRepository.observeAllPlaylists().firstOrNull { it.isNotEmpty() } ?: return emptyList()
+    val playlists = playlistsRepository.observeAllPlaylists().firstNonEmptyOrEmpty()
 
     return playlists.map { playlist ->
       playlist.asBrowsableMediaItem()
@@ -258,14 +292,15 @@ class MediaTree(
   }
 
   private suspend fun loadDownloads(): List<MediaItem> {
-    val downloadItems = offlineDownloadManager.observeAll()
-      .map { downloads ->
-        downloads.associateWith { download ->
-          libraryItemRepository.getLibraryItem(download.libraryItemId)
+    val downloadItems = withTimeoutOrNull(LoadTimeout) {
+      offlineDownloadManager.observeAll()
+        .map { downloads ->
+          downloads.associateWith { download ->
+            libraryItemRepository.getLibraryItem(download.libraryItemId)
+          }
         }
-      }
-      .firstOrNull { it.isNotEmpty() }
-      ?: return emptyList()
+        .firstOrNull { it.isNotEmpty() }
+    }.orEmpty()
 
     return downloadItems.map { (download, libraryItem) ->
       libraryItem.asBrowsableMediaItem(
@@ -276,6 +311,15 @@ class MediaTree(
       )
     }
   }
+
+  /**
+   * Await the first non-empty emission, bounded so repositories whose flows never emit a
+   * non-empty value (e.g. book-only concepts on a podcast library, or an empty playlist
+   * list that Store suppresses) can't hang the browse request forever.
+   */
+  private suspend fun <T> Flow<List<T>>.firstNonEmptyOrEmpty(
+    timeout: Duration = LoadTimeout,
+  ): List<T> = withTimeoutOrNull(timeout) { firstOrNull { it.isNotEmpty() } }.orEmpty()
 
   suspend fun getItem(mediaId: String): MediaItem? {
     // Don't attempt to fetch our folder media items.
@@ -501,6 +545,7 @@ private fun LibraryItem.findEpisode(episodeId: PodcastEpisodeId?): PodcastEpisod
 
 private fun AndroidAutoCategory.toTopLevelMediaItem(): TopLevelMediaItem? = when (this) {
   AndroidAutoCategory.Home -> TopLevelMediaItem.Home
+  AndroidAutoCategory.Shows -> TopLevelMediaItem.Shows
   AndroidAutoCategory.Series -> TopLevelMediaItem.Series
   AndroidAutoCategory.Authors -> TopLevelMediaItem.Authors
   AndroidAutoCategory.Playlists -> TopLevelMediaItem.Playlists
@@ -512,8 +557,10 @@ enum class TopLevelMediaItem(
   val mediaId: String,
   @get:StringRes val title: Int,
   val isGridLayout: Boolean = false,
+  val folderMediaType: Int = MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
 ) {
   Home(HOME_ID, R.string.folder_home_title, true),
+  Shows(SHOWS_ID, R.string.folder_shows_title, true, MediaMetadata.MEDIA_TYPE_FOLDER_PODCASTS),
   Series(SERIES_ID, R.string.folder_series_title),
   Authors(AUTHORS_ID, R.string.folder_authors_title),
   Playlists(PLAYLISTS_ID, R.string.folder_playlists_title),
@@ -530,7 +577,7 @@ enum class TopLevelMediaItem(
     .setMediaMetadata(
       MediaMetadata.Builder()
         .setTitle(context.getString(title))
-        .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS)
+        .setMediaType(folderMediaType)
         .setIsBrowsable(true)
         .setIsPlayable(false)
         .fluentIf(isGridLayout) {
@@ -552,9 +599,13 @@ enum class TopLevelMediaItem(
   }
 }
 
+private val MediaTypeTimeout = 3.seconds
+private val LoadTimeout = 5.seconds
+
 private const val ROOT_ID = "root-campfire"
 
 private const val HOME_ID = "home-campfire"
+private const val SHOWS_ID = "shows-campfire"
 private const val SERIES_ID = "series-campfire"
 private const val SERIES_PREFIX = "series_"
 private const val AUTHORS_ID = "authors-campfire"

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/MediaTree.kt
@@ -57,6 +57,8 @@ import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import me.tatarka.inject.annotations.Inject
 
@@ -87,12 +89,33 @@ class MediaTree(
       )
       .build()
 
-  // TODO: Support paging through this api
+  /**
+   * Return one page of a parent's children. The full child list is loaded (and cached)
+   * on the first page request; later pages slice the cached list so paging browsers
+   * don't re-run the underlying repository loads per page. Page 0 always reloads, which
+   * is how a browser re-querying after [invalidationParentIds] notifications gets fresh
+   * data.
+   */
   suspend fun getChildren(
     parentId: String,
     page: Int,
     pageSize: Int,
   ): List<MediaItem> {
+    val children = childrenCacheMutex.withLock {
+      val cached = childrenCache
+      if (page > 0 && cached?.first == parentId) {
+        cached.second
+      } else {
+        loadChildren(parentId).also { childrenCache = parentId to it }
+      }
+    }
+    return children.paginate(page, pageSize)
+  }
+
+  private val childrenCacheMutex = Mutex()
+  private var childrenCache: Pair<String, List<MediaItem>>? = null
+
+  private suspend fun loadChildren(parentId: String): List<MediaItem> {
     return when (parentId) {
       ROOT_ID -> {
         val mediaType = currentMediaType()
@@ -347,18 +370,39 @@ class MediaTree(
     return null
   }
 
+  /**
+   * Run a fresh search and cache the full result list. Called when the browser submits a
+   * query — the returned size feeds `notifySearchResultChanged`, after which the browser
+   * pages through the same results via [getSearchResults].
+   */
   suspend fun search(query: String): List<MediaItem> {
     val result = searchRepository.searchCurrentLibrary(query)
       .firstOrNull { it !is SearchResult.Loading }
     bark { "Search result: $result" }
-    return if (result is SearchResult.Success) {
+    val items = if (result is SearchResult.Success) {
       result.books.map { it.asBrowsableMediaItem(titleHint = "Books") } +
         result.series.map { it.asBrowsableMediaItem(titleHint = "Series") } +
         result.authors.map { it.asBrowsableMediaItem(titleHint = "Authors") }
     } else {
       emptyList()
     }
+    searchCacheMutex.withLock { searchCache = query to items }
+    return items
   }
+
+  /**
+   * Return one page of the results for [query], serving from the cache populated by
+   * [search] so paging doesn't re-hit the search repository per page.
+   */
+  suspend fun getSearchResults(query: String, page: Int, pageSize: Int): List<MediaItem> {
+    val cached = searchCacheMutex.withLock {
+      searchCache?.takeIf { it.first == query }?.second
+    }
+    return (cached ?: search(query)).paginate(page, pageSize)
+  }
+
+  private val searchCacheMutex = Mutex()
+  private var searchCache: Pair<String, List<MediaItem>>? = null
 
   @OptIn(UnstableApi::class)
   private fun LibraryItem.asBrowsableMediaItem(

--- a/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
+++ b/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
@@ -25,6 +25,7 @@
   <string name="exo_controls_skip_next">Skip next</string>
   <string name="exo_controls_skip_previous">Skip previous</string>
   <string name="folder_home_title">Home</string>
+  <string name="folder_shows_title">Shows</string>
   <string name="folder_series_title">Series</string>
   <string name="folder_collections_title">Collections</string>
   <string name="folder_authors_title">Authors</string>

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/browse/BrowseMediaId.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/browse/BrowseMediaId.kt
@@ -1,0 +1,37 @@
+package app.campfire.audioplayer.impl.browse
+
+import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PodcastEpisodeId
+
+/**
+ * Media3 browse/playback callbacks only carry a single string mediaId, so podcast episode
+ * entries encode both the owning [LibraryItemId] and the [PodcastEpisodeId] into one id
+ * that can be decoded back at playback time.
+ */
+internal data class BrowseMediaId(
+  val libraryItemId: LibraryItemId,
+  val episodeId: PodcastEpisodeId? = null,
+) {
+
+  fun encoded(): String = if (episodeId != null) {
+    "$libraryItemId$EPISODE_SEPARATOR$episodeId"
+  } else {
+    libraryItemId
+  }
+
+  companion object {
+    // Audiobookshelf ids are UUIDs or legacy `li_`/`ep_` style ids, neither of which
+    // contain "::", so the separator can't collide with a real id.
+    private const val EPISODE_SEPARATOR = "::"
+
+    fun decode(mediaId: String): BrowseMediaId {
+      val separatorIndex = mediaId.indexOf(EPISODE_SEPARATOR)
+      if (separatorIndex == -1) return BrowseMediaId(mediaId)
+      return BrowseMediaId(
+        libraryItemId = mediaId.substring(0, separatorIndex),
+        episodeId = mediaId.substring(separatorIndex + EPISODE_SEPARATOR.length)
+          .takeIf { it.isNotEmpty() },
+      )
+    }
+  }
+}

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/browse/Paginate.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/browse/Paginate.kt
@@ -1,0 +1,21 @@
+package app.campfire.audioplayer.impl.browse
+
+/**
+ * Slice a fully-loaded child list to the page a media browser requested.
+ *
+ * [page] is zero-based. A page past the end returns an empty list (how browsers detect
+ * the end of pagination). A non-positive [pageSize] is treated as "no paging" and
+ * returns the full list — defensive, since Media3 requires pageSize >= 1.
+ */
+internal fun <T> List<T>.paginate(page: Int, pageSize: Int): List<T> {
+  if (pageSize <= 0) return this
+  if (page < 0) return emptyList()
+
+  // Long math: page * pageSize overflows Int for large pageSize values (e.g. a browser
+  // paging with pageSize = Int.MAX_VALUE).
+  val fromIndex = page.toLong() * pageSize
+  if (fromIndex >= size) return emptyList()
+
+  val toIndex = minOf(size.toLong(), fromIndex + pageSize)
+  return subList(fromIndex.toInt(), toIndex.toInt())
+}

--- a/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/browse/BrowseMediaIdTest.kt
+++ b/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/browse/BrowseMediaIdTest.kt
@@ -1,0 +1,42 @@
+package app.campfire.audioplayer.impl.browse
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BrowseMediaIdTest {
+
+  @Test
+  fun `bare library item id round trips`() {
+    val browseId = BrowseMediaId("li_abc123")
+    assertEquals("li_abc123", browseId.encoded())
+    assertEquals(browseId, BrowseMediaId.decode(browseId.encoded()))
+  }
+
+  @Test
+  fun `episode id round trips`() {
+    val browseId = BrowseMediaId("li_abc123", "ep_xyz789")
+    assertEquals("li_abc123::ep_xyz789", browseId.encoded())
+    assertEquals(browseId, BrowseMediaId.decode(browseId.encoded()))
+  }
+
+  @Test
+  fun `uuid style ids round trip`() {
+    val browseId = BrowseMediaId(
+      libraryItemId = "0693cf5c-98f5-4bc4-b2c4-63a91d38b0f0",
+      episodeId = "77b6f0e5-8929-4111-b6b8-eef6f4f9c0f3",
+    )
+    assertEquals(browseId, BrowseMediaId.decode(browseId.encoded()))
+  }
+
+  @Test
+  fun `decoding an id with a trailing separator yields no episode`() {
+    val browseId = BrowseMediaId.decode("li_abc123::")
+    assertEquals(BrowseMediaId("li_abc123"), browseId)
+  }
+
+  @Test
+  fun `decoding a folder id passes through unchanged`() {
+    val browseId = BrowseMediaId.decode("downloads-campfire")
+    assertEquals(BrowseMediaId("downloads-campfire"), browseId)
+  }
+}

--- a/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/browse/PaginateTest.kt
+++ b/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/browse/PaginateTest.kt
@@ -1,0 +1,55 @@
+package app.campfire.audioplayer.impl.browse
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PaginateTest {
+
+  private val items = (1..10).toList()
+
+  @Test
+  fun `first page returns the first pageSize items`() {
+    assertEquals(listOf(1, 2, 3), items.paginate(page = 0, pageSize = 3))
+  }
+
+  @Test
+  fun `middle page slices from the right offset`() {
+    assertEquals(listOf(4, 5, 6), items.paginate(page = 1, pageSize = 3))
+  }
+
+  @Test
+  fun `last page returns the partial remainder`() {
+    assertEquals(listOf(10), items.paginate(page = 3, pageSize = 3))
+  }
+
+  @Test
+  fun `page past the end returns empty`() {
+    assertEquals(emptyList(), items.paginate(page = 4, pageSize = 3))
+  }
+
+  @Test
+  fun `page size larger than the list returns everything`() {
+    assertEquals(items, items.paginate(page = 0, pageSize = Int.MAX_VALUE))
+  }
+
+  @Test
+  fun `huge page and pageSize does not overflow`() {
+    assertEquals(emptyList(), items.paginate(page = 2, pageSize = Int.MAX_VALUE))
+  }
+
+  @Test
+  fun `non-positive page size disables paging`() {
+    assertEquals(items, items.paginate(page = 3, pageSize = 0))
+    assertEquals(items, items.paginate(page = 0, pageSize = -1))
+  }
+
+  @Test
+  fun `negative page returns empty`() {
+    assertEquals(emptyList(), items.paginate(page = -1, pageSize = 3))
+  }
+
+  @Test
+  fun `empty list always pages to empty`() {
+    assertEquals(emptyList(), emptyList<Int>().paginate(page = 0, pageSize = 5))
+  }
+}


### PR DESCRIPTION
## Summary

This PR overhauls the Android Auto / media browse experience across three areas:

### Podcast episode support (closes #798)
- Podcast library items now browse into their episode list (newest first), and episode entries — home shelves, playlists, per-episode downloads — carry proper episode metadata (title, artwork, duration, `MEDIA_TYPE_PODCAST_EPISODE`)
- Episode ids are encoded into the browse mediaId via a new `BrowseMediaId` (`libraryItemId::episodeId`) so tapping an entry starts playback for that exact episode instead of failing

### Library-type-aware root tabs
- Root tabs now adapt to the active library's media type: podcast libraries get **Home, Shows, Playlists, Downloads** (the new Shows tab lists every podcast as a browsable folder), while book-only Series/Authors/Collections tabs are hidden
- `AndroidAutoCategory` gained `supportedMediaTypes`; a new `LibraryRepository.observeCurrentLibraryItems()` (Store5-backed, network-populating on cold cache) feeds the Shows tab via a new media-type-agnostic `selectAllForLibrary` query
- The tab row refreshes live via `notifyChildrenChanged` when the library or Android Auto settings change
- Fixed category loads hanging forever on empty libraries (bounded waits)

### Browse/search paging (closes #592)
- `getChildren` and search results now honor the requested page/pageSize, keeping large episode lists under binder transaction limits and preventing duplicates on paging clients; full child lists are cached per parent with page 0 always reloading so invalidation stays fresh

## Testing
- 24 new unit tests (`BrowseMediaIdTest`, `AndroidAutoCategoryTest`, `FetchAllPagesTest`, `PaginateTest`), all passing
- DB migration parity verified (`verifyCommonMainCampfireDatabaseMigration`)
- Manually validated on a head unit: episode browse + playback, adaptive tabs, live library-switch refresh, and paged episode lists

Closes #798
Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)