### PR TITLE
Fix misleading auth error when account has no library access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Books belonging to multiple series now show all of their series on the book detail screen
 - App freezing completely when connecting to Android Auto
+- Logging in with an account that has no library access now explains the problem instead of incorrectly reporting bad credentials
 
 ### Other Notes & Contributions
 

--- a/data/network/api/src/commonMain/kotlin/app/campfire/network/envelopes/LoginEnvelope.kt
+++ b/data/network/api/src/commonMain/kotlin/app/campfire/network/envelopes/LoginEnvelope.kt
@@ -17,7 +17,8 @@ data class LoginRequest(
 @Serializable
 data class LoginResponse(
   val user: User,
-  val userDefaultLibraryId: String,
+  // Null when the user has no accessible libraries on the server
+  val userDefaultLibraryId: String? = null,
   val serverSettings: ServerSettings,
   @SerialName("Source") val source: String,
 )

--- a/features/auth/api/src/commonMain/kotlin/app/campfire/auth/api/AuthException.kt
+++ b/features/auth/api/src/commonMain/kotlin/app/campfire/auth/api/AuthException.kt
@@ -1,0 +1,31 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.auth.api
+
+/**
+ * Typed authentication failures returned by [AuthRepository.authenticate] so that
+ * callers can present an accurate error message instead of guessing from raw
+ * network/serialization exceptions.
+ */
+sealed class AuthException(
+  message: String,
+  cause: Throwable? = null,
+) : Exception(message, cause) {
+
+  /** The server rejected the provided credentials. */
+  class InvalidCredentials(cause: Throwable? = null) :
+    AuthException("The server rejected the provided credentials", cause)
+
+  /** Login succeeded, but the account has no accessible libraries on the server. */
+  class NoAccessibleLibraries :
+    AuthException("The account has no accessible libraries on the server")
+
+  /** The connection to the server failed. */
+  class Network(cause: Throwable) :
+    AuthException("Network failure during authentication", cause)
+
+  /** The server responded in a way the app couldn't understand. */
+  class UnexpectedResponse(message: String, cause: Throwable? = null) :
+    AuthException(message, cause)
+}

--- a/features/auth/impl/build.gradle.kts
+++ b/features/auth/impl/build.gradle.kts
@@ -22,7 +22,17 @@ kotlin {
         implementation(projects.data.account.api)
         implementation(projects.data.db.mapping)
 
+        implementation(libs.kotlinx.io.core)
+
         api(projects.features.auth.api)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(libs.bundles.test.common)
+        implementation(libs.bundles.test.impl)
+        implementation(libs.kotlinx.serialization.json)
       }
     }
   }

--- a/features/auth/impl/src/commonMain/kotlin/app/campfire/auth/DefaultAuthRepository.kt
+++ b/features/auth/impl/src/commonMain/kotlin/app/campfire/auth/DefaultAuthRepository.kt
@@ -3,8 +3,8 @@
 
 package app.campfire.auth
 
-import app.campfire.CampfireDatabase
 import app.campfire.account.api.AccountManager
+import app.campfire.auth.api.AuthException
 import app.campfire.auth.api.AuthRepository
 import app.campfire.auth.api.model.ServerStatus
 import app.campfire.auth.di.ExistingUser
@@ -15,16 +15,17 @@ import app.campfire.core.di.AppScope
 import app.campfire.core.model.NetworkSettings
 import app.campfire.core.model.UserId
 import app.campfire.data.mapping.asDomainModel
+import app.campfire.network.ApiException
 import app.campfire.network.AuthAudioBookShelfApi
 import app.campfire.network.envelopes.LoginResponse
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.io.IOException
 import me.tatarka.inject.annotations.Inject
 
 @ContributesBinding(AppScope::class)
 @Inject
 class DefaultAuthRepository(
   private val api: AuthAudioBookShelfApi,
-  private val db: CampfireDatabase,
   private val accountManager: AccountManager,
   @NewUser private val newUserStorageStrategy: UserStorageStrategy,
   @ExistingUser private val existingUserStorageStrategy: UserStorageStrategy,
@@ -47,25 +48,13 @@ class DefaultAuthRepository(
     networkSettings: NetworkSettings?,
   ): Result<Unit> {
     val result = api.login(serverUrl, username, password, networkSettings?.extraHeaders)
-
-    if (result.isSuccess) {
-      val response = result.getOrThrow()
-      if (!validateResponse(response)) {
-        return Result.failure(IllegalStateException("Unable to authenticate user. No valid tokens."))
-      }
-
-      handleLoginResponse(
-        serverUrl = serverUrl,
-        serverName = serverName,
-        response = response,
-        userId = userId,
-        networkSettings = networkSettings,
-      )
-
-      return Result.success(Unit)
-    } else {
-      return result.map { Unit }
-    }
+    return processLoginResult(
+      result = result,
+      serverUrl = serverUrl,
+      serverName = serverName,
+      userId = userId,
+      networkSettings = networkSettings,
+    )
   }
 
   override suspend fun authenticate(
@@ -78,25 +67,13 @@ class DefaultAuthRepository(
     networkSettings: NetworkSettings?,
   ): Result<Unit> {
     val result = api.oauth(serverUrl, state, code, codeVerifier, networkSettings?.extraHeaders)
-
-    if (result.isSuccess) {
-      val response = result.getOrThrow()
-      if (!validateResponse(response)) {
-        return Result.failure(IllegalStateException("Unable to authenticate user. No valid tokens."))
-      }
-
-      handleLoginResponse(
-        serverUrl = serverUrl,
-        serverName = serverName,
-        response = response,
-        userId = userId,
-        networkSettings = networkSettings,
-      )
-
-      return Result.success(Unit)
-    } else {
-      return result.map { Unit }
-    }
+    return processLoginResult(
+      result = result,
+      serverUrl = serverUrl,
+      serverName = serverName,
+      userId = userId,
+      networkSettings = networkSettings,
+    )
   }
 
   override suspend fun getNetworkSettings(userId: UserId): NetworkSettings? {
@@ -105,10 +82,39 @@ class DefaultAuthRepository(
     }
   }
 
+  private suspend fun processLoginResult(
+    result: Result<LoginResponse>,
+    serverUrl: String,
+    serverName: String,
+    userId: UserId?,
+    networkSettings: NetworkSettings?,
+  ): Result<Unit> {
+    val response = result.getOrElse { return Result.failure(it.asAuthException()) }
+
+    if (response.user.accessToken == null) {
+      return Result.failure(AuthException.UnexpectedResponse("No valid tokens found in the login response"))
+    }
+
+    val defaultLibraryId = response.userDefaultLibraryId
+      ?: return Result.failure(AuthException.NoAccessibleLibraries())
+
+    handleLoginResponse(
+      serverUrl = serverUrl,
+      serverName = serverName,
+      response = response,
+      defaultLibraryId = defaultLibraryId,
+      userId = userId,
+      networkSettings = networkSettings,
+    )
+
+    return Result.success(Unit)
+  }
+
   private suspend fun handleLoginResponse(
     serverUrl: String,
     serverName: String,
     response: LoginResponse,
+    defaultLibraryId: String,
     userId: UserId?,
     networkSettings: NetworkSettings?,
   ) {
@@ -124,7 +130,7 @@ class DefaultAuthRepository(
       serverUrl = serverUrl,
       serverSettings = response.serverSettings,
       user = response.user,
-      userDefaultLibraryId = response.userDefaultLibraryId,
+      userDefaultLibraryId = defaultLibraryId,
     )
 
     // Add the new account/user and set it as the current session
@@ -133,11 +139,18 @@ class DefaultAuthRepository(
       accessToken = requireNotNull(response.user.accessToken),
       refreshToken = response.user.refreshToken,
       extraHeaders = networkSettings?.extraHeaders,
-      user = response.user.asDomainModel(serverUrl, response.userDefaultLibraryId),
+      user = response.user.asDomainModel(serverUrl, defaultLibraryId),
     )
   }
 
-  private fun validateResponse(response: LoginResponse): Boolean {
-    return response.user.accessToken != null
+  private fun Throwable.asAuthException(): AuthException = when {
+    this is AuthException -> this
+    this is IOException -> AuthException.Network(this)
+    this is ApiException && statusCode == HTTP_UNAUTHORIZED -> AuthException.InvalidCredentials(this)
+    else -> AuthException.UnexpectedResponse("The server returned an unexpected response", this)
+  }
+
+  companion object {
+    private const val HTTP_UNAUTHORIZED = 401
   }
 }

--- a/features/auth/impl/src/commonTest/kotlin/app/campfire/auth/DefaultAuthRepositoryTest.kt
+++ b/features/auth/impl/src/commonTest/kotlin/app/campfire/auth/DefaultAuthRepositoryTest.kt
@@ -1,0 +1,321 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.auth
+
+import app.campfire.account.api.AbsToken
+import app.campfire.account.api.AccountManager
+import app.campfire.auth.api.AuthException
+import app.campfire.auth.local.UserStorageStrategy
+import app.campfire.core.model.Server
+import app.campfire.core.model.User as DomainUser
+import app.campfire.core.model.UserId
+import app.campfire.network.ApiException
+import app.campfire.network.AuthAudioBookShelfApi
+import app.campfire.network.envelopes.AuthorizationResponse
+import app.campfire.network.envelopes.LoginResponse
+import app.campfire.network.models.ServerSettings
+import app.campfire.network.models.ServerStatus
+import app.campfire.network.models.User as NetworkUser
+import app.campfire.network.models.UserPermissions
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+import kotlinx.serialization.json.Json
+
+class DefaultAuthRepositoryTest {
+
+  private val api = FakeAuthApi()
+  private val accountManager = FakeAccountManager()
+  private val newUserStorage = FakeUserStorageStrategy()
+  private val existingUserStorage = FakeUserStorageStrategy()
+
+  private val repository = DefaultAuthRepository(
+    api = api,
+    accountManager = accountManager,
+    newUserStorageStrategy = newUserStorage,
+    existingUserStorageStrategy = existingUserStorage,
+  )
+
+  @Test
+  fun `login with no accessible libraries fails with NoAccessibleLibraries`() = runTest {
+    api.loginResult = Result.success(loginResponse(userDefaultLibraryId = null))
+
+    val result = repository.authenticate(SERVER_URL, SERVER_NAME, "user", "pass")
+
+    assertThat(result.exceptionOrNull()).isNotNull().isInstanceOf<AuthException.NoAccessibleLibraries>()
+    assertThat(newUserStorage.stored).isFalse()
+    assertThat(accountManager.addedAccount).isFalse()
+  }
+
+  @Test
+  fun `oauth login with no accessible libraries fails with NoAccessibleLibraries`() = runTest {
+    api.oauthResult = Result.success(loginResponse(userDefaultLibraryId = null))
+
+    val result = repository.authenticate(SERVER_URL, SERVER_NAME, "verifier", "code", "state")
+
+    assertThat(result.exceptionOrNull()).isNotNull().isInstanceOf<AuthException.NoAccessibleLibraries>()
+    assertThat(newUserStorage.stored).isFalse()
+    assertThat(accountManager.addedAccount).isFalse()
+  }
+
+  @Test
+  fun `login with a default library succeeds and stores the user`() = runTest {
+    api.loginResult = Result.success(loginResponse(userDefaultLibraryId = "lib_1"))
+
+    val result = repository.authenticate(SERVER_URL, SERVER_NAME, "user", "pass")
+
+    assertThat(result.isSuccess).isTrue()
+    assertThat(newUserStorage.stored).isTrue()
+    assertThat(newUserStorage.storedDefaultLibraryId).isEqualTo("lib_1")
+    assertThat(accountManager.addedAccount).isTrue()
+  }
+
+  @Test
+  fun `login rejected with 401 fails with InvalidCredentials`() = runTest {
+    api.loginResult = Result.failure(ApiException(401, "Invalid user or password"))
+
+    val result = repository.authenticate(SERVER_URL, SERVER_NAME, "user", "wrong-pass")
+
+    assertThat(result.exceptionOrNull()).isNotNull().isInstanceOf<AuthException.InvalidCredentials>()
+  }
+
+  @Test
+  fun `login network failure fails with Network`() = runTest {
+    api.loginResult = Result.failure(IOException("connection refused"))
+
+    val result = repository.authenticate(SERVER_URL, SERVER_NAME, "user", "pass")
+
+    assertThat(result.exceptionOrNull()).isNotNull().isInstanceOf<AuthException.Network>()
+  }
+
+  @Test
+  fun `login serialization failure fails with UnexpectedResponse`() = runTest {
+    api.loginResult = Result.failure(IllegalStateException("Unexpected JSON token"))
+
+    val result = repository.authenticate(SERVER_URL, SERVER_NAME, "user", "pass")
+
+    assertThat(result.exceptionOrNull()).isNotNull().isInstanceOf<AuthException.UnexpectedResponse>()
+  }
+
+  @Test
+  fun `login response without tokens fails with UnexpectedResponse`() = runTest {
+    api.loginResult = Result.success(loginResponse(userDefaultLibraryId = "lib_1", accessToken = null))
+
+    val result = repository.authenticate(SERVER_URL, SERVER_NAME, "user", "pass")
+
+    assertThat(result.exceptionOrNull()).isNotNull().isInstanceOf<AuthException.UnexpectedResponse>()
+    assertThat(newUserStorage.stored).isFalse()
+  }
+
+  @Test
+  fun `login response with null userDefaultLibraryId deserializes`() {
+    val json = Json { ignoreUnknownKeys = true }
+    val response = json.decodeFromString<LoginResponse>(NO_LIBRARY_LOGIN_JSON)
+
+    assertThat(response.userDefaultLibraryId).isNull()
+  }
+
+  private fun loginResponse(
+    userDefaultLibraryId: String?,
+    accessToken: String? = "access-token",
+  ): LoginResponse = LoginResponse(
+    user = NetworkUser(
+      id = "usr_1",
+      username = "testuser",
+      type = "user",
+      accessToken = accessToken,
+      refreshToken = "refresh-token",
+      mediaProgress = emptyList(),
+      seriesHideFromContinueListening = emptyList(),
+      bookmarks = emptyList(),
+      isActive = true,
+      isLocked = false,
+      lastSeen = null,
+      createdAt = 0L,
+      permissions = UserPermissions(
+        download = true,
+        update = false,
+        delete = false,
+        upload = false,
+        accessAllLibraries = true,
+        accessAllTags = true,
+        accessExplicitContent = true,
+      ),
+      librariesAccessible = emptyList(),
+    ),
+    userDefaultLibraryId = userDefaultLibraryId,
+    serverSettings = serverSettings(),
+    source = "docker",
+  )
+
+  private fun serverSettings(): ServerSettings = ServerSettings(
+    id = "server-settings",
+    scannerFindCovers = false,
+    scannerCoverProvider = "google",
+    scannerParseSubtitle = false,
+    scannerPreferMatchedMetadata = false,
+    scannerDisableWatcher = false,
+    storeCoverWithItem = false,
+    storeMetadataWithItem = false,
+    metadataFileFormat = "json",
+    rateLimitLoginRequests = 10,
+    rateLimitLoginWindow = 600000L,
+    backupSchedule = "30 1 * * *",
+    backupsToKeep = 2,
+    maxBackupSize = 1,
+    loggerDailyLogsToKeep = 7,
+    loggerScannerLogsToKeep = 2,
+    homeBookshelfView = 1,
+    bookshelfView = 1,
+    sortingIgnorePrefix = false,
+    sortingPrefixes = listOf("the"),
+    chromecastEnabled = false,
+    dateFormat = "MM/dd/yyyy",
+    timeFormat = "HH:mm",
+    language = "en-us",
+    logLevel = 2,
+    version = "2.36.0",
+  )
+
+  private class FakeAuthApi : AuthAudioBookShelfApi {
+    var loginResult: Result<LoginResponse> = Result.failure(IllegalStateException("not stubbed"))
+    var oauthResult: Result<LoginResponse> = Result.failure(IllegalStateException("not stubbed"))
+
+    override suspend fun status(
+      serverUrl: String,
+      extraHeaders: Map<String, String>?,
+    ): Result<ServerStatus> = Result.failure(IllegalStateException("not stubbed"))
+
+    override suspend fun login(
+      serverUrl: String,
+      username: String,
+      password: String,
+      extraHeaders: Map<String, String>?,
+    ): Result<LoginResponse> = loginResult
+
+    override suspend fun authorization(
+      serverUrl: String,
+      codeChallenge: String,
+      codeVerifier: String,
+      state: String,
+      extraHeaders: Map<String, String>?,
+    ): Result<AuthorizationResponse> = Result.failure(IllegalStateException("not stubbed"))
+
+    override suspend fun oauth(
+      serverUrl: String,
+      state: String,
+      code: String,
+      codeVerifier: String,
+      extraHeaders: Map<String, String>?,
+    ): Result<LoginResponse> = oauthResult
+  }
+
+  private class FakeAccountManager : AccountManager {
+    var addedAccount: Boolean = false
+
+    override suspend fun addAccount(
+      serverUrl: String,
+      accessToken: String,
+      refreshToken: String?,
+      extraHeaders: Map<String, String>?,
+      user: DomainUser,
+    ) {
+      addedAccount = true
+    }
+
+    override suspend fun invalidateAccount(user: DomainUser) = Unit
+    override suspend fun switchAccount(user: DomainUser) = Unit
+    override suspend fun logout(server: Server) = Unit
+    override suspend fun getToken(userId: UserId): AbsToken? = null
+    override suspend fun updateToken(userId: UserId, newToken: AbsToken) = Unit
+    override suspend fun getExtraHeaders(userId: UserId): Map<String, String>? = null
+  }
+
+  private class FakeUserStorageStrategy : UserStorageStrategy {
+    var stored: Boolean = false
+    var storedDefaultLibraryId: String? = null
+
+    override suspend fun store(
+      serverName: String,
+      serverUrl: String,
+      serverSettings: ServerSettings,
+      user: NetworkUser,
+      userDefaultLibraryId: String,
+    ) {
+      stored = true
+      storedDefaultLibraryId = userDefaultLibraryId
+    }
+  }
+
+  companion object {
+    private const val SERVER_URL = "https://abs.example.com"
+    private const val SERVER_NAME = "Test Campsite"
+
+    // Trimmed-down /login response from an ABS server where the user has no library access
+    private val NO_LIBRARY_LOGIN_JSON = """
+      {
+        "user": {
+          "id": "usr_1",
+          "username": "testuser",
+          "type": "user",
+          "accessToken": "access-token",
+          "mediaProgress": [],
+          "seriesHideFromContinueListening": [],
+          "bookmarks": [],
+          "isActive": true,
+          "isLocked": false,
+          "lastSeen": null,
+          "createdAt": 1633522963509,
+          "permissions": {
+            "download": true,
+            "update": false,
+            "delete": false,
+            "upload": false,
+            "accessAllLibraries": true,
+            "accessAllTags": true,
+            "accessExplicitContent": true
+          },
+          "librariesAccessible": []
+        },
+        "userDefaultLibraryId": null,
+        "serverSettings": {
+          "id": "server-settings",
+          "scannerFindCovers": false,
+          "scannerCoverProvider": "google",
+          "scannerParseSubtitle": false,
+          "scannerPreferMatchedMetadata": false,
+          "scannerDisableWatcher": false,
+          "storeCoverWithItem": false,
+          "storeMetadataWithItem": false,
+          "metadataFileFormat": "json",
+          "rateLimitLoginRequests": 10,
+          "rateLimitLoginWindow": 600000,
+          "backupSchedule": "30 1 * * *",
+          "backupsToKeep": 2,
+          "maxBackupSize": 1,
+          "loggerDailyLogsToKeep": 7,
+          "loggerScannerLogsToKeep": 2,
+          "homeBookshelfView": 1,
+          "bookshelfView": 1,
+          "sortingIgnorePrefix": false,
+          "sortingPrefixes": ["the"],
+          "chromecastEnabled": false,
+          "dateFormat": "MM/dd/yyyy",
+          "timeFormat": "HH:mm",
+          "language": "en-us",
+          "logLevel": 2,
+          "version": "2.36.0"
+        },
+        "Source": "docker"
+      }
+    """.trimIndent()
+  }
+}

--- a/features/auth/ui/src/commonMain/composeResources/values/auth_ui_strings.xml
+++ b/features/auth/ui/src/commonMain/composeResources/values/auth_ui_strings.xml
@@ -16,6 +16,8 @@
   <string name="label_authenticating_loading_message">Logging in…</string>
   <string name="label_login_error_network">A network error has occurred. Please try again.</string>
   <string name="label_login_error_auth">The provided username and password combination is incorrect.</string>
+  <string name="label_login_error_no_libraries">Your account doesn\'t have access to any libraries on this server. Ask your server admin to grant library access, then try again.</string>
+  <string name="label_login_error_unexpected_response">The server returned an unexpected response. Please try again, and check that Campfire and your server are up to date.</string>
   <string name="label_login_error_oauth">Something went wrong with the OpenID provider.</string>
   <string name="label_login_error_oauth_invalid_redirect_uri">The server rejected the mobile redirect URI. Please configure "campfireaudiobooks://oauth" as an allowed Mobile Redirect URI in your Audiobookshelf OpenID settings.</string>
 

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginPresenter.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginPresenter.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import app.campfire.auth.api.AuthException
 import app.campfire.auth.api.AuthRepository
 import app.campfire.auth.api.model.AUTH_METHOD_LOCAL
 import app.campfire.auth.api.model.AUTH_METHOD_OPENID
@@ -169,10 +170,7 @@ class LoginPresenter(
               applySelectedTheme(theme)
             }.onFailure {
               isAuthenticating = false
-              authError = when (it.cause) {
-                is IOException -> AuthError.NetworkError
-                else -> AuthError.InvalidCredentials
-              }
+              authError = it.asAuthError()
             }
           }
         }
@@ -195,10 +193,7 @@ class LoginPresenter(
                   applySelectedTheme(theme)
                 }.onFailure { e ->
                   isAuthenticating = false
-                  authError = when (e.cause) {
-                    is IOException -> AuthError.NetworkError
-                    else -> AuthError.InvalidCredentials
-                  }
+                  authError = e.asAuthError()
                 }
               }
               .onFailure {
@@ -302,6 +297,16 @@ class LoginPresenter(
 
     return connectionState
   }
+}
+
+private fun Throwable.asAuthError(): AuthError = when (this) {
+  is AuthException.InvalidCredentials -> AuthError.InvalidCredentials
+  is AuthException.NoAccessibleLibraries -> AuthError.NoLibraryAccess
+  is AuthException.Network -> AuthError.NetworkError
+  is AuthException.UnexpectedResponse -> AuthError.UnexpectedResponse
+  // Fallbacks for errors thrown outside of AuthRepository's typed mapping
+  is IOException -> AuthError.NetworkError
+  else -> if (cause is IOException) AuthError.NetworkError else AuthError.UnexpectedResponse
 }
 
 private fun Throwable.toOAuthAuthError(): AuthError {

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUiState.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUiState.kt
@@ -51,6 +51,8 @@ sealed interface LoginUiEvent : CircuitUiEvent {
 
 sealed interface AuthError {
   data object InvalidCredentials : AuthError
+  data object NoLibraryAccess : AuthError
+  data object UnexpectedResponse : AuthError
   data object NetworkError : AuthError
   data object OAuthError : AuthError
   data object OAuthInvalidRedirectUri : AuthError

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/composables/ServerCard.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/composables/ServerCard.kt
@@ -97,8 +97,10 @@ import campfire.features.auth.ui.generated.resources.action_show_password
 import campfire.features.auth.ui.generated.resources.invalid_server_url
 import campfire.features.auth.ui.generated.resources.label_login_error_auth
 import campfire.features.auth.ui.generated.resources.label_login_error_network
+import campfire.features.auth.ui.generated.resources.label_login_error_no_libraries
 import campfire.features.auth.ui.generated.resources.label_login_error_oauth
 import campfire.features.auth.ui.generated.resources.label_login_error_oauth_invalid_redirect_uri
+import campfire.features.auth.ui.generated.resources.label_login_error_unexpected_response
 import campfire.features.auth.ui.generated.resources.label_password
 import campfire.features.auth.ui.generated.resources.label_server_name_placeholder
 import campfire.features.auth.ui.generated.resources.label_server_url
@@ -384,6 +386,8 @@ internal fun ServerCard(
             text = stringResource(
               when (authError) {
                 AuthError.InvalidCredentials -> Res.string.label_login_error_auth
+                AuthError.NoLibraryAccess -> Res.string.label_login_error_no_libraries
+                AuthError.UnexpectedResponse -> Res.string.label_login_error_unexpected_response
                 AuthError.NetworkError -> Res.string.label_login_error_network
                 AuthError.OAuthError -> Res.string.label_login_error_oauth
                 AuthError.OAuthInvalidRedirectUri -> Res.string.label_login_error_oauth_invalid_redirect_uri

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -238,6 +238,7 @@ connectivity-apple = { module = "dev.jordond.connectivity:connectivity-apple", v
 connectivity-http = { module = "dev.jordond.connectivity:connectivity-http", version.ref = "connectivity" }
 kmp-xlog-api = "com.piasy:kmp-xlog-api:1.5.0"
 kotlinx-io-bytestring = "org.jetbrains.kotlinx:kotlinx-io-bytestring:0.9.1"
+kotlinx-io-core = "org.jetbrains.kotlinx:kotlinx-io-core:0.9.1"
 oidc-crypto = { module = "io.github.kalinjul.kotlin.multiplatform:oidc-crypto", version = "0.18.1" }
 
 tools-desugarjdklibs = "com.android.tools:desugar_jdk_libs:2.1.5"


### PR DESCRIPTION
## Summary

Fixes #916

Logging into a server where the account has no accessible libraries returned a 200 whose `userDefaultLibraryId` is `null`. Campfire's `LoginResponse` declared the field non-nullable, so deserialization threw and the failure surfaced as *"The provided username and password combination is incorrect"* — a misleading message given the credentials were fine.

## Changes

- `LoginResponse.userDefaultLibraryId` is now nullable so the response parses
- `DefaultAuthRepository` rejects such logins with a typed `AuthException.NoAccessibleLibraries` **before** anything is persisted (the `user` table's `selectedLibraryId` is NOT NULL), on both the password and OIDC paths
- The login screen now shows an accurate message telling the user to ask their server admin for library access
- Auth failures are typed end-to-end via a new sealed `AuthException` in `features/auth/api`: HTTP 401 → `InvalidCredentials`, IO failures → `Network`, everything else (including serialization errors) → `UnexpectedResponse` with its own user-facing message — so future server schema drift can never masquerade as bad credentials
- Removed the unused `CampfireDatabase` constructor dependency from `DefaultAuthRepository` and consolidated the duplicated login/OAuth result handling
- Added `DefaultAuthRepositoryTest` (8 tests) covering the no-libraries case on both auth paths, error translation, and a regression test decoding a real-shaped `/login` payload with `"userDefaultLibraryId": null`

## Testing

- `./gradlew :features:auth:impl:jvmTest` — 8/8 passing
- `./gradlew :app:desktop:compileKotlin` — full DI graph compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
