### PR TITLE
Fix socket crash on large or malformed realtime sync payloads

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,12 @@ ktlint_standard_filename = disabled
 [*.df.kts]
 ktlint_standard_no-wildcard-imports = disabled
 
+# Vendored third-party sources keep upstream's formatting so re-syncs stay trivial diffs.
+[thirdparty/**.kt]
+indent_size = 4
+ij_continuation_indent_size = 4
+ktlint_standard = disabled
+
 [*.sq]
 indent_size = 2
 ij_continuation_indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Crash when the server sends large or malformed realtime sync updates, such as progress updates for accounts with a long listening history
+
 ### Other Notes & Contributions
 
 ## [1.0.0-rc2]

--- a/docs/architecture/MODULARIZATION.md
+++ b/docs/architecture/MODULARIZATION.md
@@ -105,121 +105,430 @@ Lastly this contains a set of modules for providing independent re-usable UI ele
 }%%
 
 graph LR
+  :features["features"]
+  :app["app"]
+  :thirdparty["thirdparty"]
+  :scripts["scripts"]
+  :app["app"]
+  :features["features"]
+  :scripts["scripts"]
+  :thirdparty["thirdparty"]
   subgraph :features
+    :features:filters["filters"]
+    :features:playlists["playlists"]
+    :features:author["author"]
+    :features:libraries["libraries"]
+    :features:sessions["sessions"]
+    :features:series["series"]
+    :features:collections["collections"]
+    :features:stats["stats"]
+    :features:user["user"]
+    :features:home["home"]
+    :features:settings["settings"]
+    :features:auth["auth"]
+    :features:user["user"]
+    :features:libraries["libraries"]
+    :features:home["home"]
+    :features:series["series"]
+    :features:collections["collections"]
+    :features:author["author"]
+    :features:sessions["sessions"]
+    :features:search["search"]
+    :features:settings["settings"]
+    :features:stats["stats"]
+    :features:filters["filters"]
+    :features:playlists["playlists"]
+    :features:podcasts["podcasts"]
+    :features:auth["auth"]
+    :features:search["search"]
+    :features:podcasts["podcasts"]
     subgraph :sessions
+      :features:sessions:api["api"]
       :features:sessions:impl["impl"]
       :features:sessions:api["api"]
+      :features:sessions:api["api"]
+      :features:sessions:test["test"]
+      :features:sessions:test["test"]
       :features:sessions:ui["ui"]
       :features:sessions:api["api"]
+      :features:sessions:impl["impl"]
+      :features:sessions:test["test"]
     end
     subgraph :settings
       :features:settings:api["api"]
       :features:settings:ui["ui"]
+      :features:settings:test["test"]
       :features:settings:api["api"]
       :features:settings:impl["impl"]
+      :features:settings:api["api"]
+      :features:settings:test["test"]
+      :features:settings:api["api"]
+      :features:settings:impl["impl"]
+      :features:settings:test["test"]
     end
     subgraph :libraries
       :features:libraries:api["api"]
+      :features:libraries:impl["impl"]
+      :features:libraries:api["api"]
+      :features:libraries:test["test"]
+      :features:libraries:ui["ui"]
+      :features:libraries:test["test"]
       :features:libraries:api["api"]
       :features:libraries:impl["impl"]
-      :features:libraries:ui["ui"]
+      :features:libraries:test["test"]
       :features:libraries:api["api"]
     end
     subgraph :user
       :features:user:api["api"]
       :features:user:impl["impl"]
       :features:user:api["api"]
+      :features:user:test["test"]
+      :features:user:api["api"]
+      :features:user:api["api"]
+      :features:user:impl["impl"]
+      :features:user:test["test"]
+      :features:user:test["test"]
+    end
+    subgraph :podcasts
+      :features:podcasts:impl["impl"]
+      :features:podcasts:api["api"]
+      :features:podcasts:ui["ui"]
+      :features:podcasts:api["api"]
+      :features:podcasts:api["api"]
+      :features:podcasts:api["api"]
+      :features:podcasts:impl["impl"]
     end
     subgraph :home
       :features:home:impl["impl"]
       :features:home:api["api"]
-      :features:home:ui["ui"]
       :features:home:api["api"]
+      :features:home:api["api"]
+      :features:home:impl["impl"]
+      :features:home:ui["ui"]
+    end
+    subgraph :playlists
+      :features:playlists:ui["ui"]
+      :features:playlists:api["api"]
+      :features:playlists:api["api"]
+      :features:playlists:impl["impl"]
+      :features:playlists:api["api"]
+      :features:playlists:api["api"]
+      :features:playlists:impl["impl"]
     end
     subgraph :stats
       :features:stats:impl["impl"]
       :features:stats:api["api"]
       :features:stats:ui["ui"]
       :features:stats:api["api"]
+      :features:stats:api["api"]
+      :features:stats:api["api"]
+      :features:stats:impl["impl"]
+    end
+    subgraph :filters
+      :features:filters:impl["impl"]
+      :features:filters:api["api"]
+      :features:filters:api["api"]
+      :features:filters:ui["ui"]
+      :features:filters:test["test"]
+      :features:filters:api["api"]
+      :features:filters:test["test"]
+      :features:filters:api["api"]
+      :features:filters:impl["impl"]
+      :features:filters:test["test"]
     end
     subgraph :author
+      :features:author:impl["impl"]
+      :features:author:api["api"]
+      :features:author:api["api"]
       :features:author:ui["ui"]
       :features:author:api["api"]
       :features:author:impl["impl"]
       :features:author:api["api"]
     end
     subgraph :search
-      :features:search:impl["impl"]
-      :features:search:api["api"]
       :features:search:ui["ui"]
       :features:search:api["api"]
+      :features:search:api["api"]
+      :features:search:impl["impl"]
+      :features:search:api["api"]
+      :features:search:api["api"]
+      :features:search:impl["impl"]
+    end
+    subgraph :collections
+      :features:collections:api["api"]
+      :features:collections:api["api"]
+      :features:collections:ui["ui"]
+      :features:collections:api["api"]
+      :features:collections:impl["impl"]
+      :features:collections:impl["impl"]
+      :features:collections:api["api"]
     end
     subgraph :auth
       :features:auth:ui["ui"]
       :features:auth:api["api"]
       :features:auth:impl["impl"]
       :features:auth:api["api"]
-    end
-    subgraph :collections
-      :features:collections:api["api"]
-      :features:collections:ui["ui"]
-      :features:collections:impl["impl"]
-      :features:collections:api["api"]
+      :features:auth:api["api"]
+      :features:auth:api["api"]
+      :features:auth:impl["impl"]
     end
     subgraph :series
       :features:series:api["api"]
+      :features:series:test["test"]
+      :features:series:test["test"]
+      :features:series:api["api"]
+      :features:series:api["api"]
+      :features:series:impl["impl"]
+      :features:series:test["test"]
+      :features:series:api["api"]
       :features:series:ui["ui"]
       :features:series:impl["impl"]
-      :features:series:api["api"]
     end
   end
+  subgraph :app
+    :app:android["android"]
+    :app:baselineprofile["baselineprofile"]
+    :app:baselineprofile["baselineprofile"]
+    :app:android["android"]
+    :app:desktop["desktop"]
+    :app:ios["ios"]
+    :app:android["android"]
+    :app:desktop["desktop"]
+    :app:ios["ios"]
+    :app:baselineprofile["baselineprofile"]
+  end
+  subgraph :thirdparty
+    :thirdparty:socketio-kotlin["socketio-kotlin"]
+    :thirdparty:kmp-socketio["kmp-socketio"]
+    :thirdparty:socketio-kotlin["socketio-kotlin"]
+    :thirdparty:kmp-socketio["kmp-socketio"]
+    :thirdparty:socketio-kotlin["socketio-kotlin"]
+  end
+  subgraph :scripts
+    :scripts:app["app"]
+    :scripts:app["app"]
+  end
 
+  :features:sessions:api --> :
   :features:sessions:impl --> :features:sessions:api
   :features:sessions:impl --> :features:settings:api
   :features:sessions:impl --> :features:libraries:api
   :features:sessions:impl --> :features:user:api
-  :features:settings:ui --> :features:settings:api
+  :features:sessions:impl --> :
   :features:user:impl --> :features:user:api
   :features:user:impl --> :features:settings:api
+  :features:user:impl --> :features:user:test
+  :features:user:impl --> :
+  :features:settings:ui --> :features:settings:api
+  :features:settings:ui --> :features:libraries:api
+  :features:settings:ui --> :
+  :features:podcasts:impl --> :features:podcasts:api
+  :features:podcasts:impl --> :features:user:api
+  :features:podcasts:impl --> :
+  :features --> :
   :features:home:impl --> :features:home:api
   :features:home:impl --> :features:settings:api
   :features:home:impl --> :features:user:api
+  :features:home:impl --> :
+  :app --> :
+  :features:playlists:ui --> :features:playlists:api
+  :features:playlists:ui --> :features:sessions:api
+  :features:playlists:ui --> :
+  :features:filters --> :
   :features:stats:impl --> :features:stats:api
   :features:stats:impl --> :features:user:api
-  :features:author:ui --> :features:author:api
-  :features:sessions:ui --> :features:sessions:api
-  :features:sessions:ui --> :features:user:api
-  :features:sessions:ui --> :features:libraries:api
-  :features:settings:impl --> :features:settings:api
+  :features:stats:impl --> :
+  :features:filters:impl --> :features:filters:api
+  :features:filters:impl --> :features:user:api
+  :features:filters:impl --> :
+  :features:podcasts:ui --> :features:libraries:api
+  :features:podcasts:ui --> :features:playlists:api
+  :features:podcasts:ui --> :features:podcasts:api
+  :features:podcasts:ui --> :features:user:api
+  :features:podcasts:ui --> :features:sessions:api
+  :features:podcasts:ui --> :features:user:test
+  :features:podcasts:ui --> :
+  :app:android --> :app:baselineprofile
+  :app:android --> :
+  :features:playlists --> :
   :features:libraries:impl --> :features:libraries:api
   :features:libraries:impl --> :features:settings:api
   :features:libraries:impl --> :features:user:api
+  :features:libraries:impl --> :features:libraries:test
+  :features:libraries:impl --> :
   :features:author:impl --> :features:author:api
   :features:author:impl --> :features:settings:api
   :features:author:impl --> :features:user:api
-  :features:search:impl --> :features:search:api
-  :features:search:impl --> :features:user:api
-  :features:search:impl --> :features:settings:api
+  :features:author:impl --> :
   :features:search:ui --> :features:search:api
+  :features:search:ui --> :
+  :thirdparty:socketio-kotlin --> :
+  :features:collections:api --> :
   :features:auth:ui --> :features:auth:api
+  :features:auth:ui --> :
   :features:libraries:ui --> :features:author:api
   :features:libraries:ui --> :features:collections:api
   :features:libraries:ui --> :features:libraries:api
+  :features:libraries:ui --> :features:podcasts:api
   :features:libraries:ui --> :features:series:api
   :features:libraries:ui --> :features:sessions:api
   :features:libraries:ui --> :features:user:api
+  :features:libraries:ui --> :features:filters:api
+  :features:libraries:ui --> :features:playlists:api
+  :features:libraries:ui --> :features:libraries:test
+  :features:libraries:ui --> :features:sessions:test
+  :features:libraries:ui --> :features:series:test
+  :features:libraries:ui --> :features:settings:test
+  :features:libraries:ui --> :features:user:test
+  :features:libraries:ui --> :
+  :features:author --> :
+  :features:libraries --> :
+  :features:sessions --> :
   :features:auth:impl --> :features:auth:api
   :features:auth:impl --> :features:settings:api
+  :features:auth:impl --> :
+  :thirdparty --> :
+  :features:series --> :
+  :features:playlists:api --> :
+  :features:sessions:test --> :features:sessions:api
+  :features:sessions:test --> :
+  :features:settings:api --> :
+  :features:collections --> :
+  :features:series:test --> :features:series:api
+  :features:series:test --> :
+  :app:baselineprofile --> :
+  :app:baselineprofile --> :app:android
+  :features:podcasts:api --> :features:libraries:api
+  :features:podcasts:api --> :
+  :features:collections:ui --> :features:collections:api
+  :features:collections:ui --> :
+  :features:user:api --> :
+  :features:search:api --> :
+  :features:stats:ui --> :features:libraries:api
+  :features:stats:ui --> :features:stats:api
+  :features:stats:ui --> :
+  :scripts --> :
+  :thirdparty:kmp-socketio --> :thirdparty:socketio-kotlin
+  :thirdparty:kmp-socketio --> :
+  :features:filters:ui --> :features:filters:api
+  :features:filters:ui --> :features:filters:test
+  :features:filters:ui --> :
+  :features:stats --> :
+  :features:playlists:impl --> :features:playlists:api
+  :features:playlists:impl --> :features:user:api
+  :features:playlists:impl --> :
+  :features:user --> :
+  :features:home --> :
+  :features:filters:api --> :
+  :features:author:ui --> :features:author:api
+  :features:author:ui --> :features:filters:api
+  :features:author:ui --> :features:user:api
+  :features:author:ui --> :
+  :features:sessions:ui --> :features:sessions:api
+  :features:sessions:ui --> :features:user:api
+  :features:sessions:ui --> :features:libraries:api
+  :features:sessions:ui --> :
+  :app:desktop --> :
+  :app:ios --> :
+  :features:settings:impl --> :features:settings:api
+  :features:settings:impl --> :
+  :features:home:api --> :
+  :features:search:impl --> :features:search:api
+  :features:search:impl --> :features:user:api
+  :features:search:impl --> :features:settings:api
+  :features:search:impl --> :
+  :features:libraries:test --> :features:libraries:api
+  :features:libraries:test --> :
+  :features:settings:test --> :features:settings:api
+  :features:settings:test --> :
+  :features:stats:api --> :
+  :features:auth:api --> :
+  :features:filters:test --> :features:filters:api
+  :features:filters:test --> :
+  :features:settings --> :
+  : --> :app
+  : --> :app:android
+  : --> :app:desktop
+  : --> :app:ios
+  : --> :app:baselineprofile
+  : --> :features
+  : --> :features:auth
+  : --> :features:auth:api
+  : --> :features:auth:impl
+  : --> :features:user
+  : --> :features:user:api
+  : --> :features:user:impl
+  : --> :features:user:test
+  : --> :features:libraries
+  : --> :features:libraries:api
+  : --> :features:libraries:impl
+  : --> :features:libraries:test
+  : --> :features:home
+  : --> :features:home:api
+  : --> :features:home:impl
+  : --> :features:series
+  : --> :features:series:api
+  : --> :features:series:impl
+  : --> :features:series:test
+  : --> :features:collections
+  : --> :features:collections:api
+  : --> :features:collections:impl
+  : --> :features:author
+  : --> :features:author:api
+  : --> :features:author:impl
+  : --> :features:sessions
+  : --> :features:sessions:api
+  : --> :features:sessions:impl
+  : --> :features:sessions:test
+  : --> :features:search
+  : --> :features:search:api
+  : --> :features:search:impl
+  : --> :features:settings
+  : --> :features:settings:api
+  : --> :features:settings:impl
+  : --> :features:settings:test
+  : --> :features:stats
+  : --> :features:stats:api
+  : --> :features:stats:impl
+  : --> :features:filters
+  : --> :features:filters:api
+  : --> :features:filters:impl
+  : --> :features:filters:test
+  : --> :features:playlists
+  : --> :features:playlists:api
+  : --> :features:playlists:impl
+  : --> :features:podcasts
+  : --> :features:podcasts:api
+  : --> :features:podcasts:impl
+  : --> :scripts
+  : --> :scripts:app
+  : --> :thirdparty
+  : --> :thirdparty:kmp-socketio
+  : --> :thirdparty:socketio-kotlin
+  :features:auth --> :
+  :features:series:api --> :
+  :features:search --> :
+  :scripts:app --> :
   :features:series:ui --> :features:series:api
+  :features:series:ui --> :features:filters:api
+  :features:series:ui --> :features:user:api
+  :features:series:ui --> :
+  :features:libraries:api --> :
+  :features:podcasts --> :
   :features:series:impl --> :features:series:api
   :features:series:impl --> :features:settings:api
   :features:series:impl --> :features:user:api
-  :features:collections:ui --> :features:collections:api
-  :features:stats:ui --> :features:libraries:api
-  :features:stats:ui --> :features:stats:api
+  :features:series:impl --> :features:user:test
+  :features:series:impl --> :
   :features:collections:impl --> :features:collections:api
   :features:collections:impl --> :features:settings:api
   :features:collections:impl --> :features:user:api
+  :features:collections:impl --> :
+  :features:user:test --> :features:user:api
+  :features:user:test --> :
+  :features:author:api --> :
   :features:home:ui --> :features:home:api
   :features:home:ui --> :features:libraries:api
+  :features:home:ui --> :features:user:api
+  :features:home:ui --> :
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,8 +28,6 @@ halogen = "0.2.0"
 jb-compose-navigationevent = "1.1.0"
 junit = "4.13.2"
 kimchi = "0.7.0"
-kmp-socketio = "1.4.4"
-socketio-kotlin = "2.8.0"
 kotlin = "2.4.10"
 kotlin-inject = "0.9.0"
 kotlinpoet = "2.2.0"
@@ -228,15 +226,17 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-contentnegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 connectivity-core = { module = "dev.jordond.connectivity:connectivity-core", version.ref = "connectivity" }
 connectivity-android = { module = "dev.jordond.connectivity:connectivity-android", version.ref = "connectivity" }
 connectivity-apple = { module = "dev.jordond.connectivity:connectivity-apple", version.ref = "connectivity" }
 connectivity-http = { module = "dev.jordond.connectivity:connectivity-http", version.ref = "connectivity" }
-kmp-socketio = { module = "com.piasy:kmp-socketio", version.ref = "kmp-socketio" }
-socketio-kotlin = { module = "org.hildan.socketio:socketio-kotlin", version.ref = "socketio-kotlin" }
+kmp-xlog-api = "com.piasy:kmp-xlog-api:1.5.0"
+kotlinx-io-bytestring = "org.jetbrains.kotlinx:kotlinx-io-bytestring:0.9.1"
 oidc-crypto = { module = "io.github.kalinjul.kotlin.multiplatform:oidc-crypto", version = "0.16.5" }
 
 tools-desugarjdklibs = "com.android.tools:desugar_jdk_libs:2.1.5"

--- a/infra/socket/impl/build.gradle.kts
+++ b/infra/socket/impl/build.gradle.kts
@@ -16,12 +16,11 @@ kotlin {
         implementation(projects.core)
         implementation(projects.data.account.api)
         implementation(projects.features.settings.api)
-        implementation(libs.kmp.socketio)
-        // Forces kmp-socketio's transitive socketio-kotlin from 2.6.0 up to a version whose
-        // packet regex tolerates line-terminator chars (U+2028 etc.) inside JSON payloads;
-        // 2.6.0 throws InvalidSocketIOPacketException on such packets, crashing the app.
-        // Safe to remove once kmp-socketio depends on socketio-kotlin >= 2.8.0 itself.
-        implementation(libs.socketio.kotlin)
+        // Patched vendored copies of kmp-socketio and (transitively) socketio-kotlin — every
+        // published socketio-kotlin's packet regex crashes on Audiobookshelf payloads, and the
+        // published kmp-socketio lets decode exceptions escape its internal coroutines and crash
+        // the app. See thirdparty/kmp-socketio/README.md and the vendored SocketIO.kt.
+        implementation(projects.thirdparty.kmpSocketio)
         implementation(libs.kotlinx.coroutines.core)
         implementation(libs.kotlinx.serialization.json)
       }

--- a/infra/socket/impl/src/commonTest/kotlin/app/campfire/socket/impl/SocketIOLineTerminatorTest.kt
+++ b/infra/socket/impl/src/commonTest/kotlin/app/campfire/socket/impl/SocketIOLineTerminatorTest.kt
@@ -3,21 +3,31 @@ package app.campfire.socket.impl
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.hildan.socketio.SocketIO
 import org.hildan.socketio.SocketIOPacket
 
 /**
- * Guards the forced socketio-kotlin upgrade in this module's build file.
+ * Guards the vendored socketio-kotlin copy in `org.hildan.socketio` (see the vendored SocketIO.kt
+ * for why it exists). Both cases here crashed the app in the field with
+ * [org.hildan.socketio.InvalidSocketIOPacketException] (Crashlytics issue
+ * 4350da0dd8d479a67b4004bddebb06da) under different published versions of the library:
  *
- * JavaScript's JSON.stringify leaves the line-terminator characters U+2028, U+2029, and U+0085
- * unescaped inside strings, and the Audiobookshelf server emits them verbatim in socket payloads
- * (e.g. podcast descriptions). socketio-kotlin 2.6.0 — the version kmp-socketio 1.4.4 pulls in —
- * parses packets with a `.*` regex that stops at line terminators, so such payloads threw
- * [org.hildan.socketio.InvalidSocketIOPacketException] and crashed the app
- * (Crashlytics issue 4350da0dd8d479a67b4004bddebb06da). If a dependency change ever rolls the
- * library back below 2.8.0, this test fails instead of the app crashing in the field.
+ * 1. JavaScript's JSON.stringify leaves the line-terminator characters U+2028, U+2029, and U+0085
+ *    unescaped inside strings, and the Audiobookshelf server emits them verbatim in socket payloads
+ *    (e.g. podcast descriptions). socketio-kotlin < 2.7.0 parsed packets with a `.*` regex that
+ *    stops at line terminators, so such payloads failed to decode.
+ *
+ * 2. socketio-kotlin 2.7.0+ fixed that with a `(.|[^.])*` payload regex, but that alternation
+ *    backtracks per character: on large payloads (~70KB+ `user_updated`/`item_updated` events for
+ *    users with big mediaProgress lists) it throws StackOverflowError on the desktop JVM and
+ *    silently fails to match on Android's ICU regex engine, which the library reports as an
+ *    invalid packet.
+ *
+ * The vendored copy's `[\s\S]*` payload regex handles both. If the vendored sources are ever
+ * dropped in favor of an upstream release, these tests must still pass against it.
  */
 class SocketIOLineTerminatorTest {
 
@@ -32,5 +42,30 @@ class SocketIOLineTerminatorTest {
     val item = packet.payload[1].jsonObject
     assertThat(item.getValue("id").jsonPrimitive.content).isEqualTo("item-1")
     assertThat(item.getValue("description").jsonPrimitive.content).isEqualTo(description)
+  }
+
+  @Test
+  fun decodesLargeEventPayload() {
+    // Mirrors the field crash: a `user_updated` event for a root user whose mediaProgress list
+    // pushes the packet past the size where a backtracking payload regex falls over (~70KB on
+    // the JVM). 200KB gives comfortable margin on every platform's regex engine.
+    val progressEntries = buildString {
+      while (length < 200_000) {
+        if (isNotEmpty()) append(',')
+        append(
+          """{"id":"40a5cc02-076f-48d8-ba67-e6414dcb9ab6","libraryItemId":"59bae628-ed64-4232-b36f-76902289e914",""" +
+            """"duration":74966.83,"progress":1,"currentTime":74966.9,"isFinished":true,"lastUpdate":1752043120894}""",
+        )
+      }
+    }
+    val encoded = """2["user_updated",{"id":"user-1","username":"tester","mediaProgress":[$progressEntries]}]"""
+
+    val packet = SocketIO.decode(encoded) as SocketIOPacket.Event
+
+    assertThat(packet.payload[0].jsonPrimitive.content).isEqualTo("user_updated")
+    val user = packet.payload[1].jsonObject
+    assertThat(user.getValue("id").jsonPrimitive.content).isEqualTo("user-1")
+    val firstProgress = user.getValue("mediaProgress").jsonArray[0].jsonObject
+    assertThat(firstProgress.getValue("isFinished").jsonPrimitive.content).isEqualTo("true")
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -240,5 +240,9 @@ include(
   ":ui:theming:test",
 )
 include(":scripts:app")
+include(
+  ":thirdparty:kmp-socketio",
+  ":thirdparty:socketio-kotlin",
+)
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/thirdparty/kmp-socketio/README.md
+++ b/thirdparty/kmp-socketio/README.md
@@ -1,0 +1,28 @@
+# Vendored kmp-socketio
+
+Vendored copy of [kmp-socketio](https://github.com/HackWebRTC/kmp-socketio) v1.4.4
+(MIT License, Copyright (c) 2025 HackWebRTC), replacing the `com.piasy:kmp-socketio` artifact.
+Only the source sets Campfire targets are vendored (common, android, jvm, apple); js/wasm/linux/mingw
+transports and upstream tests are omitted.
+
+## Why
+
+The published artifact's coroutine error handling crashes the app (Crashlytics issue
+`4350da0dd8d479a67b4004bddebb06da`): decode exceptions escape its internal `CoroutineScope`s,
+which have no exception handler, so they propagate to the platform's uncaught-exception handler.
+Any single failure also cancels the scope's implicit job, silently killing the socket. Vendoring
+also lets this module depend on the patched `:thirdparty:socketio-kotlin` directly instead of
+masquerading its klib identity for the Kotlin/Native compiler.
+
+## Local patches (marked `CAMPFIRE PATCH` in source)
+
+- `engineio/transports/WebSocket.kt` — `onWsText` catches all decode exceptions (upstream only
+  caught `InvalidEngineIOPacketException`, letting `InvalidSocketIOPacketException` and
+  `SerializationException` crash the app); default `ioScope` is supervised.
+- `socketio/IO.kt` — the library-wide work scope is supervised.
+- `engineio/transports/PollingXHR.kt` — default `ioScope` is supervised.
+- `global/SupervisedScope.kt` — new file: `supervisedScope()` helper
+  (`SupervisorJob` + logging `CoroutineExceptionHandler`).
+
+Everything else is identical to upstream — keep it that way so re-syncs are trivial diffs.
+Remove this module (and `:thirdparty:socketio-kotlin`) once upstream releases fix the crashes.

--- a/thirdparty/kmp-socketio/build.gradle.kts
+++ b/thirdparty/kmp-socketio/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+  id("app.campfire.android.library")
+  id("app.campfire.multiplatform")
+}
+
+kotlin {
+  sourceSets {
+    all {
+      languageSettings.optIn("kotlinx.coroutines.ExperimentalCoroutinesApi")
+    }
+    commonMain {
+      dependencies {
+        api(projects.thirdparty.socketioKotlin)
+        api(libs.kotlinx.coroutines.core)
+        api(libs.ktor.client.core)
+        api(libs.ktor.client.logging)
+        api(libs.ktor.client.websockets)
+        api(libs.kmp.xlog.api)
+      }
+    }
+    jvmMain {
+      dependencies {
+        api(libs.ktor.client.cio)
+      }
+    }
+    androidMain {
+      dependencies {
+        api(libs.ktor.client.okhttp)
+      }
+    }
+    appleMain {
+      dependencies {
+        api(libs.ktor.client.darwin)
+      }
+    }
+    commonTest {
+      dependencies {
+        implementation(libs.kotlin.test)
+        implementation(libs.kotlinx.coroutines.test)
+      }
+    }
+  }
+}

--- a/thirdparty/kmp-socketio/src/androidMain/kotlin/com/piasy/kmp/socketio/engineio/transports/transport.android.kt
+++ b/thirdparty/kmp-socketio/src/androidMain/kotlin/com/piasy/kmp/socketio/engineio/transports/transport.android.kt
@@ -1,0 +1,35 @@
+package com.piasy.kmp.socketio.engineio.transports
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.okhttp.OkHttp
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+actual fun httpClient(
+    trustAllCerts: Boolean,
+    config: HttpClientConfig<*>.() -> Unit
+): HttpClient = HttpClient(OkHttp) {
+    if (trustAllCerts) {
+        val trustManager = object : X509TrustManager {
+            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
+
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(null, arrayOf(trustManager), SecureRandom())
+        }
+
+        engine {
+            config {
+                sslSocketFactory(sslContext.socketFactory, trustManager)
+                hostnameVerifier { _, _ -> true }
+            }
+        }
+    }
+
+    config(this)
+}

--- a/thirdparty/kmp-socketio/src/appleMain/kotlin/com/piasy/kmp/socketio/engineio/transports/transport.apple.kt
+++ b/thirdparty/kmp-socketio/src/appleMain/kotlin/com/piasy/kmp/socketio/engineio/transports/transport.apple.kt
@@ -1,0 +1,26 @@
+package com.piasy.kmp.socketio.engineio.transports
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.darwin.Darwin
+import platform.Foundation.NSURLCredential
+import platform.Foundation.create
+import platform.Foundation.serverTrust
+import platform.Security.SecTrustRef
+
+actual fun httpClient(trustAllCerts: Boolean, config: HttpClientConfig<*>.() -> Unit): HttpClient = HttpClient(Darwin) {
+    config(this)
+    engine {
+        if (trustAllCerts) {
+            handleChallenge { session, task, challenge, completionHandler ->
+                val serverTrust: SecTrustRef? = challenge.protectionSpace.serverTrust
+                if (serverTrust != null) {
+                    val credential = NSURLCredential.create(trust = serverTrust)
+                    completionHandler(0, credential)
+                } else {
+                    completionHandler(1, null)
+                }
+            }
+        }
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/emitter/Emitter.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/emitter/Emitter.kt
@@ -1,0 +1,166 @@
+package com.piasy.kmp.socketio.emitter
+
+import com.piasy.kmp.socketio.engineio.CallerThread
+
+/**
+ * Created by Piasy{github.com/Piasy} on 2022/11/16.
+ *
+ * The event emitter which is ported from the Java module.
+ *
+ * This class is NOT thread-safe.
+ * Don't call on/once/off inside event callback, it may trigger ConcurrentModificationException.
+ */
+open class Emitter {
+    interface Listener {
+        fun call(vararg args: Any)
+    }
+
+    private val callbacks = mutableMapOf<String, MutableList<Listener>>()
+
+    // to avoid concurrent modification error, we use two collections of listener.
+    private val onceCallbacks = mutableMapOf<String, MutableList<Listener>>()
+
+    /**
+     * Listens on the event.
+     * @param event event name.
+     * @param fn
+     * @return a reference to this object.
+     */
+    @CallerThread
+    fun on(event: String, fn: Listener): Emitter {
+        addListener(callbacks, event, fn)
+        return this
+    }
+
+    @CallerThread
+    fun on(event: String, block: (Array<out Any>) -> Unit): Emitter {
+        return on(event, object : Listener {
+            override fun call(vararg args: Any) {
+                block(args)
+            }
+        })
+    }
+
+    private fun addListener(
+        callbacks: MutableMap<String, MutableList<Listener>>,
+        event: String,
+        fn: Listener
+    ) {
+        callbacks.getOrElse(event) {
+            val listeners = mutableListOf<Listener>()
+            callbacks[event] = listeners
+            listeners
+        }.add(fn)
+    }
+
+    /**
+     * Adds a one time listener for the event.
+     *
+     * @param event an event name.
+     * @param fn
+     * @return a reference to this object.
+     */
+    @CallerThread
+    fun once(event: String, fn: Listener): Emitter {
+        addListener(onceCallbacks, event, fn)
+        return this
+    }
+
+    @CallerThread
+    fun once(event: String, block: (Array<out Any>) -> Unit): Emitter {
+        return once(event, object : Listener {
+            override fun call(vararg args: Any) {
+                block(args)
+            }
+        })
+    }
+
+    /**
+     * Removes all registered listeners.
+     *
+     * @return a reference to this object.
+     */
+    @CallerThread
+    fun off(): Emitter {
+        callbacks.clear()
+        onceCallbacks.clear()
+        return this
+    }
+
+    /**
+     * Removes all listeners of the specified event.
+     *
+     * @param event an event name.
+     * @return a reference to this object.
+     */
+    @CallerThread
+    fun off(event: String): Emitter {
+        callbacks.remove(event)
+        onceCallbacks.remove(event)
+        return this
+    }
+
+    /**
+     * Removes the listener.
+     *
+     * @param event an event name.
+     * @param fn
+     * @return a reference to this object.
+     */
+    @CallerThread
+    fun off(event: String, fn: Listener): Emitter {
+        callbacks[event]?.remove(fn)
+        onceCallbacks[event]?.remove(fn)
+        return this
+    }
+
+    /**
+     * Executes each of listeners with the given args.
+     *
+     * @param event an event name.
+     * @param args
+     * @return a reference to this object.
+     */
+    @CallerThread
+    open fun emit(event: String, vararg args: Any): Emitter {
+        val actions = ArrayList<() -> Unit>()
+        callbacks[event]?.forEach {
+            actions.add { it.call(*args) }
+        }
+
+        onceCallbacks.remove(event)?.forEach {
+            actions.add { it.call(*args) }
+        }
+
+        for (action in actions) {
+            action()
+        }
+
+        return this
+    }
+
+    /**
+     * Returns a list of listeners for the specified event.
+     *
+     * @param event an event name.
+     * @return a reference to this object.
+     */
+    @CallerThread
+    fun listeners(event: String): List<Listener> {
+        val listeners = mutableListOf<Listener>()
+        listeners.addAll(callbacks[event].orEmpty())
+        listeners.addAll(onceCallbacks[event].orEmpty())
+        return listeners
+    }
+
+    /**
+     * Check if this emitter has listeners for the specified event.
+     *
+     * @param event an event name.
+     * @return a reference to this object.
+     */
+    @CallerThread
+    fun hasListeners(event: String): Boolean {
+        return !(callbacks[event].isNullOrEmpty() && onceCallbacks[event].isNullOrEmpty())
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/EngineSocket.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/EngineSocket.kt
@@ -1,0 +1,638 @@
+package com.piasy.kmp.socketio.engineio
+
+import com.piasy.kmp.socketio.emitter.Emitter
+import com.piasy.kmp.socketio.engineio.transports.DefaultTransportFactory
+import com.piasy.kmp.socketio.engineio.transports.PollingXHR
+import com.piasy.kmp.socketio.engineio.transports.TransportFactory
+import com.piasy.kmp.socketio.engineio.transports.WebSocket
+import com.piasy.kmp.xlog.Logging
+import io.ktor.http.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.hildan.socketio.EngineIOPacket
+import kotlin.jvm.JvmField
+
+class EngineSocket(
+    uri: String,
+    @JvmField internal val opt: Options,
+    internal val scope: CoroutineScope,
+    private val factory: TransportFactory = DefaultTransportFactory,
+    private val rawMessage: Boolean = false,
+) : Emitter() {
+    open class Options : Transport.Options() {
+        /**
+         * List of transport names.
+         */
+        @JvmField
+        var transports: List<String> = emptyList()
+
+        /**
+         * Whether to upgrade the transport. Defaults to `true`.
+         */
+        @JvmField
+        var upgrade = true
+
+        @JvmField
+        var rememberUpgrade = false
+
+        @JvmField
+        var transportOptions: Map<String, Transport.Options> = emptyMap()
+    }
+
+    internal var disablePingTimeout = false // to help unit test
+    private var state = State.INIT
+    internal var id = ""
+    private var upgrades = emptyList<String>()
+    private var pingInterval = 0
+    private var pingTimeout = 0
+    internal var transport: Transport? = null
+    private val subs = ArrayList<On.Handle>()
+    private var upgrading = false
+
+    internal val writeBuffer = ArrayDeque<EngineIOPacket<*>>()
+    private var prevBufferLen = 0
+
+    private val heartbeatListener = object : Listener {
+        override fun call(vararg args: Any) {
+            onHeartBeat()
+        }
+    }
+    private var pingTimeoutJob: Job? = null
+
+    init {
+        val url = Url(uri)
+        opt.secure = url.protocol == URLProtocol.HTTPS
+                || url.protocol == URLProtocol.WSS
+
+        var hostname = url.host
+        if (hostname.split(':').size > 2) {
+            val start = hostname.indexOf('[')
+            if (start != -1) {
+                hostname = hostname.substring(start + 1)
+            }
+            val end = hostname.lastIndexOf(']')
+            if (end != -1) {
+                hostname = hostname.substring(0, end)
+            }
+        }
+        opt.hostname = hostname
+        opt.port = url.port
+        if (opt.path.isEmpty()) {
+            opt.path = "/engine.io/"
+        }
+
+        if (opt.timestampParam.isEmpty()) {
+            opt.timestampParam = "t"
+        }
+
+        if (!url.parameters.isEmpty()) {
+            val query = HashMap<String, String>()
+            url.parameters.entries().forEach {
+                query[it.key] = it.value[0]
+            }
+            opt.query = query
+        }
+
+        if (opt.transports.isEmpty()) {
+            opt.transports = listOf(PollingXHR.NAME, WebSocket.NAME)
+        }
+    }
+
+    /**
+     * Connects the client.
+     *
+     * @return a reference to this object.
+     */
+    @WorkThread
+    fun open() {
+        Logging.info(TAG, "open: state $state")
+        if (state != State.INIT && state != State.CLOSED) {
+            Logging.error(TAG, "open at wrong state: $state")
+            return
+        }
+
+        val name = if (opt.rememberUpgrade && priorWebsocketSuccess
+            && opt.transports.contains(WebSocket.NAME)
+        ) {
+            WebSocket.NAME
+        } else {
+            // transports won't be empty
+            opt.transports[0]
+        }
+
+        state = State.OPENING
+        val transport = createTransport(name)
+        setTransport(transport)
+        transport.open()
+    }
+
+    /**
+     * Sends a packet.
+     *
+     * @param packet
+     */
+    @WorkThread
+    fun send(packet: EngineIOPacket<*>) {
+        sendPackets(listOf(packet))
+    }
+
+    @WorkThread
+    fun send(packets: List<EngineIOPacket<*>>) {
+        sendPackets(packets)
+    }
+
+    /**
+     * Disconnects the client.
+     *
+     * @return a reference to this object.
+     */
+    @WorkThread
+    fun close() {
+        Logging.info(TAG, "close: state $state, writeBuffer.size ${writeBuffer.size}, upgrading: $upgrading")
+        if (state != State.OPENING && state != State.OPEN) {
+            Logging.info(TAG, "close at wrong state: $state")
+            return
+        }
+        state = State.CLOSING
+
+        val closeAction = {
+            Logging.info(TAG, "socket closing - telling transport to close")
+            onClose("force close")
+        }
+        val cleanupAndClose = object : Listener {
+            override fun call(vararg args: Any) {
+                Logging.info(TAG, "close waiting upgrade success")
+                off(EVENT_UPGRADE, this)
+                off(EVENT_UPGRADE_ERROR, this)
+                closeAction()
+            }
+        }
+        val waitForUpgrade = {
+            Logging.info(TAG, "close waiting upgrade")
+            // wait for upgrade to finish since we can't
+            // send packets while pausing transport.
+            once(EVENT_UPGRADE, cleanupAndClose)
+            once(EVENT_UPGRADE_ERROR, cleanupAndClose)
+        }
+
+        if (writeBuffer.isNotEmpty()) {
+            Logging.info(TAG, "close waiting drain event")
+            once(EVENT_DRAIN, object : Listener {
+                override fun call(vararg args: Any) {
+                    Logging.info(TAG, "close waiting drain success")
+                    if (upgrading) {
+                        waitForUpgrade()
+                    } else {
+                        closeAction()
+                    }
+                }
+            })
+        } else if (upgrading) {
+            waitForUpgrade()
+        } else {
+            closeAction()
+        }
+    }
+
+    @WorkThread
+    private fun createTransport(name: String): Transport {
+        Logging.info(TAG, "createTransport $name")
+        val query = HashMap(opt.query)
+        query["EIO"] = "4"
+        query["transport"] = name
+        if (id.isNotEmpty()) {
+            query[SID] = id
+        }
+
+        val options = opt.transportOptions[name]
+        val opts = Transport.Options()
+        opts.query = query
+
+        opts.secure = options?.secure ?: opt.secure
+        opts.hostname = options?.hostname ?: opt.hostname
+        opts.port = options?.port ?: opt.port
+        opts.path = options?.path ?: opt.path
+        opts.timestampRequests = options?.timestampRequests ?: opt.timestampRequests
+        opts.timestampParam = options?.timestampParam ?: opt.timestampParam
+        opts.extraHeaders = opt.extraHeaders
+        opts.trustAllCerts = opt.trustAllCerts
+        opts.httpClient = options?.httpClient ?: opt.httpClient
+
+        val transport = factory.create(name, opts, scope, rawMessage)
+        emit(EVENT_TRANSPORT, transport)
+        return transport
+    }
+
+    @WorkThread
+    private fun setTransport(transport: Transport) {
+        Logging.info(TAG, "setTransport ${transport.name}")
+        val oldTransport = this.transport
+        if (oldTransport != null) {
+            Logging.info(TAG, "clearing existing transport ${oldTransport.name}")
+            for (sub in subs) {
+                sub.destroy()
+            }
+            subs.clear()
+            // old transport is always Polling, and it's already paused.
+            // so we don't need to close it.
+        }
+
+        this.transport = transport
+
+        subs.add(On.on(transport, Transport.EVENT_DRAIN, object : Listener {
+            override fun call(vararg args: Any) {
+                if (args.isNotEmpty() && args[0] is Int) {
+                    onDrain(args[0] as Int)
+                } else {
+                    Logging.error(TAG, "onDrain with wrong args: `${args.joinToString()}`")
+                }
+            }
+        }))
+        subs.add(On.on(transport, Transport.EVENT_PACKET, object : Listener {
+            override fun call(vararg args: Any) {
+                val packet = args.firstOrNull() ?: return
+                Logging.debug(TAG) { "transport on packet $packet" }
+                if (packet is EngineIOPacket<*>) {
+                    onPacket(packet)
+                }
+            }
+        }))
+        subs.add(On.on(transport, Transport.EVENT_ERROR, object : Listener {
+            override fun call(vararg args: Any) {
+                val msg = args.firstOrNull() ?: ""
+                if (msg is String) {
+                    onError(msg)
+                }
+            }
+        }))
+        subs.add(On.on(transport, Transport.EVENT_CLOSE, object : Listener {
+            override fun call(vararg args: Any) {
+                onClose("transport close")
+            }
+        }))
+    }
+
+    @WorkThread
+    private fun onDrain(len: Int) {
+        Logging.debug(TAG) { "onDrain: prevBufferLen $prevBufferLen, writeBuffer.size ${writeBuffer.size}, len $len" }
+        for (i in 1..len) {
+            writeBuffer.removeAt(0)
+        }
+        prevBufferLen -= len
+
+        if (writeBuffer.isEmpty()) {
+            Logging.debug(TAG) { "onDrain fire socket drain event" }
+            emit(EVENT_DRAIN)
+        } else if (writeBuffer.size > prevBufferLen) {
+            flush()
+        }
+    }
+
+    @WorkThread
+    private fun sendPackets(packets: List<EngineIOPacket<*>>) {
+        Logging.debug(TAG) { "sendPackets: state $state, $packets" }
+        if (state != State.OPENING && state != State.OPEN) {
+            Logging.error(TAG, "sendPackets at wrong state: $state")
+            return
+        }
+
+        emit(EVENT_PACKET_CREATE, packets.size)
+        writeBuffer.addAll(packets)
+        flush()
+    }
+
+    @WorkThread
+    private fun onPacket(packet: EngineIOPacket<*>) {
+        Logging.debug(TAG) { "onPacket $packet" }
+        if (inactive()) {
+            Logging.error(TAG, "packet received at wrong state: $state")
+            return
+        }
+
+        emit(EVENT_PACKET, packet)
+        emit(EVENT_HEARTBEAT)
+
+        when (packet) {
+            is EngineIOPacket.Open -> onHandshake(packet)
+            is EngineIOPacket.Ping -> {
+                emit(EVENT_PING)
+                sendPackets(listOf(EngineIOPacket.Pong(null)))
+            }
+
+            is EngineIOPacket.BinaryData -> emit(EVENT_DATA, packet.payload)
+            is EngineIOPacket.Message<*> -> {
+                val data = packet.payload
+                if (data != null) {
+                    emit(EVENT_DATA, data)
+                }
+            }
+
+            else -> {}
+        }
+    }
+
+    @WorkThread
+    private fun onHandshake(pkt: EngineIOPacket.Open) {
+        emit(EVENT_HANDSHAKE, pkt)
+        id = pkt.sid
+        transport?.opt?.query?.set(SID, id)
+        upgrades = filterUpgrades(pkt.upgrades)
+        pingInterval = pkt.pingInterval
+        pingTimeout = pkt.pingTimeout
+        onOpen()
+
+        // In case open handler closes socket
+        if (state != State.OPEN) {
+            Logging.info(TAG, "onHandshake skip: state $state")
+            return
+        }
+
+        onHeartBeat()
+        off(EVENT_HEARTBEAT, heartbeatListener)
+        on(EVENT_HEARTBEAT, heartbeatListener)
+    }
+
+    internal fun filterUpgrades(upgrades: List<String>): List<String> =
+        upgrades.filter { opt.transports.contains(it) && it != transport?.name }
+
+    @WorkThread
+    private fun onOpen() {
+        Logging.info(TAG, "onOpen")
+        state = State.OPEN
+        priorWebsocketSuccess = transport?.name == WebSocket.NAME
+        emit(EVENT_OPEN)
+        // this flush call will always be ignored, because `emit(EVENT_OPEN)` will trigger
+        // sending Connect packet, which will trigger flush.
+        //flush()
+
+        if (opt.upgrade && transport?.name == PollingXHR.NAME && upgrades.isNotEmpty()) {
+            Logging.info(TAG, "starting upgrade probes")
+            for (upgrade in upgrades) {
+                probe(upgrade)
+            }
+        }
+    }
+
+    @WorkThread
+    private fun flush() {
+        Logging.debug(TAG) {
+            "flush: state $state, writable ${transport?.writable}, " +
+                    "upgrading $upgrading, prevBufferLen $prevBufferLen, " +
+                    "writeBuffer.size ${writeBuffer.size}"
+        }
+        if (state != State.CLOSED
+            && transport?.writable == true
+            && !upgrading
+            && writeBuffer.size > prevBufferLen
+        ) {
+            val packets = writeBuffer.subList(prevBufferLen, writeBuffer.size)
+            prevBufferLen = writeBuffer.size
+            transport?.send(ArrayList(packets))
+            emit(EVENT_FLUSH)
+        } else {
+            Logging.info(
+                TAG, "flush ignored: state $state, transport.writable ${transport?.writable}, " +
+                        "upgrading $upgrading, writeBuffer.size ${writeBuffer.size}, prevBufferLen $prevBufferLen"
+            )
+        }
+    }
+
+    @WorkThread
+    private fun probe(name: String) {
+        Logging.info(TAG, "probing transport '$name'")
+        val transport = createTransport(name)
+        var failed = false
+        priorWebsocketSuccess = false
+
+        val cleanUp = ArrayList<() -> Unit>()
+        var cleaned = false
+
+        val onTransportOpen = object : Listener {
+            override fun call(vararg args: Any) {
+                Logging.info(TAG, "probe transport $name opened, failed: $failed")
+                if (failed) {
+                    return
+                }
+
+                transport.send(listOf(EngineIOPacket.Ping(PROBE)))
+                transport.once(Transport.EVENT_PACKET, object : Listener {
+                    override fun call(vararg args: Any) {
+                        if (failed) {
+                            return
+                        }
+                        if (args.isNotEmpty() && args[0] is EngineIOPacket.Pong
+                            && (args[0] as EngineIOPacket.Pong).payload == PROBE
+                        ) {
+                            Logging.info(TAG, "probe transport $name pong")
+                            upgrading = true
+                            emit(EVENT_UPGRADING, transport)
+                            if (cleaned) {
+                                return
+                            }
+
+                            priorWebsocketSuccess = transport.name == WebSocket.NAME
+                            val currentTransport = this@EngineSocket.transport ?: return
+                            Logging.info(TAG, "pausing current transport ${currentTransport.name}")
+                            currentTransport.pause {
+                                if (failed || state == State.CLOSED) {
+                                    return@pause
+                                }
+                                Logging.info(TAG, "changing transport and sending upgrade packet")
+                                cleanUp[0]()
+                                transport.once(EVENT_DRAIN, object : Listener {
+                                    override fun call(vararg args: Any) {
+                                        Logging.info(TAG, "upgrade packet send success")
+                                        emit(EVENT_UPGRADE, transport)
+                                        setTransport(transport)
+                                        cleaned = true
+                                        upgrading = false
+                                        flush()
+                                    }
+                                })
+                                transport.send(listOf(EngineIOPacket.Upgrade))
+                            }
+                        } else {
+                            Logging.error(TAG, "probe transport $name failed")
+                            emit(EVENT_UPGRADE_ERROR, PROBE_ERROR)
+                        }
+                    }
+                })
+            }
+        }
+        val freezeTransport = object : Listener {
+            override fun call(vararg args: Any) {
+                if (failed) {
+                    return
+                }
+                failed = true
+                cleanUp[0]()
+                transport.close()
+                cleaned = true
+            }
+        }
+        // Handle any error that happens while probing
+        val onTransportError = object : Listener {
+            override fun call(vararg args: Any) {
+                freezeTransport.call()
+                Logging.error(TAG, "probe transport $name failed because of error: ${args.joinToString()}")
+                emit(EVENT_UPGRADE_ERROR, PROBE_ERROR)
+            }
+        }
+        val onTransportClose = object : Listener {
+            override fun call(vararg args: Any) {
+                Logging.error(TAG, "probe transport $name, but transport closed")
+                onTransportError.call("transport closed")
+            }
+        }
+        val onClose = object : Listener {
+            override fun call(vararg args: Any) {
+                Logging.error(TAG, "probe transport $name, but socket closed")
+                onTransportError.call("socket closed")
+            }
+        }
+        val onUpgrade = object : Listener {
+            override fun call(vararg args: Any) {
+                if (args.isNotEmpty() && args[0] is Transport) {
+                    val to = args[0] as Transport
+                    if (to.name != transport.name) {
+                        Logging.info(TAG, "probe but ${to.name} works, abort ${transport.name}")
+                        freezeTransport.call()
+                    }
+                }
+            }
+        }
+
+        cleanUp.add {
+            transport.off(Transport.EVENT_OPEN, onTransportOpen)
+            transport.off(Transport.EVENT_ERROR, onTransportError)
+            transport.off(Transport.EVENT_CLOSE, onTransportClose)
+            off(EVENT_CLOSE, onClose)
+            off(EVENT_UPGRADING, onUpgrade)
+        }
+
+        transport.once(Transport.EVENT_OPEN, onTransportOpen)
+        transport.once(Transport.EVENT_ERROR, onTransportError)
+        transport.once(Transport.EVENT_CLOSE, onTransportClose)
+        once(EVENT_CLOSE, onClose)
+        once(EVENT_UPGRADING, onUpgrade)
+
+        transport.open()
+    }
+
+    @WorkThread
+    private fun onHeartBeat() {
+        if (disablePingTimeout) {
+            return
+        }
+        pingTimeoutJob?.cancel()
+        pingTimeoutJob = scope.launch {
+            delay((pingInterval + pingTimeout).toLong())
+            if (!inactive()) {
+                onClose("ping timeout")
+            }
+        }
+    }
+
+    @WorkThread
+    private fun onError(msg: String) {
+        val log = "transport onError: `$msg`"
+        Logging.error(TAG, log)
+        priorWebsocketSuccess = false
+        emit(EVENT_ERROR, msg)
+        onClose(log)
+    }
+
+    @WorkThread
+    private fun onClose(reason: String) {
+        if (inactive()) {
+            return
+        }
+
+        Logging.info(TAG, "onClose $reason")
+        pingTimeoutJob?.cancel()
+
+        // stop event from firing again for transport
+        transport?.off(EVENT_CLOSE)
+        // ensure transport won't stay open
+        transport?.close()
+        // ignore further transport communication
+        // transport?.off() // this will cause missing event
+        for (sub in subs) {
+            sub.destroy()
+        }
+        subs.clear()
+
+        state = State.CLOSED
+        id = ""
+
+        emit(EVENT_CLOSE, reason)
+
+        // clear buffers after, so users can still
+        // grab the buffers on `close` event
+        writeBuffer.clear()
+        prevBufferLen = 0
+    }
+
+    private fun inactive() = state != State.OPENING
+            && state != State.OPEN
+            && state != State.CLOSING
+
+    companion object {
+        private const val TAG = "EngineSocket"
+        private const val PROBE_ERROR = "probe error"
+        private var priorWebsocketSuccess = false
+
+        internal const val PROBE = "probe"
+        internal const val SID = "sid"
+
+        /**
+         * Called on successful connection.
+         */
+        const val EVENT_OPEN = "open"
+
+        /**
+         * Called on disconnection.
+         */
+        const val EVENT_CLOSE = "close"
+
+        /**
+         * Called when data is received from the server.
+         */
+        const val EVENT_DATA = "data"
+
+        /**
+         * Called when an error occurs.
+         */
+        const val EVENT_ERROR = "error"
+
+
+        const val EVENT_UPGRADE_ERROR = "upgradeError"
+
+        /**
+         * Called on completing a buffer flush.
+         */
+        const val EVENT_FLUSH = "flush"
+
+        /**
+         * Called after `drain` event of transport if writeBuffer is empty.
+         */
+        const val EVENT_DRAIN = "drain"
+
+
+        const val EVENT_HANDSHAKE = "handshake"
+        const val EVENT_UPGRADING = "upgrading"
+        const val EVENT_UPGRADE = "upgrade"
+        const val EVENT_PACKET = "packet"
+        const val EVENT_PACKET_CREATE = "packetCreate"
+        const val EVENT_HEARTBEAT = "heartbeat"
+        const val EVENT_PING = "ping"
+
+        /**
+         * Called on new transport is created.
+         */
+        const val EVENT_TRANSPORT = "transport"
+
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/On.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/On.kt
@@ -1,0 +1,18 @@
+package com.piasy.kmp.socketio.engineio
+
+import com.piasy.kmp.socketio.emitter.Emitter
+
+object On {
+    fun on(emitter: Emitter, event: String, listener: Emitter.Listener): Handle {
+        emitter.on(event, listener)
+        return object : Handle {
+            override fun destroy() {
+                emitter.off(event, listener)
+            }
+        }
+    }
+
+    interface Handle {
+        fun destroy()
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/Transport.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/Transport.kt
@@ -1,0 +1,186 @@
+package com.piasy.kmp.socketio.engineio
+
+import com.piasy.kmp.socketio.emitter.Emitter
+import com.piasy.kmp.xlog.Logging
+import com.piasy.kmp.socketio.parseqs.ParseQS
+import io.ktor.client.HttpClient
+import io.ktor.util.date.*
+import kotlinx.coroutines.CoroutineScope
+import org.hildan.socketio.EngineIOPacket
+import kotlin.jvm.JvmField
+
+abstract class Transport(
+    internal val opt: Options,
+    protected val scope: CoroutineScope,
+    val name: String,
+    protected val rawMessage: Boolean,
+) : Emitter() {
+    open class Options {
+        // @JvmField for jvm test code
+        @JvmField
+        var secure = false
+
+        @JvmField
+        var hostname = ""
+
+        @JvmField
+        var port = -1
+
+        @JvmField
+        var path = ""
+
+        @JvmField
+        var timestampRequests = false
+
+        @JvmField
+        var timestampParam = ""
+
+        @JvmField
+        var query: MutableMap<String, String> = HashMap()
+
+        @JvmField
+        var extraHeaders: Map<String, List<String>> = emptyMap()
+
+        @JvmField
+        var trustAllCerts: Boolean = false
+
+        /**
+         * Optional externally managed ktor HttpClient to reuse.
+         */
+        @JvmField
+        var httpClient: HttpClient? = null
+    }
+
+    protected var state = State.INIT
+    internal var writable = false
+
+    @WorkThread
+    fun open(): Transport {
+        logD { "open" }
+        if (state == State.CLOSED || state == State.INIT) {
+            state = State.OPENING
+            doOpen()
+        }
+        return this
+    }
+
+    @WorkThread
+    fun send(packets: List<EngineIOPacket<*>>) {
+        logD { "send: state $state, ${packets.size} packets" }
+        if (state == State.OPEN) {
+            doSend(packets)
+        } else {
+            onError("Transport not open")
+        }
+    }
+
+    @WorkThread
+    fun close(): Transport {
+        logI("close, state $state")
+        if (state == State.OPENING || state == State.OPEN) {
+            val fromOpenState = state == State.OPEN
+            state = State.CLOSING
+            doClose(fromOpenState)
+        }
+        return this
+    }
+
+    @WorkThread
+    abstract fun pause(onPause: () -> Unit)
+
+    @WorkThread
+    protected fun onOpen() {
+        logI("onOpen, state $state")
+        if (state == State.OPENING || state == State.CLOSING) {
+            state = State.OPEN
+            writable = true
+            emit(EVENT_OPEN)
+        }
+    }
+
+    @WorkThread
+    protected fun onPacket(packet: EngineIOPacket<*>) {
+        logD { "onPacket $packet" }
+        emit(EVENT_PACKET, packet)
+    }
+
+    @WorkThread
+    internal fun onError(msg: String) {
+        logE("onError `$msg`")
+        emit(EVENT_ERROR, msg)
+    }
+
+    @WorkThread
+    protected fun onClose() {
+        logI("onClose")
+        state = State.CLOSED
+        emit(EVENT_CLOSE)
+    }
+
+    @WorkThread
+    protected abstract fun doOpen()
+
+    @WorkThread
+    protected abstract fun doSend(packets: List<EngineIOPacket<*>>)
+
+    @WorkThread
+    protected abstract fun doClose(fromOpenState: Boolean)
+
+    @WorkThread
+    protected fun uri(secureSchema: String, insecureSchema: String): String {
+        val query = HashMap(opt.query)
+        val schema = if (opt.secure) secureSchema else insecureSchema
+        var port = ""
+
+        if (opt.port > 0 && ((opt.secure && opt.port != 443)
+                    || (!opt.secure && opt.port != 80))
+        ) {
+            port = ":" + opt.port
+        }
+
+        if (opt.timestampRequests) {
+            // In official Java implementation, the radix is 64, we just use 36
+            // here because it's the max radix in kotlin.
+            query[opt.timestampParam] = GMTDate().timestamp.toString(36)
+        }
+
+        var derivedQuery = ParseQS.encode(query)
+        if (derivedQuery.isNotEmpty()) {
+            derivedQuery = "?$derivedQuery"
+        }
+
+        val hostname = if (opt.hostname.contains(":")) {
+            "[" + opt.hostname + "]"
+        } else {
+            opt.hostname
+        }
+        return "$schema://$hostname$port${opt.path}$derivedQuery"
+    }
+
+    protected fun logD(block: () -> String) {
+        if (Logging.debug()) {
+            Logging.debug(TAG, "$name@${hashCode()} ${block()}")
+        }
+    }
+
+    protected fun logI(log: String) {
+        Logging.info(TAG, "$name@${hashCode()} $log")
+    }
+
+    protected fun logE(log: String) {
+        Logging.error(TAG, "$name@${hashCode()} $log")
+    }
+
+    companion object {
+        // all internal events are emitted from work thread.
+        const val EVENT_OPEN: String = "open"
+        const val EVENT_CLOSE: String = "close"
+        const val EVENT_PACKET: String = "packet"
+        const val EVENT_DRAIN: String = "drain"
+        const val EVENT_ERROR: String = "error"
+        const val EVENT_REQUEST_HEADERS: String = "requestHeaders"
+        const val EVENT_RESPONSE_HEADERS: String = "responseHeaders"
+
+        private const val TAG = "Transport"
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/defs.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/defs.kt
@@ -1,0 +1,17 @@
+package com.piasy.kmp.socketio.engineio
+
+enum class State {
+    INIT, OPENING, OPEN, CLOSING, CLOSED, PAUSED
+}
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR)
+@Retention(AnnotationRetention.SOURCE)
+annotation class WorkThread
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR)
+@Retention(AnnotationRetention.SOURCE)
+annotation class IoThread
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR)
+@Retention(AnnotationRetention.SOURCE)
+annotation class CallerThread

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/transports/PollingXHR.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/transports/PollingXHR.kt
@@ -1,0 +1,237 @@
+// CAMPFIRE PATCH (see the module README): the default ioScope survives child failures instead of
+// crashing the app.
+package com.piasy.kmp.socketio.engineio.transports
+
+import com.piasy.kmp.socketio.engineio.IoThread
+import com.piasy.kmp.socketio.engineio.State
+import com.piasy.kmp.socketio.engineio.Transport
+import com.piasy.kmp.socketio.engineio.WorkThread
+import com.piasy.kmp.socketio.global.supervisedScope
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.util.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.hildan.socketio.*
+
+open class PollingXHR(
+    opt: Options,
+    scope: CoroutineScope,
+    private val ioScope: CoroutineScope = supervisedScope(NAME, Dispatchers.Default),
+    private val factory: HttpClientFactory = DefaultHttpClientFactory(
+        externalHttpClient = opt.httpClient,
+        trustAllCerts = opt.trustAllCerts,
+    ),
+    rawMessage: Boolean,
+) : Transport(opt, scope, NAME, rawMessage) {
+    private var polling = false
+
+    @WorkThread
+    override fun pause(onPause: () -> Unit) {
+        logI("pause")
+        state = State.PAUSED
+        val paused = {
+            logI("paused")
+            state = State.PAUSED
+            onPause()
+        }
+
+        if (polling || !writable) {
+            var counter = 0
+            val waitJob: (String, String) -> Unit = { event, job ->
+                logI("pause: wait $job")
+                counter++
+                once(event, object : Listener {
+                    override fun call(vararg args: Any) {
+                        logI("pause: pre-pause $job complete")
+                        counter--
+                        if (counter == 0) {
+                            paused()
+                        }
+                    }
+                })
+            }
+
+            if (polling) {
+                waitJob(EVENT_POLL_COMPLETE, "polling")
+            }
+            if (!writable) {
+                waitJob(EVENT_DRAIN, "writing")
+            }
+        } else {
+            paused()
+        }
+    }
+
+    @WorkThread
+    override fun doOpen() {
+        poll()
+    }
+
+    @WorkThread
+    private fun poll() {
+        logD { "poll start" }
+        polling = true
+
+        val method = HttpMethod.Get
+        val headers = prepareRequestHeaders(method)
+        ioScope.launch {
+            doRequest(uri(), method, headers, onResponse = { onPollComplete(it) })
+        }
+        emit(EVENT_POLL)
+    }
+
+    @WorkThread
+    private fun prepareRequestHeaders(method: HttpMethod): Map<String, List<String>> {
+        val requestHeaders = HashMap<String, List<String>>()
+        requestHeaders.putAll(opt.extraHeaders)
+        if (method == HttpMethod.Post) {
+            requestHeaders["Content-type"] = listOf("text/plain;charset=UTF-8")
+        }
+        requestHeaders["Accept"] = listOf("*/*")
+        emit(EVENT_REQUEST_HEADERS, requestHeaders)
+        return requestHeaders
+    }
+
+    @IoThread
+    private suspend fun doRequest(
+        uri: String,
+        method: HttpMethod,
+        requestHeaders: Map<String, List<String>>,
+        data: String? = null,
+        onResponse: (String) -> Unit = {},
+        onSuccess: () -> Unit = {},
+    ) {
+        logD { "doRequest ${method.value} $uri, data $data, headers $requestHeaders" }
+        val resp = try {
+            factory.httpRequest(uri) {
+                this.method = method
+
+                headers {
+                    putHeaders(this, requestHeaders)
+                }
+
+                if (data != null) {
+                    setBody(data)
+                }
+            }
+        } catch (e: Exception) {
+            scope.launch { onError("http exception: ${e.message}") }
+            return
+        }
+
+        logD { "doRequest ${method.value} $uri response: ${resp.status}" }
+        scope.launch {
+            emit(EVENT_RESPONSE_HEADERS, resp.headers.toMap())
+        }
+        if (resp.status.isSuccess()) {
+            val body = resp.bodyAsText()
+            scope.launch {
+                onResponse(body)
+                onSuccess()
+            }
+        } else {
+            scope.launch {
+                onError("HTTP error: ${resp.status}")
+            }
+        }
+    }
+
+    @WorkThread
+    private fun onPollComplete(data: String) {
+        logD { "onPollComplete: state $state, `$data`" }
+        val packets = try {
+            if (rawMessage) {
+                EngineIO.decodeHttpBatch(data, deserializePayload = { it })
+            } else {
+                EngineIO.decodeHttpBatch(data, SocketIO::decode)
+            }
+        } catch (e: Exception) { // InvalidSocketIOPacketException | InvalidEngineIOPacketException
+            val log = "onPollComplete decode error: ${e.message}"
+            logE(log)
+            onError(log)
+            return
+        }
+        for (pkt in packets) {
+            if ((state == State.OPENING || state == State.CLOSING) && pkt is EngineIOPacket.Open) {
+                onOpen()
+            }
+
+            if (pkt is EngineIOPacket.Close) {
+                onClose()
+                break
+            }
+
+            onPacket(pkt)
+        }
+
+        if (state != State.CLOSED) {
+            polling = false
+            emit(EVENT_POLL_COMPLETE)
+
+            if (state == State.OPEN) {
+                poll()
+            } else {
+                logI("onPollComplete ignore poll, state $state")
+            }
+        }
+    }
+
+    @WorkThread
+    override fun doSend(packets: List<EngineIOPacket<*>>) {
+        writable = false
+        val data = if (rawMessage) {
+            EngineIO.encodeHttpBatch(packets, serializePayload = { it.toString() })
+        } else {
+            EngineIO.encodeHttpBatch(packets, serializePayload = { SocketIO.encode(it as SocketIOPacket) })
+        }
+
+        val method = HttpMethod.Post
+        val headers = prepareRequestHeaders(method)
+        ioScope.launch {
+            doRequest(uri(), method, headers, data) {
+                writable = true
+                emit(EVENT_DRAIN, packets.size)
+            }
+        }
+    }
+
+    @WorkThread
+    override fun doClose(fromOpenState: Boolean) {
+        val doCloseAction: () -> Unit = {
+            logI("doClose writing close packet")
+            once(EVENT_DRAIN, object : Listener {
+                override fun call(vararg args: Any) {
+                    onClose()
+                }
+            })
+            doSend(listOf(EngineIOPacket.Close))
+        }
+
+        if (fromOpenState) {
+            logI("doClose on OPEN state, closing")
+            doCloseAction()
+        } else {
+            logI("doClose on OPENING state, deferring close")
+            once(EVENT_OPEN, object : Listener {
+                override fun call(vararg args: Any) {
+                    doCloseAction()
+                }
+            })
+        }
+    }
+
+    @WorkThread
+    protected open fun uri() = uri(SECURE_SCHEMA, INSECURE_SCHEMA)
+
+    companion object {
+        const val NAME = "polling"
+        const val SECURE_SCHEMA = "https"
+        const val INSECURE_SCHEMA = "http"
+
+        const val EVENT_POLL = "poll"
+        const val EVENT_POLL_COMPLETE = "pollComplete"
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/transports/WebSocket.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/transports/WebSocket.kt
@@ -1,0 +1,211 @@
+// CAMPFIRE PATCHES (see the module README): onWsText catches all decode exceptions, and the
+// default ioScope survives child failures instead of crashing the app.
+package com.piasy.kmp.socketio.engineio.transports
+
+import com.piasy.kmp.socketio.engineio.EngineSocket
+import com.piasy.kmp.socketio.engineio.IoThread
+import com.piasy.kmp.socketio.engineio.State
+import com.piasy.kmp.socketio.engineio.Transport
+import com.piasy.kmp.socketio.engineio.WorkThread
+import com.piasy.kmp.socketio.global.supervisedScope
+import io.ktor.client.plugins.websocket.*
+import io.ktor.client.request.*
+import io.ktor.util.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.io.bytestring.unsafe.UnsafeByteStringApi
+import kotlinx.io.bytestring.unsafe.UnsafeByteStringOperations
+import org.hildan.socketio.EngineIO
+import org.hildan.socketio.EngineIOPacket
+import org.hildan.socketio.SocketIOPacket
+
+open class WebSocket(
+    opt: Options,
+    scope: CoroutineScope,
+    private val ioScope: CoroutineScope = supervisedScope(NAME, Dispatchers.Default),
+    private val factory: HttpClientFactory = DefaultHttpClientFactory(
+        externalHttpClient = opt.httpClient,
+        trustAllCerts = opt.trustAllCerts,
+    ),
+    rawMessage: Boolean,
+) : Transport(opt, scope, NAME, rawMessage) {
+    private var ws: WebSocketSession? = null
+
+    @WorkThread
+    override fun pause(onPause: () -> Unit) {
+        // ws don't need to pause
+    }
+
+    @WorkThread
+    override fun doOpen() {
+        val uri = uri()
+        logI("doOpen $uri")
+
+        val requestHeaders = HashMap<String, List<String>>()
+        requestHeaders.putAll(opt.extraHeaders)
+        emit(EVENT_REQUEST_HEADERS, requestHeaders)
+
+        ioScope.launch {
+            try {
+                factory.createWs(uri, {
+                    headers {
+                        putHeaders(this, requestHeaders)
+                    }
+                }) {
+                    ws = this
+                    if (this is DefaultClientWebSocketSession) {
+                        val respHeaders = call.response.headers.toMap()
+                        scope.launch {
+                            emit(EVENT_RESPONSE_HEADERS, respHeaders)
+                            onOpen()
+                        }
+                    }
+
+                    listen()
+                }
+            } catch (e: Exception) {
+                scope.launch { onError("ws exception: ${e.message}") }
+            }
+        }
+    }
+
+    @WorkThread
+    protected open fun uri() = uri(SECURE_SCHEMA, INSECURE_SCHEMA)
+
+    @IoThread
+    private suspend fun listen() {
+        while (true) {
+            try {
+                val frame = ws?.incoming?.receive() ?: break
+                logD { "Receive frame: $frame" }
+                when (frame) {
+                    is Frame.Text -> {
+                        onWsText(frame.readText())
+                    }
+
+                    is Frame.Binary -> {
+                        onWsBinary(frame.readBytes())
+                    }
+
+                    is Frame.Close -> {
+                        logI("Received Close frame")
+                        break
+                    }
+
+                    else -> {
+                        // ignore
+                        //logI("Received unknown frame")
+                    }
+                }
+            } catch (e: Exception) {
+                logE("Receive error while reading websocket frame: `${e.message}`")
+                break
+            }
+        }
+        scope.launch { onClose() }
+    }
+
+    @IoThread
+    // CAMPFIRE PATCH: internal (upstream: private) so the decode error handling is testable.
+    internal fun onWsText(data: String) {
+        scope.launch {
+            logD { "onWsText: `$data`" }
+            val packet = try {
+                if (rawMessage) {
+                    EngineIO.decodeWsFrame(data, deserializePayload = { it })
+                } else {
+                    EngineIO.decodeSocketIO(data)
+                }
+            } catch (e: Exception) {
+                // CAMPFIRE PATCH: upstream catches only InvalidEngineIOPacketException here, so
+                // InvalidSocketIOPacketException (and SerializationException from the handshake
+                // payload) escaped the coroutine and crashed the app. Catch everything a bad frame
+                // can throw and degrade to the transport error path, mirroring PollingXHR's
+                // onPollComplete which already catches broadly.
+                val log = "onWsText decode error: ${e.message}"
+                logE(log)
+                onError(log)
+                return@launch
+            }
+            onPacket(packet)
+        }
+    }
+
+    @OptIn(UnsafeByteStringApi::class)
+    @IoThread
+    private fun onWsBinary(data: ByteArray) {
+        scope.launch {
+            logD { "onWsBinary ${data.size} bytes" }
+            onPacket(EngineIO.decodeWsFrame(UnsafeByteStringOperations.wrapUnsafe(data)))
+        }
+    }
+
+    @OptIn(UnsafeByteStringApi::class)
+    @WorkThread
+    override fun doSend(packets: List<EngineIOPacket<*>>) {
+        logD { "doSend ${packets.size} packets start" }
+        writable = false
+
+        // Check if this is a probe ping - if so, skip drain event to avoid race condition
+        val isProbePing = packets.size == 1
+            && packets[0] is EngineIOPacket.Ping
+            && (packets[0] as EngineIOPacket.Ping).payload == EngineSocket.PROBE
+
+        ioScope.launch {
+            for (pkt in packets) {
+                if (state != State.OPEN) {
+                    // Ensure we don't try to send anymore packets
+                    // if the socket ends up being closed due to an exception
+                    break
+                }
+                try {
+                    if (pkt is EngineIOPacket.BinaryData) {
+                        UnsafeByteStringOperations.withByteArrayUnsafe(pkt.payload) {
+                            logD { "doSend binary: ${it.size} bytes" }
+                            ws?.send(it)
+                        }
+                    } else {
+                        val data = if (rawMessage) {
+                            EngineIO.encodeWsFrame(pkt, serializePayload = { it.toString() })
+                        } else {
+                            @Suppress("UNCHECKED_CAST")
+                            EngineIO.encodeSocketIO(pkt as EngineIOPacket<SocketIOPacket>)
+                        }
+                        logD { "doSend: $pkt, `$data`" }
+                        ws?.send(data)
+                    }
+                } catch (e: Exception) {
+                    logE("doSend error: `${e.message}`")
+                    //break
+                    // TODO: send error is ignored, should we handle it?
+                }
+            }
+
+            scope.launch {
+                logD { "doSend ${packets.size} packets finish" }
+                writable = true
+                // Skip drain event for probe ping to avoid race condition between
+                // probe ping drain and upgrade drain - see docs/ut-case-analysis/
+                if (!isProbePing) {
+                    emit(EVENT_DRAIN, packets.size)
+                }
+            }
+        }
+    }
+
+    @WorkThread
+    override fun doClose(fromOpenState: Boolean) {
+        logI("doClose")
+        ioScope.launch {
+            ws?.close()
+        }
+    }
+
+    companion object {
+        const val NAME = "websocket"
+        const val SECURE_SCHEMA = "wss"
+        const val INSECURE_SCHEMA = "ws"
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/transports/transport.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/engineio/transports/transport.kt
@@ -1,0 +1,98 @@
+package com.piasy.kmp.socketio.engineio.transports
+
+import com.piasy.kmp.socketio.engineio.Transport
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.logging.*
+import io.ktor.client.plugins.websocket.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.websocket.WebSocketSession
+import kotlinx.coroutines.CoroutineScope
+
+expect fun httpClient(trustAllCerts: Boolean = false, config: HttpClientConfig<*>.() -> Unit = {}): HttpClient
+
+internal fun putHeaders(
+    builder: HeadersBuilder,
+    headers: Map<String, List<String>>
+) {
+    headers.forEach {
+        it.value.forEach { v ->
+            builder.append(it.key, v)
+        }
+    }
+}
+
+interface TransportFactory {
+    fun create(
+        name: String,
+        opt: Transport.Options,
+        scope: CoroutineScope,
+        rawMessage: Boolean,
+    ): Transport
+}
+
+object DefaultTransportFactory : TransportFactory {
+    override fun create(
+        name: String,
+        opt: Transport.Options,
+        scope: CoroutineScope,
+        rawMessage: Boolean,
+    ) = when (name) {
+        WebSocket.NAME -> WebSocket(opt, scope, rawMessage = rawMessage)
+        PollingXHR.NAME -> PollingXHR(opt, scope, rawMessage = rawMessage)
+        else -> throw RuntimeException("Bad transport name: $name")
+    }
+}
+
+interface HttpClientFactory {
+    suspend fun createWs(
+        url: String,
+        request: HttpRequestBuilder.() -> Unit,
+        block: suspend WebSocketSession.() -> Unit,
+    )
+
+    suspend fun httpRequest(
+        url: String,
+        block: HttpRequestBuilder.() -> Unit
+    ): HttpResponse
+}
+
+class DefaultHttpClientFactory(
+    externalHttpClient: HttpClient? = null,
+    trustAllCerts: Boolean = false,
+): HttpClientFactory {
+    private val wsClient = externalHttpClient ?: run {
+        httpClient(
+            trustAllCerts = trustAllCerts,
+        ) {
+            install(Logging) {
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        com.piasy.kmp.xlog.Logging.info("Net", message)
+                    }
+                }
+                level = LogLevel.ALL
+            }
+            install(WebSockets) {
+                pingIntervalMillis = 20_000
+            }
+        }
+    }
+    // Linux curl engine doesn't work for simultaneous websocket and http request.
+    // see https://youtrack.jetbrains.com/issue/KTOR-8259/
+    // But it's fixed in 3.2.0.
+    private val httpClient: HttpClient = wsClient
+
+    override suspend fun createWs(
+        url: String,
+        request: HttpRequestBuilder.() -> Unit,
+        block: suspend WebSocketSession.() -> Unit,
+    ) = wsClient.webSocket(url, request, block)
+
+    override suspend fun httpRequest(
+        url: String,
+        block: HttpRequestBuilder.() -> Unit
+    ) = httpClient.request(url, block)
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/global/Global.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/global/Global.kt
@@ -1,0 +1,22 @@
+package com.piasy.kmp.socketio.global
+
+import io.ktor.http.*
+import kotlin.jvm.JvmStatic
+
+object Global {
+    @JvmStatic
+    fun encodeURIComponent(str: String): String {
+        return str.encodeURLParameter()
+            .replace("+", "%20")
+            .replace("%21", "!")
+            .replace("%27", "'")
+            .replace("%28", "(")
+            .replace("%29", ")")
+            .replace("%7E", "~")
+    }
+
+    @JvmStatic
+    fun decodeURIComponent(str: String): String {
+        return str.decodeURLQueryComponent()
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/global/SupervisedScope.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/global/SupervisedScope.kt
@@ -1,0 +1,25 @@
+// CAMPFIRE PATCH — this file is not part of upstream kmp-socketio.
+package com.piasy.kmp.socketio.global
+
+import com.piasy.kmp.xlog.Logging
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * A [CoroutineScope] for the library's internal workers that survives child failures.
+ *
+ * Upstream uses bare `CoroutineScope(dispatcher)`, which fails in two ways when a launched
+ * coroutine throws: the exception reaches the platform's default uncaught-exception handler and
+ * crashes the app (this is how Crashlytics issue 4350da0dd8d479a67b4004bddebb06da surfaced), and
+ * the scope's implicit job is cancelled, silently killing every future socket coroutine. Known
+ * decode errors are caught at their source (see WebSocket.onWsText), and this scope backstops
+ * anything unanticipated: the failure degrades to a logged error while the socket keeps running.
+ */
+internal fun supervisedScope(name: String, context: CoroutineContext): CoroutineScope =
+    CoroutineScope(
+        context + SupervisorJob() + CoroutineExceptionHandler { _, e ->
+            Logging.error(name, "Uncaught exception in socket coroutine: $e")
+        },
+    )

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/parseqs/ParseQS.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/parseqs/ParseQS.kt
@@ -1,0 +1,34 @@
+package com.piasy.kmp.socketio.parseqs
+
+import com.piasy.kmp.socketio.global.Global
+import kotlin.jvm.JvmStatic
+
+object ParseQS {
+    @JvmStatic
+    fun encode(obj: Map<String, String>): String {
+        val str = StringBuilder()
+        for ((k, v) in obj) {
+            if (str.isNotEmpty()) {
+                str.append('&')
+            }
+            str.append(Global.encodeURIComponent(k))
+                .append('=')
+                .append(Global.encodeURIComponent(v))
+        }
+        return str.toString()
+    }
+
+    @JvmStatic
+    fun decode(qs: String): Map<String, String> {
+        val qry = HashMap<String, String>()
+        for (kv in qs.split('&')) {
+            val pair = kv.split('=')
+            qry[Global.decodeURIComponent(pair[0])] = if (pair.size == 2) {
+                Global.decodeURIComponent(pair[1])
+            } else {
+                ""
+            }
+        }
+        return qry
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/Ack.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/Ack.kt
@@ -1,0 +1,47 @@
+package com.piasy.kmp.socketio.socketio
+
+import com.piasy.kmp.xlog.Logging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+interface Ack {
+    fun call(vararg args: Any)
+}
+
+abstract class AckWithTimeout(val timeout: Long) : Ack {
+    private var job: Job? = null
+
+    override fun call(vararg args: Any) {
+        Logging.info(TAG, "@${hashCode()} ack success")
+        job?.cancel()
+        onSuccess(*args)
+    }
+
+    internal fun schedule(scope: CoroutineScope, block: () -> Unit) {
+        if (job != null) {
+            Logging.error(TAG, "@${hashCode()} schedule error: already scheduled")
+            return
+        }
+        Logging.info(TAG, "@${hashCode()} schedule ack timeout $timeout")
+        job = scope.launch {
+            delay(timeout)
+            Logging.info(TAG, "@${hashCode()} ack timeout $timeout")
+            block()
+            onTimeout()
+        }
+    }
+
+    internal fun cancel() {
+        Logging.info(TAG, "@${hashCode()} cancel timeout")
+        job?.cancel()
+    }
+
+    abstract fun onSuccess(vararg args: Any)
+    abstract fun onTimeout()
+
+    companion object {
+        private const val TAG = "AckWithTimeout"
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/Backoff.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/Backoff.kt
@@ -1,0 +1,62 @@
+package com.piasy.kmp.socketio.socketio
+
+import io.ktor.util.date.GMTDate
+import kotlin.math.floor
+import kotlin.math.min
+import kotlin.math.max
+import kotlin.math.pow
+import kotlin.random.Random
+
+/**
+ * Initialize backoff timer with `opts`.
+ * - `min` initial timeout in milliseconds [100]
+ * - `max` max timeout [10000]
+ * - `jitter` [0]
+ * - `factor` [2]
+ */
+class Backoff(
+    var min: Long = 100,
+    var max: Long = 10000,
+    jitter: Double = 0.0,
+    private val factor: Double = 2.0,
+) {
+    private val rand = Random(GMTDate().timestamp)
+
+    init {
+        checkValidJitter(jitter)
+    }
+
+    var attempts: Int = 0
+        private set
+
+    var jitter: Double = jitter
+        set(value) {
+            checkValidJitter(value)
+            field = value
+        }
+
+    /** Return the backoff duration. */
+    val duration: Long
+        get() {
+            var ms = min * factor.pow(attempts++)
+            if (jitter > 0.0) {
+                val rand = rand.nextDouble()
+                val deviation = rand * jitter * ms
+                ms = if (((floor(rand * 10).toInt()).and(1)) == 0) (ms - deviation) else (ms + deviation)
+            }
+            return max(min(ms.toLong(), max), min)
+        }
+
+    /** Reset the number of attempts. */
+    fun reset(): Int {
+        val oldAttempts = attempts
+        attempts = 0
+        return oldAttempts
+    }
+
+    private fun checkValidJitter(jitter: Double) {
+        require(jitter in 0.0..1.0) {
+            throw IllegalArgumentException("jitter should be between 0.0 and 1.0, but $jitter")
+        }
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/BinaryPacketReconstructor.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/BinaryPacketReconstructor.kt
@@ -1,0 +1,36 @@
+package com.piasy.kmp.socketio.socketio
+
+import com.piasy.kmp.xlog.Logging
+import kotlinx.io.bytestring.ByteString
+import org.hildan.socketio.PayloadElement
+import org.hildan.socketio.SocketIOPacket
+
+class BinaryPacketReconstructor(
+    private val packet: SocketIOPacket.BinaryMessage,
+    private val emitter: (isAck: Boolean, ackId: Int?, ArrayList<Any>) -> Unit,
+) {
+    private val buffers = ArrayList<ByteString>()
+
+    fun add(buffer: ByteString) {
+        buffers.add(buffer)
+        if (buffers.size == packet.nBinaryAttachments) {
+            val data = ArrayList<Any>()
+            packet.payload.forEach {
+                if (it is PayloadElement.AttachmentRef) {
+                    if (it.attachmentIndex in 0..<buffers.size) {
+                        data.add(buffers[it.attachmentIndex])
+                    } else {
+                        Logging.error(
+                            Socket.TAG,
+                            "BinaryPacketReconstructor bad index: ${it.attachmentIndex}, ${buffers.size}"
+                        )
+                        return
+                    }
+                } else {
+                    data.add((it as PayloadElement.Json).jsonElement)
+                }
+            }
+            emitter(packet is SocketIOPacket.BinaryAck, packet.ackId, data)
+        }
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/IO.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/IO.kt
@@ -1,0 +1,56 @@
+// CAMPFIRE PATCH (see the module README): the library-wide work scope survives child failures
+// instead of crashing the app and silently dying.
+package com.piasy.kmp.socketio.socketio
+
+import com.piasy.kmp.socketio.global.supervisedScope
+import com.piasy.kmp.xlog.Logging
+import io.ktor.http.Url
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
+
+object IO {
+    class Options : Manager.Options() {
+        @JvmField
+        var forceNew = false
+
+        /**
+         * Whether to enable multiplexing. Default is true.
+         */
+        @JvmField
+        var multiplex = true
+    }
+
+    private const val TAG = "IO"
+    private val scope = supervisedScope(TAG, Dispatchers.Default.limitedParallelism(1, "siowkr"))
+    private val managers = HashMap<String, Manager>()
+
+    @JvmStatic
+    fun socket(uri: String, opt: Options, block: (Socket) -> Unit) {
+        scope.launch {
+            Logging.info(TAG, "socket: uri $uri, opt $opt")
+            val url = Url(uri)
+            val id = "${url.protocol}://${url.host}:${url.port}"
+            val sameNsp = managers.containsKey(id)
+                    && managers[id]?.nsps?.containsKey(url.encodedPath) == true
+            val newConn = opt.forceNew || !opt.multiplex || sameNsp
+
+            // url queries will be handled in EngineSocket
+
+            val io = if (newConn) {
+                Logging.info(TAG, "socket newConn, sameNsp $sameNsp")
+                Manager(uri, opt, scope)
+            } else {
+                managers.getOrElse(id) {
+                    Logging.info(TAG, "socket not newConn, but create one")
+                    val manager = Manager(uri, opt, scope)
+                    managers[id] = manager
+                    manager
+                }
+            }
+            val socket = io.socket(if (url.segments.isEmpty()) "/" else url.encodedPath, opt.auth)
+            block(socket)
+        }
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/Manager.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/Manager.kt
@@ -1,0 +1,368 @@
+package com.piasy.kmp.socketio.socketio
+
+import com.piasy.kmp.socketio.emitter.Emitter
+import com.piasy.kmp.socketio.engineio.EngineSocket
+import com.piasy.kmp.socketio.engineio.On
+import com.piasy.kmp.socketio.engineio.State
+import com.piasy.kmp.socketio.engineio.WorkThread
+import com.piasy.kmp.xlog.Logging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.hildan.socketio.EngineIOPacket
+import kotlin.jvm.JvmField
+
+class Manager(
+    private val uri: String,
+    private val opt: Options,
+    private val scope: CoroutineScope,
+) : Emitter() {
+    open class Options : EngineSocket.Options() {
+        internal lateinit var backoff: Backoff
+
+        @JvmField
+        var reconnection = true
+
+        @JvmField
+        var reconnectionAttempts: Int = Int.MAX_VALUE
+        var reconnectionDelay: Long = 1000
+            set(value) {
+                if (::backoff.isInitialized) {
+                    backoff.min = value
+                }
+                field = value
+            }
+        var reconnectionDelayMax: Long = 5000
+            set(value) {
+                if (::backoff.isInitialized) {
+                    backoff.max = value
+                }
+                field = value
+            }
+        var randomizationFactor: Double = 0.5
+            set(value) {
+                if (::backoff.isInitialized) {
+                    backoff.jitter = value
+                }
+                field = value
+            }
+        @JvmField
+        var auth: Map<String, String> = emptyMap()
+
+        /**
+         * Connection timeout (ms). Set -1 to disable.
+         */
+        @JvmField
+        var timeout: Long = 20000
+    }
+
+    internal var state = State.INIT
+        private set
+    private val subs = ArrayList<On.Handle>()
+    internal var engine: EngineSocket? = null
+    internal val nsps = HashMap<String, Socket>()
+
+    private var skipReconnect = false
+    internal var reconnecting = false
+        private set
+
+    init {
+        if (opt.path.isEmpty()) {
+            opt.path = "/socket.io/"
+        }
+        opt.backoff = Backoff(opt.reconnectionDelay, opt.reconnectionDelayMax, opt.randomizationFactor)
+    }
+
+    fun reconnectionDelay(delay: Long) {
+        opt.reconnectionDelay = delay
+    }
+
+    fun reconnectionDelayMax(delayMax: Long) {
+        opt.reconnectionDelayMax = delayMax
+    }
+
+    fun randomizationFactor(factor: Double) {
+        opt.randomizationFactor = factor
+    }
+
+    /**
+     * Connects the client.
+     *
+     * @param callback callback.
+     */
+    @WorkThread
+    fun open(callback: ((String) -> Unit)? = null) {
+        Logging.info(TAG, "open, state $state, uri $uri")
+        if (state != State.INIT && state != State.CLOSED) {
+            return
+        }
+
+        val socket = EngineSocket(uri, opt, scope)
+        engine = socket
+        state = State.OPENING
+        skipReconnect = false
+
+        socket.on(EngineSocket.EVENT_TRANSPORT, object : Listener {
+            override fun call(vararg args: Any) {
+                emit(EVENT_TRANSPORT, *args)
+            }
+        })
+
+        val openSub = On.on(socket, EngineSocket.EVENT_OPEN, object : Listener {
+            override fun call(vararg args: Any) {
+                onOpen()
+                callback?.invoke("")
+            }
+        })
+        val errorSub = On.on(socket, EngineSocket.EVENT_ERROR, object : Listener {
+            override fun call(vararg args: Any) {
+                Logging.error(TAG, "open connect_error")
+                cleanUp()
+                state = State.CLOSED
+                emit(EVENT_ERROR, *args)
+                if (callback != null) {
+                    callback("Connection error")
+                } else {
+                    // Only do this if there is no fn to handle the error
+                    maybeReconnectOnOpen()
+                }
+            }
+        })
+
+        val onTimeout = {
+            Logging.error(TAG, "connect attempt timed out after ${opt.timeout}")
+            openSub.destroy()
+            socket.close()
+            socket.emit(EngineSocket.EVENT_ERROR, "timeout")
+        }
+        if (opt.timeout == 0L) {
+            onTimeout()
+            return
+        } else {
+            val job = scope.launch {
+                delay(opt.timeout)
+                onTimeout()
+            }
+            subs.add(object : On.Handle {
+                override fun destroy() {
+                    job.cancel()
+                }
+            })
+        }
+
+        subs.add(openSub)
+        subs.add(errorSub)
+        socket.open()
+    }
+
+    @WorkThread
+    private fun onOpen() {
+        Logging.info(TAG, "onOpen, state $state")
+        if (state != State.OPENING) {
+            return
+        }
+        cleanUp()
+        state = State.OPEN
+        emit(EVENT_OPEN)
+
+        val socket = engine ?: return
+        subs.add(On.on(socket, EngineSocket.EVENT_DATA, object : Listener {
+            override fun call(vararg args: Any) {
+                if (args.isNotEmpty()) {
+                    Logging.debug(TAG) { "on EngineSocket data ${args[0]::class}" }
+                    emit(EVENT_PACKET, args[0])
+                }
+            }
+        }))
+        subs.add(On.on(socket, EngineSocket.EVENT_ERROR, object : Listener {
+            override fun call(vararg args: Any) {
+                if (args.isNotEmpty() && args[0] is String) {
+                    onError(args[0] as String)
+                } else {
+                    onError("EngineSocket error")
+                }
+            }
+        }))
+        subs.add(On.on(socket, EngineSocket.EVENT_CLOSE, object : Listener {
+            override fun call(vararg args: Any) {
+                if (args.isNotEmpty() && args[0] is String) {
+                    onClose(args[0] as String)
+                } else {
+                    onClose("EngineSocket close")
+                }
+            }
+        }))
+    }
+
+    @WorkThread
+    private fun cleanUp() {
+        Logging.info(TAG, "cleanUp")
+        for (sub in subs) {
+            sub.destroy()
+        }
+        subs.clear()
+    }
+
+    @WorkThread
+    private fun onError(error: String) {
+        Logging.error(TAG, "onError `$error`")
+        emit(EVENT_ERROR, error)
+    }
+
+    @WorkThread
+    internal fun close() {
+        Logging.info(TAG, "close")
+        skipReconnect = true
+        reconnecting = false
+        cleanUp()
+        opt.backoff.reset()
+        state = State.CLOSED
+        engine?.close()
+        engine = null
+    }
+
+    @WorkThread
+    private fun onClose(reason: String) {
+        Logging.info(TAG, "onClose `$reason`, reconnection ${opt.reconnection}, skipReconnect $skipReconnect")
+        cleanUp()
+        opt.backoff.reset()
+        state = State.CLOSED
+        emit(EVENT_CLOSE, reason)
+
+        if (opt.reconnection && !skipReconnect) {
+            reconnect()
+        }
+    }
+
+    @WorkThread
+    private fun maybeReconnectOnOpen() {
+        // Only try to reconnect if it's the first time we're connecting
+        Logging.info(
+            TAG, "maybeReconnectOnOpen: reconnecting $reconnecting, " +
+                    "reconnection ${opt.reconnection}, attempts ${opt.backoff.attempts}"
+        )
+        if (!reconnecting && opt.reconnection && opt.backoff.attempts == 0) {
+            reconnect()
+        }
+    }
+
+    @WorkThread
+    private fun reconnect() {
+        Logging.info(TAG, "reconnect: reconnecting $reconnecting, skipReconnect $skipReconnect")
+        if (reconnecting || skipReconnect) {
+            return
+        }
+        if (opt.backoff.attempts >= opt.reconnectionAttempts) {
+            Logging.error(TAG, "reconnect failed")
+            opt.backoff.reset()
+            emit(EVENT_RECONNECT_FAILED)
+            reconnecting = false
+        } else {
+            val delay = opt.backoff.duration
+            Logging.info(TAG, "reconnect will wait $delay ms before attempt")
+            reconnecting = true
+            val job = scope.launch {
+                delay(delay)
+                if (skipReconnect) {
+                    Logging.info(TAG, "reconnect skip after delay")
+                    return@launch
+                }
+                Logging.info(TAG, "reconnect attempting")
+                emit(EVENT_RECONNECT_ATTEMPT, opt.backoff.attempts)
+
+                // check again for the case socket closed in above events
+                if (skipReconnect) {
+                    Logging.info(TAG, "reconnect skip after EVENT_RECONNECT_ATTEMPT")
+                    return@launch
+                }
+
+                open {
+                    reconnecting = false
+                    if (it.isEmpty()) {
+                        Logging.info(TAG, "reconnect success")
+                        emit(EVENT_RECONNECT, opt.backoff.reset())
+                    } else {
+                        Logging.error(TAG, "reconnect attempt error")
+                        reconnect()
+                        emit(EVENT_RECONNECT_ERROR, it)
+                    }
+                }
+            }
+            subs.add(object : On.Handle {
+                override fun destroy() {
+                    job.cancel()
+                }
+            })
+        }
+    }
+
+    /**
+     * Initializes {@link Socket} instances for each namespace.
+     *
+     * @param nsp namespace.
+     * @param auth auth info.
+     * @return a socket instance for the namespace.
+     */
+    @WorkThread
+    internal fun socket(nsp: String, auth: Map<String, String>): Socket {
+        Logging.info(TAG, "socket: nsp $nsp, auth $auth")
+        return nsps.getOrElse(nsp) {
+            val sock = Socket(this, nsp, auth, scope)
+            nsps[nsp] = sock
+            sock
+        }
+    }
+
+    @WorkThread
+    internal fun packets(packets: List<EngineIOPacket<*>>) {
+        Logging.debug(TAG) { "send packets $packets" }
+        engine?.send(packets)
+    }
+
+    @WorkThread
+    internal fun destroy() {
+        Logging.info(TAG, "destroy")
+        for ((nsp, sock) in nsps) {
+            if (sock.active()) {
+                Logging.info(TAG, "destroy with socket in $nsp still active, skip")
+                return
+            }
+        }
+        close()
+    }
+
+    companion object {
+
+        /**
+         * Called on a successful connection.
+         */
+        const val EVENT_OPEN = EngineSocket.EVENT_OPEN
+
+        /**
+         * Called on a disconnection.
+         */
+        const val EVENT_CLOSE = EngineSocket.EVENT_CLOSE
+
+        const val EVENT_PACKET = EngineSocket.EVENT_PACKET
+        const val EVENT_ERROR = EngineSocket.EVENT_ERROR
+
+        /**
+         * Called on a successful reconnection.
+         */
+        const val EVENT_RECONNECT = "reconnect"
+
+        /**
+         * Called on a reconnection attempt error.
+         */
+        const val EVENT_RECONNECT_ERROR = "reconnect_error"
+        const val EVENT_RECONNECT_FAILED = "reconnect_failed"
+        const val EVENT_RECONNECT_ATTEMPT = "reconnect_attempt"
+
+        /**
+         * Called when new transport is created. (experimental)
+         */
+        const val EVENT_TRANSPORT = EngineSocket.EVENT_TRANSPORT
+
+        private const val TAG = "Manager"
+    }
+}

--- a/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/Socket.kt
+++ b/thirdparty/kmp-socketio/src/commonMain/kotlin/com/piasy/kmp/socketio/socketio/Socket.kt
@@ -1,0 +1,530 @@
+package com.piasy.kmp.socketio.socketio
+
+import com.piasy.kmp.socketio.emitter.Emitter
+import com.piasy.kmp.socketio.engineio.*
+import com.piasy.kmp.xlog.Logging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.*
+import org.hildan.socketio.EngineIOPacket
+import org.hildan.socketio.PayloadElement
+import org.hildan.socketio.SocketIOPacket
+
+class Socket(
+    val io: Manager,
+    val nsp: String,
+    private val auth: Map<String, String>,
+    private val scope: CoroutineScope,
+) : Emitter() {
+    /**
+     * Whether this socket namespace is currently connected.
+     */
+    var connected = false
+        private set
+    private val subs = ArrayList<On.Handle>()
+    private val ack = HashMap<Int, Ack>()
+    private var ackId = 0
+
+    private val sendBuffer = ArrayList<EngineIOPacket<*>>()
+    private val recvBuffer = ArrayList<ArrayList<Any>>()
+    private var reconstructor: BinaryPacketReconstructor? = null
+
+    var id = ""
+        private set
+
+    /**
+     * Connects the socket.
+     */
+    @CallerThread
+    fun open() {
+        scope.launch {
+            Logging.info(TAG, "open: connected $connected, io reconnecting ${io.reconnecting}")
+            if (connected || io.reconnecting) {
+                return@launch
+            }
+
+            subEvents()
+            io.open()
+            if (io.state == State.OPEN) {
+                onOpen()
+            }
+        }
+    }
+
+    /**
+     * Disconnects the socket.
+     */
+    @CallerThread
+    fun close() {
+        scope.launch {
+            Logging.info(TAG, "close: connected $connected")
+            if (connected) {
+                io.packets(listOf(EngineIOPacket.Message(SocketIOPacket.Disconnect(nsp))))
+            }
+            destroy()
+            if (connected) {
+                onClose("io client disconnect")
+            }
+        }
+    }
+
+    /**
+     * Send `message` with args.
+     * @param args only accepts String/Boolean/Number/JsonElement/ByteString
+     */
+    @CallerThread
+    fun send(vararg args: Any): Socket {
+        return emit(EVENT_MESSAGE, *args) as Socket
+    }
+
+    /**
+     * emit custom event with args.
+     * @param args only accepts String/Boolean/Number/JsonElement/ByteString
+     */
+    @CallerThread
+    override fun emit(event: String, vararg args: Any): Emitter {
+        if (RESERVED_EVENTS.contains(event)) {
+            onError("emit reserved event: $event")
+            return this
+        }
+        scope.launch {
+            if (args.isNotEmpty() && args.last() is Ack) {
+                val arr = Array(args.size - 1) {
+                    args[it]
+                }
+                emitWithAck(event, arr, args.last() as Ack)
+            } else {
+                emitWithAck(event, args, null)
+            }
+        }
+        return this
+    }
+
+    @WorkThread
+    private fun emitWithAck(event: String, args: Array<out Any>, ack: Ack?) {
+        Logging.debug(TAG) { "emitWithAck: $event, ${args.joinToString()}, ack $ack" }
+        val ackId = if (ack != null) this.ackId else null
+        if (ack != null && ackId != null) {
+            Logging.info(TAG, "emit with ack id $ackId")
+            if (ack is AckWithTimeout) {
+                ack.schedule(scope) {
+                    // remove the ack from the map (to prevent an actual acknowledgement)
+                    this.ack.remove(ackId)
+                    // remove the packet from the buffer (if applicable)
+                    val iterator = sendBuffer.iterator()
+                    while (iterator.hasNext()) {
+                        val pktAckId = when (val pkt = iterator.next()) {
+                            is EngineIOPacket.Message<*> -> {
+                                when (val payload = pkt.payload) {
+                                    is SocketIOPacket.Event -> payload.ackId
+                                    is SocketIOPacket.BinaryAck -> payload.ackId
+                                    else -> null
+                                }
+                            }
+
+                            else -> null
+                        }
+                        if (pktAckId == ackId) {
+                            iterator.remove()
+                            break
+                        }
+                    }
+                }
+            }
+
+            this.ack[ackId] = ack
+            this.ackId++
+        }
+
+        val packets = if (args.hasBinary()) {
+            binaryPackets(args) { payloads, nAttachments ->
+                SocketIOPacket.BinaryEvent(nsp, ackId, buildList {
+                    add(PayloadElement.Json(JsonPrimitive(event)))
+                    addAll(payloads)
+                }, nAttachments)
+            }
+        } else {
+            listOf(EngineIOPacket.Message(SocketIOPacket.Event(nsp, ackId, buildJsonArray {
+                add(JsonPrimitive(event))
+                args.forEach { add(toJson(it)) }
+            })))
+        }
+
+        if (connected) {
+            io.packets(packets)
+        } else {
+            sendBuffer.addAll(packets)
+        }
+    }
+
+    @WorkThread
+    private fun binaryPackets(
+        args: Array<out Any>,
+        creator: (List<PayloadElement>, Int) -> SocketIOPacket
+    ): List<EngineIOPacket<*>> {
+        val payloads = ArrayList<PayloadElement>()
+        val buffers = ArrayList<ByteString>()
+        args.forEach {
+            when (it) {
+                is JsonElement -> payloads.add(PayloadElement.Json(it))
+                is ByteString -> {
+                    payloads.add(PayloadElement.AttachmentRef(buffers.size))
+                    buffers.add(it)
+                }
+
+                else -> payloads.add(PayloadElement.Json(toJson(it)))
+            }
+        }
+
+        val packets = ArrayList<EngineIOPacket<*>>()
+        packets.add(EngineIOPacket.Message(creator(payloads, buffers.size)))
+        buffers.forEach {
+            packets.add(EngineIOPacket.BinaryData(it))
+        }
+        return packets
+    }
+
+    @WorkThread
+    private fun destroy() {
+        subs.forEach { it.destroy() }
+        subs.clear()
+        io.destroy()
+    }
+
+    @WorkThread
+    private fun subEvents() {
+        Logging.info(TAG, "subEvents: subs ${subs.size}")
+        if (subs.isNotEmpty()) {
+            return
+        }
+        subs.add(On.on(io, Manager.EVENT_OPEN, object : Listener {
+            override fun call(vararg args: Any) {
+                onOpen()
+            }
+        }))
+        subs.add(On.on(io, Manager.EVENT_PACKET, object : Listener {
+            override fun call(vararg args: Any) {
+                if (args.isNotEmpty()) {
+                    when (val pkt = args[0]) {
+                        is SocketIOPacket -> onPacket(pkt)
+                        is ByteString -> {
+                            if (reconstructor == null) {
+                                onError("Receive binary buffer while not reconstructing binary packet")
+                            }
+                            reconstructor?.add(pkt)
+                        }
+                    }
+                }
+            }
+        }))
+        subs.add(On.on(io, Manager.EVENT_ERROR, object : Listener {
+            override fun call(vararg args: Any) {
+                onManagerError(if (args.isNotEmpty() && args[0] is String) args[0] as String else "Manager error")
+            }
+        }))
+        subs.add(On.on(io, Manager.EVENT_CLOSE, object : Listener {
+            override fun call(vararg args: Any) {
+                onClose(if (args.isNotEmpty() && args[0] is String) args[0] as String else "Manager close")
+            }
+        }))
+    }
+
+    @WorkThread
+    private fun onOpen() {
+        Logging.info(TAG, "onOpen")
+        val auth = if (auth.isEmpty()) {
+            null
+        } else {
+            Json.encodeToJsonElement(auth) as JsonObject
+        }
+        io.packets(listOf(EngineIOPacket.Message(SocketIOPacket.Connect(nsp, auth))))
+    }
+
+    @WorkThread
+    private fun onPacket(packet: SocketIOPacket) {
+        Logging.debug(TAG) { "onPacket: nsp $nsp, $packet" }
+        if (nsp != packet.namespace) {
+            return
+        }
+
+        when (packet) {
+            is SocketIOPacket.Connect -> {
+                val sid = packet.payload?.get(EngineSocket.SID)
+                if (sid is JsonPrimitive) {
+                    onConnect(sid.content)
+                }
+            }
+
+            is SocketIOPacket.Disconnect -> onDisconnect()
+            is SocketIOPacket.ConnectError -> {
+                destroy()
+                val data = packet.errorData ?: JsonObject(emptyMap())
+                super.emit(EVENT_CONNECT_ERROR, data)
+            }
+
+            is SocketIOPacket.Event -> {
+                Logging.debug(TAG) { "onEvent $packet" }
+                onEvent(packet.ackId, ArrayList(packet.payload))
+            }
+
+            is SocketIOPacket.Ack -> onAck(packet.ackId, ArrayList(packet.payload))
+            is SocketIOPacket.BinaryEvent,
+            is SocketIOPacket.BinaryAck -> {
+                if (reconstructor != null) {
+                    onError("Receive binary event/ack while reconstructing binary packet, $packet")
+                    // let's just reconstruct a new binary packet
+                }
+                Logging.info(TAG, "start reconstructing binary packet, $packet")
+                reconstructor =
+                    BinaryPacketReconstructor(packet as SocketIOPacket.BinaryMessage) { isAck, ackId, data ->
+                        Logging.info(TAG, "finish reconstructing binary packet, isAck $isAck, ackId $ackId")
+                        if (isAck) {
+                            onAck(ackId!!, data)
+                        } else {
+                            onEvent(ackId, data)
+                        }
+                        reconstructor = null
+                    }
+            }
+        }
+    }
+
+    @WorkThread
+    private fun onError(msg: String) {
+        Logging.error(TAG, msg)
+        super.emit(EVENT_ERROR, msg)
+    }
+
+    @WorkThread
+    private fun onConnect(id: String) {
+        Logging.info(TAG, "onConnect sid $id")
+        connected = true
+        this.id = id
+
+        recvBuffer.forEach { fireEvent(it) }
+        recvBuffer.clear()
+
+        if (sendBuffer.isNotEmpty()) {
+            io.packets(sendBuffer)
+            sendBuffer.clear()
+        }
+
+        super.emit(EVENT_CONNECT)
+    }
+
+    @WorkThread
+    private fun onDisconnect() {
+        Logging.info(TAG, "onDisconnect")
+        destroy()
+        onClose("io server disconnect")
+    }
+
+    @WorkThread
+    private fun onEvent(eventId: Int?, data: ArrayList<Any>) {
+        if (eventId != null) {
+            Logging.debug(TAG) { "attaching ack callback to event" }
+            data.add(createAck(eventId))
+        }
+        if (data.isEmpty()) {
+            return
+        }
+        if (connected) {
+            fireEvent(data)
+        } else {
+            recvBuffer.add(data)
+        }
+    }
+
+    @WorkThread
+    private fun fireEvent(data: ArrayList<Any>) {
+        val ev = when (val event = data.removeAt(0)) {
+            is String -> event
+            is JsonPrimitive -> event.content
+            else -> {
+                onError("bad event $event")
+                return
+            }
+        }
+        val args = Array(data.size) {
+            if (data[it] is JsonElement) {
+                (data[it] as JsonElement).flatPrimitive()
+            } else {
+                data[it]
+            }
+        }
+        super.emit(ev, *args)
+    }
+
+    @WorkThread
+    private fun createAck(ackId: Int) = object : Ack {
+        private var sent = false
+
+        override fun call(vararg args: Any) {
+            scope.launch {
+                if (sent) {
+                    return@launch
+                }
+                sent = true
+                Logging.info(TAG, "sending ack: id $ackId ${args.joinToString()}")
+
+                val packets = if (args.hasBinary()) {
+                    binaryPackets(args) { payloads, nAttachments ->
+                        SocketIOPacket.BinaryAck(nsp, ackId, payloads, nAttachments)
+                    }
+                } else {
+                    listOf(EngineIOPacket.Message(SocketIOPacket.Ack(nsp, ackId, buildJsonArray {
+                        args.forEach { add(toJson(it)) }
+                    })))
+                }
+                io.packets(packets)
+            }
+        }
+    }
+
+    @WorkThread
+    private fun onAck(ackId: Int, data: ArrayList<Any>) {
+        val fn = this.ack.remove(ackId)
+        if (fn != null) {
+            Logging.info(TAG, "calling ack $ackId with $data")
+            val args = Array(data.size) {
+                when (val elem = data[it]) {
+                    is JsonElement -> elem.flatPrimitive()
+                    else -> elem
+                }
+            }
+            fn.call(*args)
+        } else {
+            Logging.info(TAG, "bad ack $ackId")
+        }
+    }
+
+    @WorkThread
+    private fun onManagerError(error: String) {
+        Logging.error(TAG, "onManagerError: `$error`")
+        if (!connected) {
+            super.emit(EVENT_CONNECT_ERROR, error)
+        }
+    }
+
+    @WorkThread
+    private fun onClose(reason: String) {
+        Logging.info(TAG, "onClose: `$reason`")
+        connected = false
+        id = ""
+        super.emit(EVENT_DISCONNECT, reason)
+        clearAck()
+    }
+
+    /**f
+     * Clears the acknowledgement handlers upon disconnection,
+     * since the client will never receive an acknowledgement from
+     * the server.
+     */
+    @WorkThread
+    private fun clearAck() {
+        ack.values.forEach {
+            if (it is AckWithTimeout) {
+                it.onTimeout()
+            }
+            // note: basic Ack objects have no way to report an error,
+            // so they are simply ignored here
+        }
+        ack.clear()
+    }
+
+    @WorkThread
+    internal fun active() = subs.isNotEmpty()
+
+    private fun toJson(primitive: Any) = when (primitive) {
+        is String -> JsonPrimitive(primitive)
+        is Boolean -> JsonPrimitive(primitive)
+        is Number -> JsonPrimitive(primitive)
+        is JsonElement -> primitive
+        else -> JsonPrimitive(primitive.toString())
+    }
+
+    companion object {
+        internal const val TAG = "Socket"
+
+        /**
+         * Called on a connection.
+         */
+        const val EVENT_CONNECT = "connect"
+
+        /**
+         * Called on a disconnection.
+         */
+        const val EVENT_DISCONNECT = "disconnect"
+
+        /**
+         * Called on a connection error.
+         *
+         *
+         * Parameters:
+         *
+         *  * (Exception) error data.
+         *
+         */
+        const val EVENT_CONNECT_ERROR = "connect_error"
+
+        const val EVENT_MESSAGE = "message"
+        const val EVENT_ERROR = Manager.EVENT_ERROR
+
+        private val RESERVED_EVENTS = setOf(
+            EVENT_CONNECT,
+            EVENT_CONNECT_ERROR,
+            EVENT_DISCONNECT,
+            // used on the server-side
+            "disconnecting",
+            "newListener",
+            "removeListener",
+        )
+    }
+}
+
+private fun JsonElement.flatPrimitive(): Any {
+    return when (this) {
+        is JsonPrimitive -> {
+            return when {
+                isString -> content
+                this is JsonNull -> "null"
+                else -> {
+                    val boolVal = jsonPrimitive.booleanOrNull
+                    if (boolVal != null) {
+                        return boolVal
+                    }
+                    val intVal = jsonPrimitive.intOrNull
+                    if (intVal != null) {
+                        return intVal
+                    }
+                    val longVal = jsonPrimitive.longOrNull
+                    if (longVal != null) {
+                        return longVal
+                    }
+                    val floatVal = jsonPrimitive.floatOrNull
+                    if (floatVal != null) {
+                        return floatVal
+                    }
+                    val doubleVal = jsonPrimitive.doubleOrNull
+                    if (doubleVal != null) {
+                        return doubleVal
+                    }
+                    Logging.error("JSON", "bad json primitive $this")
+                    return 0
+                }
+            }
+        }
+
+        else -> this
+    }
+}
+
+private fun <T> Array<T>.hasBinary(): Boolean {
+    forEach {
+        if (it is ByteString) {
+            return true
+        }
+    }
+    return false
+}

--- a/thirdparty/kmp-socketio/src/commonTest/kotlin/com/piasy/kmp/socketio/CampfirePatchesTest.kt
+++ b/thirdparty/kmp-socketio/src/commonTest/kotlin/com/piasy/kmp/socketio/CampfirePatchesTest.kt
@@ -1,0 +1,80 @@
+// CAMPFIRE PATCH — this file is not part of upstream kmp-socketio. It guards the local patches
+// documented in the module README; if an upstream re-sync reverts them, these tests fail instead
+// of the app crashing in the field (Crashlytics issue 4350da0dd8d479a67b4004bddebb06da).
+package com.piasy.kmp.socketio
+
+import com.piasy.kmp.socketio.engineio.Transport
+import com.piasy.kmp.socketio.engineio.transports.HttpClientFactory
+import com.piasy.kmp.socketio.engineio.transports.WebSocket
+import com.piasy.kmp.socketio.global.supervisedScope
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.statement.HttpResponse
+import io.ktor.websocket.WebSocketSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class CampfirePatchesTest {
+
+    /**
+     * Guards the supervisedScope patch (IO.kt, WebSocket.kt, PollingXHR.kt): a coroutine failure
+     * inside the library's internal scopes must neither crash the process nor cancel the scope.
+     * With upstream's bare `CoroutineScope(dispatcher)` this test fails twice over: the thrown
+     * exception escapes to the test harness, and the second launch never runs because the scope's
+     * implicit job was cancelled by the first failure.
+     */
+    @Test
+    fun supervisedScopeSurvivesChildFailure() = runTest {
+        val scope = supervisedScope("test", StandardTestDispatcher(testScheduler))
+
+        scope.launch { throw IllegalStateException("boom") }
+        testScheduler.advanceUntilIdle()
+
+        var ranAfterFailure = false
+        scope.launch { ranAfterFailure = true }
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(scope.isActive, "scope must survive a child failure")
+        assertTrue(ranAfterFailure, "scope must keep accepting work after a child failure")
+    }
+
+    /**
+     * Guards the WebSocket.onWsText patch: a frame whose Engine.IO envelope is valid but whose
+     * Socket.IO payload is not (upstream only caught InvalidEngineIOPacketException) must surface
+     * as a transport error event, not an exception escaping the socket scope. If the narrow catch
+     * comes back in a re-sync, the InvalidSocketIOPacketException escapes into the test scope and
+     * fails this test.
+     */
+    @Test
+    fun webSocketRoutesSocketIODecodeErrorsToOnError() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val factory = object : HttpClientFactory {
+            override suspend fun createWs(
+                url: String,
+                request: HttpRequestBuilder.() -> Unit,
+                block: suspend WebSocketSession.() -> Unit,
+            ) = throw UnsupportedOperationException("not used in this test")
+
+            override suspend fun httpRequest(
+                url: String,
+                block: HttpRequestBuilder.() -> Unit,
+            ): HttpResponse = throw UnsupportedOperationException("not used in this test")
+        }
+        val ws = WebSocket(Transport.Options(), scope, factory = factory, rawMessage = false)
+        val errors = mutableListOf<String>()
+        ws.on(Transport.EVENT_ERROR) { args -> errors.add(args.firstOrNull().toString()) }
+
+        // Engine.IO Message ('4') wrapping an invalid Socket.IO packet: upstream's narrow catch
+        // let the resulting InvalidSocketIOPacketException crash the app.
+        ws.onWsText("4x[not-a-socketio-packet")
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(1, errors.size, "decode failure must surface exactly one transport error")
+        assertTrue(errors[0].contains("decode error"), "unexpected error message: ${errors[0]}")
+    }
+}

--- a/thirdparty/kmp-socketio/src/jvmMain/kotlin/com/piasy/kmp/socketio/engineio/transports/transport.jvm.kt
+++ b/thirdparty/kmp-socketio/src/jvmMain/kotlin/com/piasy/kmp/socketio/engineio/transports/transport.jvm.kt
@@ -1,0 +1,24 @@
+package com.piasy.kmp.socketio.engineio.transports
+
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+
+actual fun httpClient(trustAllCerts: Boolean, config: HttpClientConfig<*>.() -> Unit): HttpClient = HttpClient(CIO) {
+    config(this)
+    if (trustAllCerts) {
+        engine {
+            https {
+                trustManager = object: X509TrustManager {
+                    override fun checkClientTrusted(p0: Array<out X509Certificate>?, p1: String?) { }
+
+                    override fun checkServerTrusted(p0: Array<out X509Certificate>?, p1: String?) { }
+
+                    override fun getAcceptedIssuers(): Array<X509Certificate>? = null
+                }
+            }
+        }
+    }
+}

--- a/thirdparty/socketio-kotlin/build.gradle.kts
+++ b/thirdparty/socketio-kotlin/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
   id("app.campfire.android.library")
   id("app.campfire.multiplatform")
+  // Required to generate the serializer for EngineIOPacket.Open — without it the Engine.IO
+  // handshake falls back to reflective serializer lookup and fails at runtime.
+  alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {
@@ -9,6 +12,11 @@ kotlin {
       dependencies {
         api(libs.kotlinx.serialization.json)
         api(libs.kotlinx.io.bytestring)
+      }
+    }
+    commonTest {
+      dependencies {
+        implementation(libs.kotlin.test)
       }
     }
   }

--- a/thirdparty/socketio-kotlin/build.gradle.kts
+++ b/thirdparty/socketio-kotlin/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+  id("app.campfire.android.library")
+  id("app.campfire.multiplatform")
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(libs.kotlinx.serialization.json)
+        api(libs.kotlinx.io.bytestring)
+      }
+    }
+  }
+}

--- a/thirdparty/socketio-kotlin/src/commonMain/kotlin/org/hildan/socketio/EngineIO.kt
+++ b/thirdparty/socketio-kotlin/src/commonMain/kotlin/org/hildan/socketio/EngineIO.kt
@@ -1,0 +1,179 @@
+// Vendored from socketio-kotlin 2.8.0 (https://github.com/joffrey-bion/socketio-kotlin)
+// MIT License, Copyright (c) 2023 Joffrey Bion. Unmodified — see SocketIO.kt for why this
+// package is vendored.
+package org.hildan.socketio
+
+import kotlinx.io.bytestring.*
+import kotlinx.serialization.json.*
+import kotlin.io.encoding.*
+
+/**
+ * The Engine.IO decoder, following the [Engine.IO protocol](https://socket.io/docs/v4/engine-io-protocol).
+ */
+object EngineIO {
+
+    /**
+     * Decodes the given [textFrame] as a single [EngineIOPacket].
+     *
+     * If this packet is a [EngineIOPacket.Message] packet, the payload text is deserialized as a [SocketIOPacket].
+     *
+     * This is meant to be used in web socket mode, where each web socket frame contains a single Engine.IO packet.
+     * When using HTTP long-polling with batched packets, use [decodeHttpBatch] instead.
+     *
+     * @throws InvalidEngineIOPacketException if the given [textFrame] is not a valid Engine.IO packet
+     * @throws InvalidSocketIOPacketException if the given [textFrame] does not contain a valid Socket.IO packet
+     */
+    fun decodeSocketIO(textFrame: String): EngineIOPacket<SocketIOPacket> = decodeWsFrame(textFrame, SocketIO::decode)
+
+    /**
+     * Decodes the given web socket [text] frame as a single [EngineIOPacket].
+     *
+     * If this packet is a [EngineIOPacket.Message] packet, the payload text is deserialized using the provided
+     * [deserializePayload] function.
+     *
+     * This is meant to be used in web socket mode, where each web socket frame contains a single Engine.IO packet.
+     * When using HTTP long-polling with batched packets, use [decodeHttpBatch] instead.
+     *
+     * @throws InvalidEngineIOPacketException if the given [text] is not a valid Engine.IO packet
+     */
+    fun <T> decodeWsFrame(text: String, deserializePayload: (String) -> T): EngineIOPacket<T> = decodeSinglePacket(
+        encodedData = text,
+        deserializePayload = deserializePayload,
+    ).also {
+        if (it is EngineIOPacket.BinaryData) {
+            // Base64-encoded binary payloads are supported with 'b' prefix in long-polling mode.
+            // In web socket mode, binary messages must be sent as separate binary frames.
+            throw InvalidEngineIOPacketException(text, "Unexpected binary payload in web socket text frame")
+        }
+    }
+
+    /**
+     * Decodes the given binary web socket frame's [bytes] as a single [EngineIOPacket.BinaryData].
+     *
+     * As specified by the protocol, binary messages are just sent as-is, so there is no real decoding involved in this
+     * function, it just wraps the bytes in a packet type for consistency.
+     *
+     * This is meant to be used in web socket mode, where each web socket frame contains a single Engine.IO packet.
+     * When using HTTP long-polling with batched packets, use [decodeHttpBatch] instead.
+     */
+    fun decodeWsFrame(bytes: ByteString): EngineIOPacket.BinaryData = EngineIOPacket.BinaryData(bytes)
+
+    /**
+     * Decodes the given [batch] text as a batch of [EngineIOPacket]s.
+     *
+     * Individual packets in [batch] must be delimited by the "record separator" (U+001E) character, as defined in
+     * the [specification](https://socket.io/docs/v4/engine-io-protocol#http-long-polling-1).
+     *
+     * If a packet is a [EngineIOPacket.Message] packet, the payload text is deserialized using the provided
+     * [deserializePayload] function.
+     *
+     * This is meant to be used in HTTP long-polling mode, where packets are batched in a single HTTP response.
+     * When using web sockets, use [decodeWsFrame] on each frame instead.
+     *
+     * @throws InvalidEngineIOPacketException if the given [batch] contains an invalid Engine.IO packet
+     */
+    fun <T> decodeHttpBatch(batch: String, deserializePayload: (String) -> T): List<EngineIOPacket<T>> {
+        // Splitting on the "record-separator" character as defined by the protocol:
+        // https://socket.io/docs/v4/engine-io-protocol#http-long-polling-1
+        return batch.split("\u001e").map {
+            decodeSinglePacket(it, deserializePayload)
+        }
+    }
+
+    // Base64-encoded binary payloads are supported with 'b' prefix in long-polling mode.
+    // In web socket mode, binary messages should be sent as separate binary frames.
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun <T> decodeSinglePacket(encodedData: String, deserializePayload: (String) -> T): EngineIOPacket<T> {
+        if (encodedData.isBlank()) {
+            throw InvalidEngineIOPacketException(encodedData, "The Engine.IO packet is empty")
+        }
+        val payload = encodedData.drop(1)
+        return when (val packetType = encodedData[0]) {
+            '0' -> Json.decodeFromString<EngineIOPacket.Open>(payload)
+            '1' -> EngineIOPacket.Close
+            '2' -> EngineIOPacket.Ping(payload = payload.takeIf { it.isNotEmpty() })
+            '3' -> EngineIOPacket.Pong(payload = payload.takeIf { it.isNotEmpty() })
+            '4' -> EngineIOPacket.Message(payload = deserializePayload(payload))
+            '5' -> EngineIOPacket.Upgrade
+            '6' -> EngineIOPacket.Noop
+            'b' -> EngineIOPacket.BinaryData(payload = Base64.decodeToByteString(payload))
+            else -> throw InvalidEngineIOPacketException(encodedData, "Unknown Engine.IO packet type '$packetType'")
+        }
+    }
+
+    /**
+     * Encodes the given SocketIO [packet] (wrapped in an EngineIO packet) as a string.
+     *
+     * The result can be directly used as a web socket text frame, unless it's a binary message.
+     * If the packet is a binary message, the resulting text can be sent as a web socket text frame, but must be
+     * followed by as many binary frames as there are binary attachments, in the order defined by their indices.
+     *
+     * This is meant to be used in web socket mode, where each web socket frame contains a single Engine.IO packet.
+     */
+    fun encodeSocketIO(packet: EngineIOPacket<SocketIOPacket>): String = encodeWsFrame(
+        packet = packet,
+        serializePayload = { SocketIO.encode(it) }
+    )
+
+    /**
+     * Encodes the given list of EngineIO [packets] to a text, which can be used as the body of an HTTP batch request.
+     *
+     * For each [EngineIOPacket.Message] packet, the payload is serialized using the provided [serializePayload]
+     * function.
+     *
+     * This is meant to be used in HTTP long-polling mode, where packets are batched in a single HTTP request.
+     * When using web sockets, use [encodeWsFrame] on each frame instead.
+     */
+    fun <T> encodeHttpBatch(packets: List<EngineIOPacket<T>>, serializePayload: (T) -> String): String =
+        // Joining with the "record-separator" character as defined by the protocol:
+        // https://socket.io/docs/v4/engine-io-protocol#http-long-polling-1
+        packets.joinToString("\u001e") {
+            encodeSinglePacket(it, serializePayload)
+        }
+
+    /**
+     * Encodes the given [EngineIOPacket] to a string, which can be used as a text web socket frame body.
+     *
+     * If this packet is a [EngineIOPacket.Message] packet, the payload is serialized using the provided
+     * [serializePayload] function.
+     *
+     * This is meant to be used in web socket mode, where each web socket frame contains a single Engine.IO packet.
+     * Binary packets are not allowed because the raw data should just be sent directly as a binary web socket frame.
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    fun <T> encodeWsFrame(packet: EngineIOPacket<T>, serializePayload: (T) -> String): String {
+        require(packet !is EngineIOPacket.BinaryData) {
+            "In web socket mode, binary data must be transferred directly as a binary web socket frame, not " +
+                "encoded in a text frame. Use EngineIOPacket.BinaryData when calling encodeHttpBatch()."
+        }
+        return encodeSinglePacket(packet = packet, serializePayload = serializePayload)
+    }
+
+    /**
+     * Encodes the given [EngineIOPacket] to a [ByteString], which can be used as a binary web socket frame body.
+     *
+     * This is meant to be used in web socket mode, where the raw data is sent directly as a binary web socket frame.
+     * Binary data is only encoded as base64 when using the HTTP long-polling mode (see [encodeHttpBatch]).
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    fun encodeWsFrame(packet: EngineIOPacket.BinaryData): ByteString = packet.payload
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun <T> encodeSinglePacket(packet: EngineIOPacket<T>, serializePayload: (T) -> String): String =
+        when (packet) {
+            is EngineIOPacket.Open -> "0${Json.encodeToString(packet)}"
+            is EngineIOPacket.Close -> "1"
+            is EngineIOPacket.Ping -> "2${packet.payload ?: ""}"
+            is EngineIOPacket.Pong -> "3${packet.payload ?: ""}"
+            is EngineIOPacket.Message<T> -> "4${serializePayload(packet.payload)}"
+            is EngineIOPacket.BinaryData -> "b${Base64.encode(packet.payload)}"
+            is EngineIOPacket.Upgrade -> "5"
+            is EngineIOPacket.Noop -> "6"
+        }
+}
+
+/**
+ * An exception thrown when encoded data doesn't represent a valid Engine.IO packet as defined by the
+ * [Engine.IO protocol](https://socket.io/docs/v4/engine-io-protocol).
+ */
+class InvalidEngineIOPacketException(val encodedData: String, message: String) : Exception(message)

--- a/thirdparty/socketio-kotlin/src/commonMain/kotlin/org/hildan/socketio/EngineIOPacket.kt
+++ b/thirdparty/socketio-kotlin/src/commonMain/kotlin/org/hildan/socketio/EngineIOPacket.kt
@@ -1,0 +1,65 @@
+// Vendored from socketio-kotlin 2.8.0 (https://github.com/joffrey-bion/socketio-kotlin)
+// MIT License, Copyright (c) 2023 Joffrey Bion. Unmodified — see SocketIO.kt for why this
+// package is vendored.
+package org.hildan.socketio
+
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.Serializable
+
+/**
+ * An Engine.IO packet, as defined in the [Engine.IO protocol](https://socket.io/docs/v4/engine-io-protocol).
+ */
+sealed interface EngineIOPacket<out T> {
+
+    /**
+     * Used during the handshake.
+     */
+    @Serializable
+    data class Open(
+        /** The session ID. */
+        val sid: String,
+        /** The list of available transport upgrades. */
+        val upgrades: List<String>,
+        /** The ping interval, used in the heartbeat mechanism (in milliseconds). */
+        val pingInterval: Int,
+        /** The ping timeout, used in the heartbeat mechanism (in milliseconds). */
+        val pingTimeout: Int,
+        /** Optional, only useful when using long-polling as transport to know how many packets to batch together. */
+        val maxPayload: Int? = null,
+    ) : EngineIOPacket<Nothing>
+
+    /**
+     * Used to indicate that a transport can be closed.
+     */
+    data object Close : EngineIOPacket<Nothing>
+
+    /**
+     * Used during the upgrade process.
+     */
+    data object Upgrade : EngineIOPacket<Nothing>
+
+    /**
+     * Used during the upgrade process.
+     */
+    data object Noop : EngineIOPacket<Nothing>
+
+    /**
+     * Used in the heartbeat mechanism.
+     */
+    data class Ping(val payload: String?) : EngineIOPacket<Nothing>
+
+    /**
+     * Used in the heartbeat mechanism.
+     */
+    data class Pong(val payload: String?) : EngineIOPacket<Nothing>
+
+    /**
+     * Used to send a text payload to the other side.
+     */
+    data class Message<T>(val payload: T) : EngineIOPacket<T>
+
+    /**
+     * Raw binary data sent as a pure binary web socket frame, or as a base64 record in HTTP long-polling mode.
+     */
+    data class BinaryData(val payload: ByteString) : EngineIOPacket<Nothing>
+}

--- a/thirdparty/socketio-kotlin/src/commonMain/kotlin/org/hildan/socketio/SocketIO.kt
+++ b/thirdparty/socketio-kotlin/src/commonMain/kotlin/org/hildan/socketio/SocketIO.kt
@@ -1,0 +1,240 @@
+// Vendored from socketio-kotlin 2.8.0 (https://github.com/joffrey-bion/socketio-kotlin)
+// MIT License, Copyright (c) 2023 Joffrey Bion.
+//
+// Vendored to patch `packetFormatRegex` below — see the comment on that property. Consumed by the
+// vendored :thirdparty:kmp-socketio module in place of the published artifact. Every other file in
+// this package is identical to upstream; keep it that way so future re-syncs are trivial diffs.
+// Remove this module once upstream ships a release whose payload regex handles large packets.
+package org.hildan.socketio
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+
+private object PacketTypes {
+    const val Connect = 0
+    const val Disconnect = 1
+    const val Event = 2
+    const val Ack = 3
+    const val ConnectError = 4
+    const val BinaryEvent = 5
+    const val BinaryAck = 6
+}
+
+/**
+ * The Socket.IO decoder, following the [Socket.IO protocol](https://socket.io/docs/v4/socket-io-protocol).
+ */
+object SocketIO {
+
+    // CAMPFIRE PATCH: upstream matches the payload with `(.|[^.])*` because RegexOption.DOT_MATCHES_ALL
+    // and inline `(?s)` aren't available in common code. That alternation backtracks per character, which
+    // blows up on large payloads (~70KB+ `user_updated`/`item_updated` events from Audiobookshelf):
+    // StackOverflowError on the desktop JVM, and a silent match failure on Android's ICU regex engine
+    // that surfaced as InvalidSocketIOPacketException and crashed the app
+    // (Crashlytics issue 4350da0dd8d479a67b4004bddebb06da). `[\s\S]` matches any character — including
+    // the line terminators that motivated upstream's `(.|[^.])*` — without alternation, on all platforms.
+    private val packetFormatRegex = Regex(
+        """(?<packetType>\d)((?<nBinaryAttachments>\d+)-)?((?<namespace>/[^,]+),)?(?<ackId>\d+)?(?<payload>[\s\S]*)?""",
+    )
+
+    /**
+     * Decodes the given [encodedData] into a [SocketIOPacket].
+     *
+     * The [encodedData] must be the pure Socket.IO packet data, not wrapped in an Engine.IO packet.
+     *
+     * Binary packet types are not supported. Binary attachments are passed in subsequent web socket frames
+     * (1 frame per attachment), and thus cannot be handled in this single-frame decoding function.
+     *
+     * @throws InvalidSocketIOPacketException if the given [encodedData] is not a valid Socket.IO packet
+     */
+    fun decode(encodedData: String): SocketIOPacket = parseRawPacket(encodedData).toSocketIOPacket()
+
+    private fun parseRawPacket(encodedData: String): RawPacket {
+        val match = packetFormatRegex.matchEntire(encodedData)
+            ?: throw InvalidSocketIOPacketException(encodedData, "Invalid Socket.IO packet: $encodedData")
+        return RawPacket(
+            encodedData = encodedData,
+            packetType = match.groups["packetType"]?.value?.toInt()
+                ?: error("Internal error: Socket.IO format regex was matched but the packetType group is missing"),
+            nBinaryAttachments = match.groups["nBinaryAttachments"]?.value?.toInt() ?: 0,
+            namespace = match.groups["namespace"]?.value ?: "/",
+            ackId = match.groups["ackId"]?.value?.toInt(),
+            payload = match.groups["payload"]?.value?.takeIf { it.isNotBlank() }?.let { parsePayload(encodedData, it) }
+        )
+    }
+
+    private fun parsePayload(encodedData: String, payload: String) = try {
+        Json.parseToJsonElement(payload)
+    } catch (e: SerializationException) {
+        throw InvalidSocketIOPacketException(encodedData, "The payload is not valid JSON: $payload", cause = e)
+    }
+
+    fun encode(packet: SocketIOPacket): String = packet.toRawPacket().encodeToString()
+
+    private fun RawPacket.encodeToString() = buildString {
+        append(packetType)
+        if (nBinaryAttachments > 0) {
+            append(nBinaryAttachments)
+            append('-')
+        }
+        if (namespace != "/") {
+            append(namespace)
+            append(',')
+        }
+        if (ackId != null) {
+            append(ackId)
+        }
+        if (payload != null) {
+            append(Json.encodeToString(payload))
+        }
+    }
+}
+
+private data class RawPacket(
+    val encodedData: String,
+    val packetType: Int,
+    val nBinaryAttachments: Int,
+    val namespace: String,
+    val ackId: Int?,
+    val payload: JsonElement?,
+)
+
+private fun RawPacket.toSocketIOPacket(): SocketIOPacket = when (packetType) {
+    PacketTypes.Connect -> SocketIOPacket.Connect(namespace, payload = connectPayload())
+    PacketTypes.Disconnect -> SocketIOPacket.Disconnect(namespace)
+    PacketTypes.Event -> SocketIOPacket.Event(namespace, ackId, payload = nonEmptyMessagePayload())
+    PacketTypes.Ack -> SocketIOPacket.Ack(namespace, ackId = mandatoryAckId(), payload = messagePayload())
+    PacketTypes.ConnectError -> SocketIOPacket.ConnectError(namespace, errorData = payload)
+    PacketTypes.BinaryEvent -> SocketIOPacket.BinaryEvent(namespace, ackId, payload = nonEmptyMessagePayload().withPlaceholders(), nBinaryAttachments)
+    PacketTypes.BinaryAck -> SocketIOPacket.BinaryAck(namespace, ackId = mandatoryAckId(), payload = messagePayload().withPlaceholders(), nBinaryAttachments)
+    else -> invalid("Unknown Socket.IO packet type $packetType")
+}
+
+private fun SocketIOPacket.toRawPacket(): RawPacket = when (this) {
+    is SocketIOPacket.Connect -> RawPacket(
+        packetType = PacketTypes.Connect,
+        nBinaryAttachments = 0,
+        namespace = namespace,
+        ackId = null,
+        payload = payload,
+        encodedData = "",
+    )
+    is SocketIOPacket.Disconnect -> RawPacket(
+        packetType = PacketTypes.Disconnect,
+        nBinaryAttachments = 0,
+        namespace = namespace,
+        ackId = null,
+        payload = null,
+        encodedData = "",
+    )
+    is SocketIOPacket.Event -> RawPacket(
+        packetType = PacketTypes.Event,
+        nBinaryAttachments = 0,
+        namespace = namespace,
+        ackId = ackId,
+        payload = payload,
+        encodedData = "",
+    )
+    is SocketIOPacket.Ack -> RawPacket(
+        packetType = PacketTypes.Ack,
+        nBinaryAttachments = 0,
+        namespace = namespace,
+        ackId = ackId,
+        payload = payload,
+        encodedData = "",
+    )
+    is SocketIOPacket.ConnectError -> RawPacket(
+        packetType = PacketTypes.ConnectError,
+        nBinaryAttachments = 0,
+        namespace = namespace,
+        ackId = null,
+        payload = errorData,
+        encodedData = "",
+    )
+    is SocketIOPacket.BinaryEvent -> RawPacket(
+        packetType = PacketTypes.BinaryEvent,
+        nBinaryAttachments = nBinaryAttachments,
+        namespace = namespace,
+        ackId = ackId,
+        payload = payload.toJsonArray(),
+        encodedData = "",
+    )
+    is SocketIOPacket.BinaryAck -> RawPacket(
+        packetType = PacketTypes.BinaryAck,
+        nBinaryAttachments = nBinaryAttachments,
+        namespace = namespace,
+        ackId = ackId,
+        payload = payload.toJsonArray(),
+        encodedData = "",
+    )
+}
+
+private fun JsonArray.withPlaceholders(): List<PayloadElement> = map { it.toPayloadElement() }
+
+private fun JsonElement.toPayloadElement(): PayloadElement = if (isBinaryPlaceholder) {
+    val attachmentIndex = jsonObject.getValue("num").jsonPrimitive.int
+    PayloadElement.AttachmentRef(attachmentIndex)
+} else {
+    PayloadElement.Json(this)
+}
+
+private val JsonElement.isBinaryPlaceholder: Boolean
+    get() = this is JsonObject
+        && size == 2
+        && (get("_placeholder") as? JsonPrimitive)?.booleanOrNull == true
+        && (get("num") as? JsonPrimitive)?.intOrNull != null
+
+private fun List<PayloadElement>.toJsonArray(): JsonArray = JsonArray(map { it.toJsonElement() })
+
+private fun PayloadElement.toJsonElement(): JsonElement = when (this) {
+    is PayloadElement.Json -> jsonElement
+    is PayloadElement.AttachmentRef -> buildJsonObject {
+        put("_placeholder", true)
+        put("num", JsonPrimitive(attachmentIndex))
+    }
+}
+
+// This is not clearly documented in the protocol spec, but the payload for CONNECT has been added in v5 and the
+// official socket.io-parser v4 (for protocol v5) has the following validation which expects JSON object in this case:
+// https://github.com/socketio/socket.io-parser/blob/164ba2a11edc34c2f363401e9768f9a8541a8b89/lib/index.ts#L285-L305
+private fun RawPacket.connectPayload(): JsonObject? {
+    if (payload == null) {
+        return null
+    }
+    return payload as? JsonObject ?: invalid("The payload for CONNECT packets must be a JSON object")
+}
+
+// Reference:
+// https://socket.io/docs/v4/socket-io-protocol#sending-and-receiving-data
+// https://socket.io/docs/v4/socket-io-protocol#acknowledgement
+private fun RawPacket.messagePayload(): JsonArray {
+    if (payload == null) {
+        invalid("The payload for EVENT and ACK packets is mandatory")
+    }
+    if (payload !is JsonArray) {
+        invalid("The payload for EVENT and ACK packets must be a JSON array")
+    }
+    return payload
+}
+
+// Reference: https://socket.io/docs/v4/socket-io-protocol#sending-and-receiving-data
+private fun RawPacket.nonEmptyMessagePayload(): JsonArray {
+    val payload = messagePayload()
+    if (payload.isEmpty()) {
+        invalid("The array payload for EVENT packets must not be empty")
+    }
+    return payload
+}
+
+private fun RawPacket.mandatoryAckId() = ackId ?: invalid("ACK packet without an Ack ID")
+
+private fun RawPacket.invalid(message: String): Nothing = throw InvalidSocketIOPacketException(encodedData, message)
+
+/**
+ * An exception thrown when some encoded data doesn't represent a valid Socket.IO packet as defined by the
+ * [Socket.IO protocol](https://socket.io/docs/v4/socket-io-protocol).
+ */
+class InvalidSocketIOPacketException(
+    val encodedData: String,
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/thirdparty/socketio-kotlin/src/commonMain/kotlin/org/hildan/socketio/SocketIOPacket.kt
+++ b/thirdparty/socketio-kotlin/src/commonMain/kotlin/org/hildan/socketio/SocketIOPacket.kt
@@ -1,0 +1,135 @@
+// Vendored from socketio-kotlin 2.8.0 (https://github.com/joffrey-bion/socketio-kotlin)
+// MIT License, Copyright (c) 2023 Joffrey Bion. Unmodified — see SocketIO.kt for why this
+// package is vendored.
+package org.hildan.socketio
+
+import kotlinx.serialization.json.*
+
+/**
+ * A Socket.IO packet, as defined in the [Socket.IO protocol](https://socket.io/docs/v4/socket-io-protocol).
+ *
+ * Exact payload types can be checked against the
+ * [reference implementation](https://github.com/socketio/socket.io-parser/blob/87236baf87cdbe32ae01e7dc53320474520ce82f/lib/index.ts#L280).
+ */
+sealed interface SocketIOPacket {
+
+    /**
+     * The namespace this packet belongs to, useful when multiplexing.
+     * The default namespace is "/".
+     */
+    val namespace: String
+
+    /**
+     * Used during the connection to a namespace.
+     */
+    data class Connect(
+        override val namespace: String,
+        /**
+         * Since v5, CONNECT messages can have a payload as a JSON object.
+         */
+        val payload: JsonObject?,
+    ) : SocketIOPacket
+
+    /**
+     * Used during the connection to a namespace.
+     */
+    data class ConnectError(
+        override val namespace: String,
+        /**
+         * A description of the error. It was a JSON string literal before v5, and is a JSON object since v5.
+         */
+        val errorData: JsonElement?,
+    ) : SocketIOPacket
+
+    /**
+     * Used when disconnecting from a namespace.
+     */
+    data class Disconnect(
+        override val namespace: String,
+    ) : SocketIOPacket
+
+    /**
+     * A parent for message packet types.
+     */
+    sealed interface Message : SocketIOPacket {
+        /**
+         * An ID used to match an [Event] with the corresponding [Ack].
+         * When an [ackId] is present in an [Event] packet, it means an [Ack] packet is expected by the sender.
+         */
+        val ackId: Int?
+    }
+
+    /**
+     * A parent for packet types having a payload.
+     */
+    sealed interface JsonMessage : Message {
+        /**
+         * The payload of the message, which must be a non-empty array.
+         * Usually the first element of the array is the event type (string or int), and the rest is the actual data.
+         */
+        val payload: JsonArray
+    }
+
+    /**
+     * Used to [send data](https://socket.io/docs/v4/socket-io-protocol#sending-and-receiving-data) to the other side.
+     */
+    data class Event(
+        override val namespace: String,
+        override val ackId: Int?,
+        override val payload: JsonArray,
+    ): JsonMessage
+
+    /**
+     * Used to acknowledge the event with the corresponding [ackId].
+     */
+    data class Ack(
+        override val namespace: String,
+        override val ackId: Int,
+        override val payload: JsonArray,
+    ): JsonMessage
+
+    sealed interface BinaryMessage : Message {
+        /**
+         * The number of binary attachments that follow this message.
+         *
+         * The [payload] of this message must contain this number of placeholder JSON elements that should be replaced
+         * with the binary data from the following binary frames.
+         */
+        val nBinaryAttachments: Int
+
+        /**
+         * The payload of the message, which must be a non-empty array.
+         * Usually the first element of the array is the event type (string or int), and the rest is the actual data.
+         *
+         * This payload contains, in addition to potential other values, [nBinaryAttachments] elements of type
+         * [PayloadElement.AttachmentRef] that act as placeholders for the binary data in the [nBinaryAttachments]
+         * subsequent binary frames.
+         */
+        val payload: List<PayloadElement>
+    }
+
+    /**
+     * Used to send binary data to the other side.
+     */
+    data class BinaryEvent(
+        override val namespace: String,
+        override val ackId: Int?,
+        override val payload: List<PayloadElement>,
+        override val nBinaryAttachments: Int,
+    ): BinaryMessage
+
+    /**
+     * Used to acknowledge an event (when the response includes binary data).
+     */
+    data class BinaryAck(
+        override val namespace: String,
+        override val ackId: Int,
+        override val payload: List<PayloadElement>,
+        override val nBinaryAttachments: Int,
+    ): BinaryMessage
+}
+
+sealed interface PayloadElement {
+    data class Json(val jsonElement: JsonElement) : PayloadElement
+    data class AttachmentRef(val attachmentIndex: Int) : PayloadElement
+}

--- a/thirdparty/socketio-kotlin/src/commonTest/kotlin/org/hildan/socketio/EngineIOHandshakeTest.kt
+++ b/thirdparty/socketio-kotlin/src/commonTest/kotlin/org/hildan/socketio/EngineIOHandshakeTest.kt
@@ -1,0 +1,44 @@
+// CAMPFIRE PATCH — this file is not part of upstream socketio-kotlin. It guards this module's
+// build wiring: EngineIOPacket.Open is the vendored code's only @Serializable class, and its
+// serializer only exists if the kotlinx-serialization compiler plugin is applied to this module.
+// Without the plugin everything still compiles and every other test passes, but the Engine.IO
+// handshake ('0' packet, the first frame of every connection) fails at runtime with a
+// "serializer not found" error — surfacing only in the field, and looking like an R8/minification
+// problem in release builds.
+package org.hildan.socketio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class EngineIOHandshakeTest {
+
+    @Test
+    fun decodesOpenHandshakePacket() {
+        val encoded =
+            """0{"sid":"lv_VI97HAXpY6yYWAAAC","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":20000,"maxPayload":1000000}"""
+
+        val packet = EngineIO.decodeSocketIO(encoded)
+
+        val open = assertIs<EngineIOPacket.Open>(packet)
+        assertEquals("lv_VI97HAXpY6yYWAAAC", open.sid)
+        assertEquals(listOf("websocket"), open.upgrades)
+        assertEquals(25000, open.pingInterval)
+        assertEquals(20000, open.pingTimeout)
+        assertEquals(1000000, open.maxPayload)
+    }
+
+    @Test
+    fun encodesOpenHandshakePacket() {
+        val open = EngineIOPacket.Open(
+            sid = "abc123",
+            upgrades = emptyList(),
+            pingInterval = 25000,
+            pingTimeout = 20000,
+        )
+
+        val encoded = EngineIO.encodeSocketIO(open)
+
+        assertEquals(open, EngineIO.decodeSocketIO(encoded))
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #906 

Fixes Crashlytics issue [`4350da0dd8d479a67b4004bddebb06da`](https://console.firebase.google.com/v1/appid/project/campfire-a9687/crashlytics/app/1:524630200499:android:1b5178780e730a271260c6/issues/4350da0dd8d479a67b4004bddebb06da) (`InvalidSocketIOPacketException`, first seen 0.13.0-beta, still crashing in 1.0.0-rc2) by vendoring patched copies of the two socket libraries under `thirdparty/`, replacing the published artifacts.

## Root cause

Two stacked library bugs, both fatal because they escape unhandled coroutine scopes:

1. **socketio-kotlin (all published versions)** — the packet-parsing regex crashes on real Audiobookshelf payloads. `< 2.7.0` uses `.*`, which rejects the Unicode line terminators (U+2028/U+2029/U+0085) ABS emits verbatim in descriptions; `2.7.0–2.8.0` "fixed" that with `(.|[^.])*`, whose per-character alternation backtracking fails on large (~70KB+) `user_updated`/`item_updated` packets — `StackOverflowError` on the JVM, and a silent match failure on Android's ICU regex engine that the library reports as an invalid packet and throws.
2. **kmp-socketio 1.4.4** — `WebSocket.onWsText` only catches `InvalidEngineIOPacketException`, so the exception from (1) escaped the library's internal `CoroutineScope`s, which have no exception handler: the app crashed, and the scope's implicit job was cancelled, silently killing the socket.

## Fix

- **`:thirdparty:socketio-kotlin`** (2.8.0, MIT) — payload regex patched to `[\s\S]*`: matches any character (including line terminators) with zero backtracking; verified against 5MB packets.
- **`:thirdparty:kmp-socketio`** (v1.4.4, MIT) — `onWsText` catches all decode exceptions into the existing transport error path (mirroring upstream's own `PollingXHR`), and the internal scopes are supervised (`SupervisorJob` + logging `CoroutineExceptionHandler`) so future uncaught exceptions degrade to logged errors instead of crashes. Patches are marked `CAMPFIRE PATCH` and listed in the module README; everything else is byte-identical to upstream for easy re-syncs.

Bad packets now surface through the existing `EVENT_CONNECT_ERROR`/error path that `DefaultSocketManager` already handles (state → `Failed`, retryable).

## Tests

- `SocketIOLineTerminatorTest` — line-terminator payloads plus a 200KB-payload regression test (fails with `StackOverflowError` against the old regex).
- `CampfirePatchesTest` — a supervised scope survives a child failure and keeps accepting work; a malformed frame produces exactly one transport error event instead of an escaping exception. Green on JVM and iosSimulatorArm64.

Verified: `jvmTest` for all three modules, `iosSimulatorArm64Test`, iOS test-binary link, `assembleAlphaRelease`, ktlint, regenerated `MODULARIZATION.md`.

`skip-coverage`: the bulk of the diff is vendored upstream library code; the patched lines themselves are covered by the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)