### PR TITLE
Fix app freeze when connecting to Android Auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- App freezing completely when connecting to Android Auto
+
 ### Other Notes & Contributions
 
 - The on-device AI theme builder is now an optional component, laying the groundwork for fully FOSS builds for F-Droid

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
@@ -183,12 +183,20 @@ internal class MediaSessionCallback(
     return super.onMediaButtonEvent(session, controllerInfo, intent)
   }
 
-  override suspend fun onGetLibraryRootInternal(
+  override fun onGetLibraryRoot(
     session: MediaLibrarySession,
     browser: MediaSession.ControllerInfo,
     params: LibraryParams?,
-  ): LibraryResult<MediaItem> {
-    return LibraryResult.ofItem(userComponent.mediaTree.root, params)
+  ): ListenableFuture<LibraryResult<MediaItem>> {
+    // Must return an already-completed future: Android Auto's legacy browser path blocks
+    // the main thread on this result (see SuspendingMediaLibrarySessionCallback). The root
+    // is a static item, so it can be built synchronously.
+    return try {
+      Futures.immediateFuture(LibraryResult.ofItem(userComponent.mediaTree.root, params))
+    } catch (e: Exception) {
+      bark(LogPriority.ERROR, throwable = e) { "onGetLibraryRoot: ${browser.uid}" }
+      Futures.immediateFuture(LibraryResult.ofError(SessionError.ERROR_BAD_VALUE))
+    }
   }
 
   override suspend fun onGetChildrenInternal(

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/SuspendingMediaLibrarySessionCallback.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/browse/SuspendingMediaLibrarySessionCallback.kt
@@ -28,27 +28,13 @@ abstract class SuspendingMediaLibrarySessionCallback(
   private val serviceScope: CoroutineScope,
 ) : MediaLibrarySession.Callback {
 
-  @SuppressLint("UnsafeOptInUsageError")
-  override fun onGetLibraryRoot(
-    session: MediaLibrarySession,
-    browser: MediaSession.ControllerInfo,
-    params: MediaLibraryService.LibraryParams?,
-  ): ListenableFuture<LibraryResult<MediaItem>> {
-    return serviceScope.future {
-      try {
-        onGetLibraryRootInternal(session, browser, params)
-      } catch (e: Exception) {
-        bark(LogPriority.ERROR, throwable = e) { "onGetLibraryRoot: ${browser.uid}" }
-        LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
-      }
-    }
-  }
-
-  protected abstract suspend fun onGetLibraryRootInternal(
-    session: MediaLibrarySession,
-    browser: MediaSession.ControllerInfo,
-    params: MediaLibraryService.LibraryParams?,
-  ): LibraryResult<MediaItem>
+  // onGetLibraryRoot is deliberately NOT adapted to a coroutine here. Media3's legacy
+  // browser stub (the path Android Auto connects through) blocks the session's application
+  // thread on the returned future and opens its ConditionVariable from a callback posted
+  // back to that same thread — so any future that isn't already complete when returned
+  // deadlocks the main thread for as long as the browser stays connected (see
+  // MediaLibraryServiceLegacyStub.onGetRoot in media3 1.11.0). Implementations must
+  // override onGetLibraryRoot directly and return an already-completed future.
 
   @SuppressLint("UnsafeOptInUsageError")
   override fun onGetItem(


### PR DESCRIPTION
## Summary

Fixes #928 — the entire app froze (on both the phone and the car screen) for as long as an Android Auto session was connected, in the alpha builds only.

## Root cause

The Media3 1.11.0 upgrade (#925) introduced a main-thread deadlock in the legacy browser path Android Auto connects through:

1. The framework invokes `MediaLibraryServiceLegacyStub.onGetRoot` on the **main thread**.
2. The 1.11.0 stub calls our `onGetLibraryRoot` — which returned a coroutine-backed future completing on `Dispatchers.IO` — then blocks the main thread on a `ConditionVariable` with no timeout (`MediaLibraryServiceLegacyStub.java:98`).
3. The future's completion callback is registered with an executor that **posts back to the main thread**, which is blocked. The post never runs, the condition variable never opens → permanent deadlock.

Media3 1.10.1 (stable builds) used `future.get()` instead, which is woken directly by the completing thread — that's why only the alpha freezes. Crashlytics confirms: the matching ANR (`Object.wait` via `ConditionVariable.block` at `onGetRoot:98`) first appeared the day #925 merged, with 31 events from the reporter's Galaxy S24 Ultra.

## Fix

Return an **already-completed future** from `onGetLibraryRoot`. When the future is already done, the stub's callback executes inline on the main thread *before* the blocking wait, so no deadlock — on any Media3 version. The library root is a static `MediaItem`, so nothing needed to suspend there anyway.

- `MediaSessionCallback` overrides `onGetLibraryRoot` directly with `Futures.immediateFuture`, keeping the same error-fallback behavior.
- `SuspendingMediaLibrarySessionCallback` no longer offers a suspend adapter for `onGetLibraryRoot`, with a comment explaining why that method must never return an incomplete future.

The other legacy-stub paths (`onLoadChildren`, `onSearch`, …) don't block the main thread, and `onConnect` is synchronous in Media3, so this was the only deadlock site. This looks like an upstream Media3 1.11.0 regression worth filing at androidx/media.

## Testing

- `:infra:audioplayer:impl:compileAndroidMain` builds, ktlint clean.
- Needs verification against a real head unit or the Android Auto Desktop Head Unit before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)