### PR TITLE
Add Play release AAB job and in-app updates for Play builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,88 @@ jobs:
           asset_name: campfire-beta-release.apk
           asset_content_type: application/vnd.android.package-archive
 
+  android-play:
+    name: Build Android Play Release Bundle
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup swap
+        run: |
+          sudo swapon --show
+          sudo swapoff -a
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon -s
+
+      - name: Free up disk space
+        run: |
+          sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|php)') \
+            firefox google-chrome-stable google-cloud-cli microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual powershell ruby
+          sudo apt autoremove -yq
+          sudo apt clean
+          sudo rm -fr /opt/ghc /opt/hostedtoolcache /opt/az /opt/microsoft /opt/google /usr/lib/node_modules /usr/local/share/boost /usr/share/dotnet /usr/share/swift
+
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Decode Keystore
+        env:
+          ENCODED_KEYSTORE: ${{ secrets.CAMPFIRE_KEYSTORE }}
+        run: |
+          echo $ENCODED_KEYSTORE | base64 -di > app/signing/campfire.keystore
+
+      - name: Download Service Accounts
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          echo $GOOGLE_SERVICES_JSON > app/android/google-services.json
+
+      # The AAB is signed with the release keystore as the Play App Signing *upload* key;
+      # Play re-signs it with the app signing key for distribution. Attached to the GitHub
+      # release for upload to the Play Console.
+      - name: Bundle Standard Release AAB
+        run: ./gradlew :app:android:bundleStandardRelease
+        env:
+          ORG_GRADLE_PROJECT_CAMPFIRE_KEYSTORE_PWD: ${{ secrets.CAMPFIRE_KEYSTORE_PWD }}
+          ORG_GRADLE_PROJECT_CAMPFIRE_KEY_PWD: ${{ secrets.CAMPFIRE_KEY_PWD }}
+          ORG_GRADLE_PROJECT_mixpanel_token: ${{ secrets.MIXPANEL_TOKEN }}
+          ORG_GRADLE_PROJECT_CAMPFIRE_VERSIONNAME: ${{ github.event.release.tag_name }}
+          CI: true
+
+      - name: Upload build outputs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-play-build-outputs
+          path: app/android/build/outputs
+
+      - name: Get release information
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Upload AAB to release
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: app/android/build/outputs/bundle/standardRelease/android-standard-release.aab
+          asset_name: campfire-play-release.aab
+          asset_content_type: application/octet-stream
+
   android-foss:
     name: Build Android FOSS Release
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Google Play builds can now update the app in-place when a new version is available on the Play Store
+
 ### Changed
 
 ### Deprecated

--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -179,6 +179,12 @@ dependencies {
     dependencies.add(project.dependencies.create(projects.data.crashreporting.firebase))
   }
 
+  // Google Play in-app updates — only the Play-distributed production variant self-updates
+  // through Play; alpha/beta use Firebase App Distribution and foss updates via its store.
+  configurations.matching { it.name == "standardReleaseImplementation" }.configureEach {
+    dependencies.add(project.dependencies.create(libs.google.play.app.update.get()))
+  }
+
   implementation(libs.about.libraries.core)
 
   implementation(libs.androidx.activity.compose)

--- a/app/android/src/standardRelease/kotlin/app/campfire/android/updates/GooglePlayAppUpdateSource.kt
+++ b/app/android/src/standardRelease/kotlin/app/campfire/android/updates/GooglePlayAppUpdateSource.kt
@@ -3,36 +3,151 @@
 
 package app.campfire.android.updates
 
+import android.app.Activity
+import android.app.Application
 import app.campfire.core.di.AppScope
+import app.campfire.core.logging.LogPriority
+import app.campfire.core.logging.bark
 import app.campfire.updates.source.AppUpdate
 import app.campfire.updates.source.AppUpdateProgress
+import app.campfire.updates.source.AppUpdateProgress.Status
 import app.campfire.updates.source.AppUpdateSource
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.android.play.core.ktx.requestAppUpdateInfo
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
+/**
+ * [AppUpdateSource] backed by Google Play's in-app updates API for Play-distributed
+ * production builds, using the flexible update flow: Play shows its confirmation dialog
+ * (via [PlayUpdateFlowLauncher]), the update downloads in the background while the app
+ * stays usable, and installation hands off to the platform installer once downloaded.
+ */
 @ContributesBinding(AppScope::class, replaces = [NoOpUpdateSource::class])
 @Inject
-class GooglePlayAppUpdateSource : AppUpdateSource {
-  override val isSupported: Boolean = false
+class GooglePlayAppUpdateSource(
+  private val application: Application,
+  private val updateFlowLauncher: PlayUpdateFlowLauncher,
+) : AppUpdateSource {
 
-  override fun isSignedIn(): Boolean {
-    return true
-  }
+  private val updateManager by lazy { AppUpdateManagerFactory.create(application) }
 
-  override suspend fun signIn() {
-  }
+  override val isSupported: Boolean = true
 
-  override suspend fun isUpdateAvailable(): Boolean {
-    return false
-  }
+  // Play updates are delivered to every install; there is no tester sign-in.
+  override fun isSignedIn(): Boolean = true
+
+  override suspend fun signIn() = Unit
+
+  override suspend fun isUpdateAvailable(): Boolean = getAvailableUpdate() != null
 
   override suspend fun getAvailableUpdate(): AppUpdate? {
-    return null
+    val info = try {
+      updateManager.requestAppUpdateInfo()
+    } catch (e: Exception) {
+      bark(LogPriority.WARN, throwable = e) { "Unable to check Google Play for an app update" }
+      return null
+    }
+    if (info.updateAvailability() != UpdateAvailability.UPDATE_AVAILABLE) return null
+    if (!info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) return null
+
+    val versionCode = info.availableVersionCode()
+    return AppUpdate(
+      versionName = versionCode.toVersionName(),
+      versionCode = versionCode.toLong(),
+    )
   }
 
   override suspend fun installUpdate(): Flow<AppUpdateProgress> {
-    return emptyFlow()
+    val info = try {
+      updateManager.requestAppUpdateInfo()
+    } catch (e: Exception) {
+      bark(LogPriority.WARN, throwable = e) { "Unable to start the Play in-app update flow" }
+      return flowOf(AppUpdateProgress(-1L, -1L, Status.Failed))
+    }
+
+    return callbackFlow {
+      send(AppUpdateProgress(-1L, -1L, Status.Pending))
+
+      val listener = InstallStateUpdatedListener { state ->
+        val status = when (state.installStatus()) {
+          InstallStatus.PENDING -> Status.Pending
+          InstallStatus.DOWNLOADING -> Status.Downloading
+          InstallStatus.DOWNLOADED,
+          InstallStatus.INSTALLING,
+          InstallStatus.INSTALLED,
+          -> Status.Downloaded
+          InstallStatus.FAILED -> Status.Failed
+          InstallStatus.CANCELED -> Status.Canceled
+          else -> return@InstallStateUpdatedListener
+        }
+        trySendBlocking(
+          AppUpdateProgress(
+            bytes = state.bytesDownloaded(),
+            totalBytes = state.totalBytesToDownload(),
+            status = status,
+          ),
+        )
+        when (state.installStatus()) {
+          // Hand the downloaded update to the platform installer; this restarts the app.
+          InstallStatus.DOWNLOADED -> updateManager.completeUpdate()
+          InstallStatus.INSTALLED,
+          InstallStatus.FAILED,
+          InstallStatus.CANCELED,
+          -> close()
+          else -> Unit
+        }
+      }
+      updateManager.registerListener(listener)
+
+      // The download listener never fires when the user declines Play's confirmation
+      // dialog, so surface that decision from the activity result instead.
+      launch {
+        val result = updateFlowLauncher.results.first()
+        if (result.resultCode != Activity.RESULT_OK) {
+          val status = if (result.resultCode == Activity.RESULT_CANCELED) Status.Canceled else Status.Failed
+          trySendBlocking(AppUpdateProgress(-1L, -1L, status))
+          close()
+        }
+      }
+
+      val launcher = updateFlowLauncher.launcher
+      val started = launcher != null && updateManager.startUpdateFlowForResult(
+        info,
+        launcher,
+        AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
+      )
+      if (!started) {
+        trySendBlocking(AppUpdateProgress(-1L, -1L, Status.Failed))
+        close()
+      }
+
+      awaitClose { updateManager.unregisterListener(listener) }
+    }
   }
+}
+
+/**
+ * Play only reports the available versionCode, so recover the display name from the
+ * deterministic MMmmppRR tag mapping in build-logic's Versioning.kt
+ * (1000003 -> "1.0.0-rc3", 1000099 -> "1.0.0").
+ */
+private fun Int.toVersionName(): String {
+  val major = this / 1_000_000
+  val minor = this / 10_000 % 100
+  val patch = this / 100 % 100
+  val rc = this % 100
+  return if (rc == 99) "$major.$minor.$patch" else "$major.$minor.$patch-rc$rc"
 }

--- a/app/android/src/standardRelease/kotlin/app/campfire/android/updates/PlayUpdateFlowLauncher.kt
+++ b/app/android/src/standardRelease/kotlin/app/campfire/android/updates/PlayUpdateFlowLauncher.kt
@@ -1,0 +1,50 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.android.updates
+
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import app.campfire.core.ComponentActivityPlugin
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Holds the [ActivityResultLauncher] that Google Play's in-app update flow uses to show its
+ * update confirmation dialog. Registered against the host activity via the
+ * [ComponentActivityPlugin] multibinding so [GooglePlayAppUpdateSource] can start the flow
+ * from outside the activity and observe the user's decision through [results].
+ */
+@SingleIn(AppScope::class)
+@Inject
+@ContributesMultibinding(AppScope::class, boundType = ComponentActivityPlugin::class)
+class PlayUpdateFlowLauncher : ComponentActivityPlugin {
+
+  private val _results = MutableSharedFlow<ActivityResult>(extraBufferCapacity = 1)
+
+  /** Emits the result of each Play update confirmation dialog (declines surface as non-OK). */
+  val results: SharedFlow<ActivityResult> = _results
+
+  var launcher: ActivityResultLauncher<IntentSenderRequest>? = null
+    private set
+
+  override fun register(activity: ComponentActivity) {
+    launcher = activity.registerForActivityResult(
+      ActivityResultContracts.StartIntentSenderForResult(),
+    ) { result ->
+      _results.tryEmit(result)
+    }
+  }
+
+  override fun unregister() {
+    launcher?.unregister()
+    launcher = null
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -161,6 +161,7 @@ google-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlyti
 google-firebase-perf = { module = "com.google.firebase:firebase-perf" }
 google-firebase-appdistribution-api = { module = "com.google.firebase:firebase-appdistribution-api-ktx", version.ref = "appdistribution" }
 google-firebase-appdistribution = { module = "com.google.firebase:firebase-appdistribution", version.ref = "appdistribution" }
+google-play-app-update = { module = "com.google.android.play:app-update-ktx", version = "2.1.0" }
 
 # Settings
 multiplatformsettings-core = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformsettings" }


### PR DESCRIPTION
Phase 3 of #911 — Google Play release preparation.

## Release pipeline

- New `android-play` job in `release.yml`: builds `bundleStandardRelease`, signed with the release keystore acting as the **Play App Signing upload key** (Play re-signs with the app signing key for distribution), and attaches `campfire-play-release.aab` to the GitHub release for upload to the Play Console.

## In-app updates for Play builds

`GooglePlayAppUpdateSource` was a stub with `isSupported = false`, so Play builds never rendered the update widget. It now implements the [Play in-app updates](https://developer.android.com/guide/playcore/in-app-updates) **flexible flow**:

- Availability via `requestAppUpdateInfo()` (`UPDATE_AVAILABLE` + `FLEXIBLE` allowed)
- New `PlayUpdateFlowLauncher` registered through the existing `ComponentActivityPlugin` multibinding (same pattern as `LocalNetworkPermissionLauncher`) provides the `ActivityResultLauncher<IntentSenderRequest>` for Play's confirmation dialog — and its activity result surfaces user declines as `Canceled`
- Download progress maps from `InstallStateUpdatedListener` into the existing `AppUpdateProgress` widget UI; `completeUpdate()` hands the downloaded update to the platform installer
- Available version name is recovered from the deterministic `MMmmppRR` versionCode mapping (Play only reports a versionCode), so the widget shows `1.0.1` rather than `1000199`
- `app-update-ktx:2.1.0` is scoped to `standardReleaseImplementation` only — the foss flavor (and alpha/beta, which use Firebase App Distribution) carry zero Play Core bits

## Verification

- `:app:android:compileStandardReleaseKotlin` green (including the kimchi DI merge with the new multibinding)
- `:app:android:compileFossReleaseKotlin` green — foss unaffected
- ktlint clean

Remaining Play work outside this repo: Play Console Data Safety form and a public privacy policy URL (`docs/privacy_policy.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)