### PR TITLE
Fix playback speed decimal display and add exact speed entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Tap the speed value in the playback speed sheet to type an exact playback speed
 ### Changed
 
+- Playback speed slider now snaps to 0.05 increments so speeds like 1.2x are easy to land on
 ### Deprecated
 
 ### Removed
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash when resuming downloads on app launch on some Android 12+ devices
 - Crash when opening Android Auto settings on devices without Android Auto installed
 - Playback resumption from Bluetooth / media buttons killing the app when the server is offline
+- Playback speeds between x.01 and x.09 displaying incorrectly (e.g. 1.03x showing as 1.3x)
 
 ### Other Notes & Contributions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Tap the speed value in the playback speed sheet to type an exact playback speed
+
 ### Changed
 
-- Playback speed slider now snaps to 0.05 increments so speeds like 1.2x are easy to land on
+
 ### Deprecated
 
 ### Removed

--- a/core/src/commonMain/kotlin/app/campfire/core/extensions/Float.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/extensions/Float.kt
@@ -5,7 +5,7 @@ package app.campfire.core.extensions
 
 import kotlin.math.abs
 import kotlin.math.pow
-import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -13,45 +13,56 @@ val Float.seconds: Duration
   get() = toDouble().seconds
 
 /**
- * Return the float receiver as a string display with numOfDec after the decimal (rounded)
- * (e.g. 35.72 with numOfDec = 1 will be 35.7, 35.78 with numOfDec = 2 will be 35.80)
+ * Return the float receiver as a string display with numOfDec after the decimal (rounded, zero-padded)
+ * (e.g. 35.72 with numOfDec = 1 will be 35.7, 1.03 with numOfDec = 2 will be 1.03, 1.999 with numOfDec = 2 will be 2.00)
  *
  * @param numOfDec number of decimal places to show (receiver is rounded to that number)
  * @return the String representation of the receiver up to numOfDec decimal places
  */
 fun Float.toString(numOfDec: Int): String {
   if (isNaN() || isInfinite()) return "--"
-  val sign = if (this < 0f) "-" else ""
-  val thisAbs = abs(this)
-  val integerDigits = thisAbs.toInt()
-  val floatDigits = ((thisAbs - integerDigits) * 10f.pow(numOfDec)).roundToInt()
-  return "$sign$integerDigits.$floatDigits"
+  require(numOfDec >= 0) { "numOfDec must be >= 0" }
+  val scale = 10.0.pow(numOfDec)
+  // Round the whole value at the requested scale so carries propagate into the integer part (0.96 -> 1.0)
+  val scaled = (abs(this).toDouble() * scale).roundToLong()
+  val integerDigits = (scaled / scale.toLong()).toString()
+  val sign = if (this < 0f && scaled != 0L) "-" else ""
+  if (numOfDec == 0) return "$sign$integerDigits"
+  val fractionDigits = (scaled % scale.toLong()).toString().padStart(numOfDec, '0')
+  return "$sign$integerDigits.$fractionDigits"
 }
 
+/**
+ * Round the receiver to the nearest hundredth, scrubbing floating point noise
+ * (e.g. 1.1500001 -> 1.15).
+ */
+fun Float.roundToHundredths(): Float = (this * 100f).roundToLong() / 100f
+
+/**
+ * Shortest display form of the receiver at tenths precision, but keeping a trailing 5 in the
+ * hundredths place (e.g. 1 -> "1", 1.5 -> "1.5", 1.25 -> "1.25", 1.23 -> "1.2").
+ */
 val Float.readable: String
   get() {
-    val asInt = roundToInt()
-    val isWhole = this == asInt.toFloat()
-    val hasHalf = (this * 10) % 1 == 0.5f
-    return if (isWhole) {
-      "$asInt"
-    } else if (hasHalf) {
-      toString(2)
-    } else {
-      toString(1)
+    val hundredths = (this * 100f).roundToLong()
+    return when {
+      hundredths % 100L == 0L -> toString(0)
+      hundredths % 10L == 0L -> toString(1)
+      hundredths % 5L == 0L -> toString(2)
+      else -> toString(1)
     }
   }
 
+/**
+ * Shortest display form of the receiver at hundredths precision
+ * (e.g. 1 -> "1", 1.1 -> "1.1", 1.03 -> "1.03", 1.25 -> "1.25").
+ */
 val Float.readableHundredths: String
   get() {
-    val asInt = roundToInt()
-    val isWhole = this == asInt.toFloat()
-    val hasFraction = (this * 10) % 1 != 0.0f
-    return if (isWhole) {
-      "$asInt"
-    } else if (hasFraction) {
-      toString(2)
-    } else {
-      toString(1)
+    val hundredths = (this * 100f).roundToLong()
+    return when {
+      hundredths % 100L == 0L -> toString(0)
+      hundredths % 10L == 0L -> toString(1)
+      else -> toString(2)
     }
   }

--- a/core/src/commonTest/kotlin/app/campfire/core/extensions/FloatExtensionsTest.kt
+++ b/core/src/commonTest/kotlin/app/campfire/core/extensions/FloatExtensionsTest.kt
@@ -6,7 +6,7 @@ package app.campfire.core.extensions
 import app.cash.burst.Burst
 import app.cash.burst.burstValues
 import assertk.assertThat
-import assertk.assertions.isNotNull
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
 @Burst
@@ -14,11 +14,74 @@ class FloatExtensionsTest {
 
   @Test
   fun toStringDecimalPlaces(
-    floatValue: Float = burstValues(0f, 10f, 23.3f, 485.1234f, -128.9876f),
-    decimalPlaces: Int = burstValues(0, 1, 2, 3),
+    case: Triple<Float, Int, String> = burstValues(
+      Triple(0f, 0, "0"),
+      Triple(0f, 2, "0.00"),
+      Triple(10f, 1, "10.0"),
+      Triple(1.03f, 2, "1.03"),
+      Triple(1.1f, 2, "1.10"),
+      Triple(1.25f, 2, "1.25"),
+      Triple(1.999f, 2, "2.00"),
+      Triple(0.96f, 1, "1.0"),
+      Triple(23.35f, 1, "23.4"),
+      Triple(485.1234f, 3, "485.123"),
+      Triple(-128.9876f, 2, "-128.99"),
+      Triple(-0.001f, 2, "0.00"),
+      Triple(Float.NaN, 2, "--"),
+      Triple(Float.POSITIVE_INFINITY, 1, "--"),
+    ),
   ) {
-    val floatString = floatValue.toString(decimalPlaces)
-    println("Float[$floatValue] ==> [$floatString]")
-    assertThat(floatString.toFloatOrNull()).isNotNull()
+    val (value, decimals, expected) = case
+    assertThat(value.toString(decimals)).isEqualTo(expected)
+  }
+
+  @Test
+  fun readableHundredths(
+    case: Pair<Float, String> = burstValues(
+      0.5f to "0.5",
+      1f to "1",
+      1.01f to "1.01",
+      1.03f to "1.03",
+      1.1f to "1.1",
+      1.10f to "1.1",
+      1.12f to "1.12",
+      1.2f to "1.2",
+      1.25f to "1.25",
+      1.1500001f to "1.15",
+      2f to "2",
+    ),
+  ) {
+    val (value, expected) = case
+    assertThat(value.readableHundredths).isEqualTo(expected)
+  }
+
+  @Test
+  fun readable(
+    case: Pair<Float, String> = burstValues(
+      0.5f to "0.5",
+      1f to "1",
+      1.1f to "1.1",
+      1.2f to "1.2",
+      1.25f to "1.25",
+      1.75f to "1.75",
+      1.23f to "1.2",
+      2f to "2",
+    ),
+  ) {
+    val (value, expected) = case
+    assertThat(value.readable).isEqualTo(expected)
+  }
+
+  @Test
+  fun roundToHundredths(
+    case: Pair<Float, Float> = burstValues(
+      1.1500001f to 1.15f,
+      1.2049f to 1.2f,
+      1.205f to 1.21f,
+      0.5f to 0.5f,
+    ),
+  ) {
+    val (value, expected) = case
+    assertThat(value.roundToHundredths()).isEqualTo(expected)
   }
 }

--- a/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
+++ b/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
@@ -13,6 +13,12 @@
   <string name="playback_error_message">Unable to play this file. The audio format may not be supported on this device.</string>
 
   <string name="speed_bottomsheet_title">Playback speed</string>
+  <string name="speed_custom_open">Enter custom speed</string>
+  <string name="speed_custom_dialog_title">Custom speed</string>
+  <string name="speed_custom_dialog_label">Speed</string>
+  <string name="speed_custom_dialog_error">Enter a value between %1$s and %2$s</string>
+  <string name="speed_custom_action_apply">Apply</string>
+  <string name="speed_custom_action_cancel">Cancel</string>
   <string name="timer_bottomsheet_title">Sleep Timer</string>
   <string name="timer_end_of_chapter">End of Chapter</string>
   <string name="timer_custom">Custom</string>

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/composables/PlaybackSpeedAction.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/composables/PlaybackSpeedAction.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.campfire.common.compose.widgets.IconButtonTooltip
-import app.campfire.sessions.ui.sheets.speed.readableHundredths
+import app.campfire.core.extensions.readableHundredths
 import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.action_playback_speed
 import org.jetbrains.compose.resources.stringResource

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
@@ -64,7 +64,6 @@ import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuitx.overlays.BottomSheetOverlay
 import ir.mahozad.multiplatform.wavyslider.WaveDirection
 import ir.mahozad.multiplatform.wavyslider.material3.WavySlider
-import kotlin.math.roundToInt
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
@@ -173,7 +172,7 @@ private fun PlaybackSpeedBottomSheet(
 
       val setSpeed: (Float) -> Unit = { raw ->
         val speed = raw.roundToHundredths().coerceIn(DefaultSpeedRange)
-        // Snapping means many drag frames resolve to the same stop; only push real changes to the player
+        // Rounding to hundredths means nearby drag frames resolve to the same value; only push real changes
         if (speed != sliderValue) {
           sliderValue = speed
           Analytics.send(PlaybackActionEvent(Speed, Changed, extras = mapOf("speed" to speed)))
@@ -184,7 +183,7 @@ private fun PlaybackSpeedBottomSheet(
       WavySlider(
         value = sliderValue,
         valueRange = DefaultSpeedRange,
-        onValueChange = { setSpeed(it.snapToSliderIncrement()) },
+        onValueChange = setSpeed,
         waveLength = waveLength,
         waveHeight = waveHeight,
         waveVelocity = waveVelocity to WaveDirection.TAIL,
@@ -296,8 +295,3 @@ private val WaveThicknessRange = 16.dp.rangeTo(6.dp)
 
 internal val DefaultSpeedRange = 0.5f.rangeTo(2f)
 private val ClosedFloatingPointRange<Float>.length: Float get() = endInclusive - start
-
-private const val SpeedSliderIncrement = 0.05f
-
-/** Snap a raw slider value to the nearest [SpeedSliderIncrement] so drags land on clean stops like 1.2 instead of 1.18. */
-internal fun Float.snapToSliderIncrement(): Float = (this / SpeedSliderIncrement).roundToInt() * SpeedSliderIncrement

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
@@ -3,6 +3,7 @@
 
 package app.campfire.sessions.ui.sheets.speed
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,11 +12,15 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -25,7 +30,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
@@ -39,11 +46,19 @@ import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.common.compose.analytics.Impression
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.ComponentHolder
-import app.campfire.core.extensions.toString
+import app.campfire.core.extensions.readable
+import app.campfire.core.extensions.readableHundredths
+import app.campfire.core.extensions.roundToHundredths
 import app.campfire.sessions.ui.sheets.SessionSheetLayout
 import app.campfire.settings.api.PlaybackSettings
 import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.speed_bottomsheet_title
+import campfire.features.sessions.ui.generated.resources.speed_custom_action_apply
+import campfire.features.sessions.ui.generated.resources.speed_custom_action_cancel
+import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_error
+import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_label
+import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_title
+import campfire.features.sessions.ui.generated.resources.speed_custom_open
 import com.r0adkll.kimchi.annotations.ContributesTo
 import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuitx.overlays.BottomSheetOverlay
@@ -156,14 +171,20 @@ private fun PlaybackSpeedBottomSheet(
       val waveVelocity = lerp(WaveVelocityRange.start, WaveVelocityRange.endInclusive, sliderProgressNormalized)
       val waveThickness = lerp(WaveThicknessRange.start, WaveThicknessRange.endInclusive, sliderProgressNormalized)
 
+      val setSpeed: (Float) -> Unit = { raw ->
+        val speed = raw.roundToHundredths().coerceIn(DefaultSpeedRange)
+        // Snapping means many drag frames resolve to the same stop; only push real changes to the player
+        if (speed != sliderValue) {
+          sliderValue = speed
+          Analytics.send(PlaybackActionEvent(Speed, Changed, extras = mapOf("speed" to speed)))
+          component.audioPlayerHolder.currentPlayer.value?.setPlaybackSpeed(speed)
+        }
+      }
+
       WavySlider(
         value = sliderValue,
         valueRange = DefaultSpeedRange,
-        onValueChange = {
-          sliderValue = it
-          Analytics.send(PlaybackActionEvent(Speed, Changed, extras = mapOf("speed" to it)))
-          component.audioPlayerHolder.currentPlayer.value?.setPlaybackSpeed(it)
-        },
+        onValueChange = { setSpeed(it.snapToSliderIncrement()) },
         waveLength = waveLength,
         waveHeight = waveHeight,
         waveVelocity = waveVelocity to WaveDirection.TAIL,
@@ -172,48 +193,101 @@ private fun PlaybackSpeedBottomSheet(
         modifier = Modifier.weight(1f),
       )
 
+      var showCustomSpeedDialog by remember { mutableStateOf(false) }
+      val customSpeedLabel = stringResource(Res.string.speed_custom_open)
+
       Text(
         text = "${sliderValue.readableHundredths}x",
-        textAlign = TextAlign.Right,
+        textAlign = TextAlign.Center,
         style = MaterialTheme.typography.labelLarge,
         fontWeight = FontWeight.ExtraBold,
         modifier = Modifier
-          .padding(horizontal = 22.dp)
-          .width(36.dp),
+          .padding(start = 12.dp)
+          .clip(RoundedCornerShape(12.dp))
+          .clickable(onClickLabel = customSpeedLabel) { showCustomSpeedDialog = true }
+          .padding(horizontal = 8.dp, vertical = 12.dp)
+          .width(44.dp),
       )
+
+      if (showCustomSpeedDialog) {
+        CustomSpeedDialog(
+          initialSpeed = sliderValue,
+          onDismiss = { showCustomSpeedDialog = false },
+          onConfirm = { speed ->
+            showCustomSpeedDialog = false
+            setSpeed(speed)
+          },
+        )
+      }
     }
 
     Spacer(Modifier.height(24.dp))
   }
 }
 
-internal val Float.readable: String
-  get() {
-    val asInt = roundToInt()
-    val isWhole = this == asInt.toFloat()
-    val hasHalf = (this * 10) % 1 == 0.5f
-    return if (isWhole) {
-      "$asInt"
-    } else if (hasHalf) {
-      toString(2)
-    } else {
-      toString(1)
-    }
-  }
+@Composable
+private fun CustomSpeedDialog(
+  initialSpeed: Float,
+  onDismiss: () -> Unit,
+  onConfirm: (Float) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var input by remember { mutableStateOf(initialSpeed.readableHundredths) }
+  val parsed = parsePlaybackSpeed(input)
+  val isError = input.isNotBlank() && parsed == null
+  val rangeError = stringResource(
+    Res.string.speed_custom_dialog_error,
+    DefaultSpeedRange.start.readable,
+    DefaultSpeedRange.endInclusive.readable,
+  )
 
-internal val Float.readableHundredths: String
-  get() {
-    val asInt = roundToInt()
-    val isWhole = this == asInt.toFloat()
-    val hasFraction = (this * 10) % 1 != 0.0f
-    return if (isWhole) {
-      "$asInt"
-    } else if (hasFraction) {
-      toString(2)
-    } else {
-      toString(1)
-    }
-  }
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    modifier = modifier,
+    title = { Text(stringResource(Res.string.speed_custom_dialog_title)) },
+    text = {
+      OutlinedTextField(
+        value = input,
+        onValueChange = { input = it },
+        singleLine = true,
+        isError = isError,
+        label = { Text(stringResource(Res.string.speed_custom_dialog_label)) },
+        suffix = { Text("x") },
+        supportingText = { Text(rangeError) },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+      )
+    },
+    confirmButton = {
+      TextButton(
+        enabled = parsed != null,
+        onClick = { parsed?.let(onConfirm) },
+      ) {
+        Text(stringResource(Res.string.speed_custom_action_apply))
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss) {
+        Text(stringResource(Res.string.speed_custom_action_cancel))
+      }
+    },
+  )
+}
+
+/**
+ * Parse a user-entered playback speed such as "1.2", "1,2" or "1.2x", rounded to hundredths.
+ * Returns null if the text isn't a number or falls outside [DefaultSpeedRange].
+ */
+internal fun parsePlaybackSpeed(text: String): Float? {
+  val value = text.trim()
+    .removeSuffix("x")
+    .removeSuffix("X")
+    .trim()
+    .replace(',', '.')
+    .toFloatOrNull()
+    ?.roundToHundredths()
+    ?: return null
+  return value.takeIf { it in DefaultSpeedRange }
+}
 
 private val WavelengthRange = 40.dp.rangeTo(135.dp)
 private val WaveHeightRange = 0.dp.rangeTo(40.dp)
@@ -222,3 +296,8 @@ private val WaveThicknessRange = 16.dp.rangeTo(6.dp)
 
 internal val DefaultSpeedRange = 0.5f.rangeTo(2f)
 private val ClosedFloatingPointRange<Float>.length: Float get() = endInclusive - start
+
+private const val SpeedSliderIncrement = 0.05f
+
+/** Snap a raw slider value to the nearest [SpeedSliderIncrement] so drags land on clean stops like 1.2 instead of 1.18. */
+internal fun Float.snapToSliderIncrement(): Float = (this / SpeedSliderIncrement).roundToInt() * SpeedSliderIncrement


### PR DESCRIPTION
Resolves #945

## Summary
- **Fix**: `Float.toString(numOfDec)` built the fractional part without zero-padding, so `1.03x` rendered as `1.3x` (and `1.999` as `1.100`). It now rounds the whole value at the requested scale and pads the fraction. `readable`/`readableHundredths` also round to hundredths first so float noise no longer produces `1.10x` for `1.1f`.
- **Dedupe**: removed the copy of `readable`/`readableHundredths` in the sessions UI; everything (sheet, bottom bar action, widgets) now shares the `:core` helpers.
- **Slider**: values are rounded to hundredths and clamped to 0.5–2.0 before being applied, and the player/analytics are only notified when the value actually changes.
- **New**: tap the speed value in the playback speed sheet to type an exact speed (accepts `1.2`, `1,2`, `1.2x`; validated against the slider range) — addresses the "dogfighting to 1.2x" part of the issue.

## Test plan
- [x] `FloatExtensionsTest` rewritten with 37 expected-value cases (was previously only asserting the output parsed as a float)
- [x] `./scripts/ktlint --check`
- [x] `:features:sessions:ui:compileKotlinJvm`, `:ui:widgets:impl:compileAndroidMain`
- [x] Manual: slider drag on Android shows `1.01`, `1.02`, … `1.1`, `1.11`; custom speed dialog applies the typed value

🤖 Generated with [Claude Code](https://claude.com/claude-code)