### PR TITLE
Fix top v1.0.0 Crashlytics fatals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Crash when the server is unreachable or an item was deleted while opening Settings or resuming playback
+- Crash when resuming downloads on app launch on some Android 12+ devices
+- Crash when opening Android Auto settings on devices without Android Auto installed
+- Playback resumption from Bluetooth / media buttons killing the app when the server is offline
+
 ### Other Notes & Contributions
 
 

--- a/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryItemRepository.kt
+++ b/features/libraries/impl/src/commonMain/kotlin/app/campfire/libraries/StoreLibraryItemRepository.kt
@@ -13,6 +13,7 @@ import app.campfire.libraries.api.LibraryItemRepository
 import app.campfire.libraries.item.LibraryItemStore
 import app.campfire.network.AudioBookShelfApi
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.firstOrNull
@@ -48,10 +49,22 @@ class StoreLibraryItemRepository(
       .firstOrNull()
       ?.dataOrNull()
 
-    return if (cached != null && cached.isHydratedForPlayback) {
-      cached
-    } else {
+    if (cached != null && cached.isHydratedForPlayback) return cached
+
+    return try {
       itemStore.fresh(itemId)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      // The server may be unreachable (offline, DNS failure, timeout) or the item may have been
+      // removed (404). Prefer a partially-hydrated cached copy over crashing the caller; only
+      // propagate when we have nothing at all to hand back.
+      if (cached != null) {
+        bark(throwable = e) { "Failed to refresh library item $itemId, falling back to cached copy" }
+        cached
+      } else {
+        throw e
+      }
     }
   }
 

--- a/features/settings/ui/src/androidMain/kotlin/app/campfire/ui/settings/auto/AndroidAutoWrapper.kt
+++ b/features/settings/ui/src/androidMain/kotlin/app/campfire/ui/settings/auto/AndroidAutoWrapper.kt
@@ -4,9 +4,11 @@
 package app.campfire.ui.settings.auto
 
 import android.app.Application
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import androidx.core.net.toUri
 import app.campfire.core.di.AppScope
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import me.tatarka.inject.annotations.Inject
@@ -56,6 +58,30 @@ class AndroidAutoWrapper(
     val settingsIntent = Intent("com.google.android.projection.gearhead.SETTINGS")
     settingsIntent.setPackage(androidAutoPackageName) // Target Android Auto specifically
     settingsIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-    application.startActivity(settingsIntent)
+    try {
+      application.startActivity(settingsIntent)
+    } catch (e: ActivityNotFoundException) {
+      // Android Auto isn't installed (or doesn't expose its settings activity on this device).
+      // Send the user to its Play Store listing instead of crashing.
+      openPlayStoreListing()
+    }
+  }
+
+  private fun openPlayStoreListing() {
+    val marketIntent = Intent(Intent.ACTION_VIEW, "market://details?id=$androidAutoPackageName".toUri())
+      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    try {
+      application.startActivity(marketIntent)
+    } catch (e: ActivityNotFoundException) {
+      val webIntent = Intent(
+        Intent.ACTION_VIEW,
+        "https://play.google.com/store/apps/details?id=$androidAutoPackageName".toUri(),
+      ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      try {
+        application.startActivity(webIntent)
+      } catch (e: ActivityNotFoundException) {
+        // No browser either; nothing sensible left to do.
+      }
+    }
   }
 }

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -26,6 +26,7 @@ import app.campfire.core.app.ApplicationUrls
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.currentPlatform
 import app.campfire.core.di.UserScope
+import app.campfire.core.logging.bark
 import app.campfire.core.model.Media
 import app.campfire.core.model.Server
 import app.campfire.core.session.UserSession
@@ -87,6 +88,7 @@ import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.foundation.NonPausablePresenter
 import com.slack.circuit.runtime.Navigator
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
@@ -175,7 +177,16 @@ class SettingsPresenter(
         .mapLatest { items ->
           items
             .mapNotNull { download ->
-              val libraryItem = libraryItemRepository.getLibraryItem(download.libraryItemId)
+              // A download whose item can't be resolved (server unreachable with no cached copy,
+              // or deleted on the server) shouldn't take the whole settings screen down.
+              val libraryItem = try {
+                libraryItemRepository.getLibraryItem(download.libraryItemId)
+              } catch (e: CancellationException) {
+                throw e
+              } catch (e: Exception) {
+                bark(throwable = e) { "Unable to resolve library item for download ${download.libraryItemId}" }
+                return@mapNotNull null
+              }
               val episodeId = download.episodeId
               if (episodeId == null) {
                 DownloadEntry.Book(libraryItem, download)

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.guava.future
 
@@ -126,12 +127,22 @@ internal class MediaSessionCallback(
       "onPlaybackResumptionInternal(controller=${controller.packageName}, isForPlayback=$isForPlayback)"
     }
 
-    userComponent.sessionsRepository.getCurrentSession()?.let { session ->
-      userComponent.playbackSessionManager.startSession(
-        libraryItemId = session.libraryItem.id,
-        playImmediately = isForPlayback,
-        episodeId = session.episodeId,
-      )
+    // Resumption is often triggered from the background (Bluetooth / media button) where the
+    // server may be unreachable. Resolving the session hits the repository layer, so guard it:
+    // an exception escaping here would leave the freshly started foreground service without a
+    // notification and Android would kill the process.
+    try {
+      userComponent.sessionsRepository.getCurrentSession()?.let { session ->
+        userComponent.playbackSessionManager.startSession(
+          libraryItemId = session.libraryItem.id,
+          playImmediately = isForPlayback,
+          episodeId = session.episodeId,
+        )
+      }
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      bark(LogPriority.ERROR, throwable = e) { "Failed to resume playback from current session" }
     }
 
     // Return an error from this response as we've taken responsibility for starting playback and

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/AndroidOfflineDownloadManager.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/offline/AndroidOfflineDownloadManager.kt
@@ -200,12 +200,30 @@ class AndroidOfflineDownloadManager(
   }
 
   override fun resumeDownloads() {
-    DownloadService.sendResumeDownloads(
-      application,
-      CampfireDownloadService::class.java,
-      /*foreground=*/
-      true,
-    )
+    // Android 12+ can refuse a foreground service start even from Activity.onStart() (e.g. when
+    // the activity is brought up while the device is locked or before the process is promoted
+    // to TOP). Fall back to a plain start and, failing that, simply skip — the service resumes
+    // downloads on its own the next time it's started.
+    try {
+      DownloadService.sendResumeDownloads(
+        application,
+        CampfireDownloadService::class.java,
+        /*foreground=*/
+        true,
+      )
+    } catch (e: IllegalStateException) {
+      bark(throwable = e) { "Unable to start download service in the foreground, retrying in background" }
+      try {
+        DownloadService.sendResumeDownloads(
+          application,
+          CampfireDownloadService::class.java,
+          /*foreground=*/
+          false,
+        )
+      } catch (e: IllegalStateException) {
+        bark(throwable = e) { "Unable to start download service, skipping resume" }
+      }
+    }
   }
 
   private fun episodeDownloadId(itemId: LibraryItemId, episodeId: PodcastEpisodeId): String =


### PR DESCRIPTION
## Summary

Fixes #946 

Addresses the fatal issues reported in Crashlytics for `app.campfire.android` 1.0.0 / 1.0.0-rc3.

| Crashlytics issue | Root cause | Fix |
|---|---|---|
| `ForegroundServiceStartNotAllowedException` in `AndroidOfflineDownloadManager.resumeDownloads` (top crash, 5 users) | `MainActivity.onStart()` starts the download service in the foreground; Android 12+ can reject this (locked device / process not yet TOP) | Catch, retry as a background start, otherwise skip |
| `ApiException 404`, `HttpRequestTimeoutException`, `UnknownHostException` surfacing as fatals | `StoreLibraryItemRepository.getLibraryItem` calls `itemStore.fresh()` whenever the cached item isn't fully hydrated, and callers (Settings downloads list, session hydration) had no catch | Fall back to the cached copy on fetch failure; Settings drops unresolvable download entries |
| `ForegroundServiceDidNotStartInTimeException` for `AudioPlayerService` (started by `MediaButtonReceiver`) | `onPlaybackResumptionInternal` hits the same repository path; an exception left the service without a notification | Guard resumption and log failures |
| `ActivityNotFoundException` in `AndroidAutoWrapper.openSettings` | Android Auto not installed | Fall back to the Play Store listing |

Not addressed: `NoSuchFieldError fontWeightAdjustment` (Compose internal on an x86_64 OnePlus "Android 11" ROM/emulator) — not fixable in app code.

All new catch blocks rethrow `CancellationException`.

## Test plan

- [x] `./scripts/ktlint --check`
- [x] Compiled `:features:libraries:impl`, `:features:settings:ui`, `:infra:audioplayer:impl`
- [x] `:features:libraries:impl:jvmTest`
- [ ] Manual: open Settings → Downloads with the server unreachable
- [ ] Manual: resume playback via Bluetooth with the server unreachable

`skip-coverage`: the repository change needs a Store+DB harness that doesn't exist in this module's tests; remaining changes are Android-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
