### PR TITLE
Fix Play release bundle failing lintVital fragment version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other Notes & Contributions
 
+- Fixed the Google Play release bundle build failing on a lint check
+
 
 ## [1.0.0]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ fun MyUi(state: MyUiState, modifier: Modifier = Modifier) { /* ... */ }
 - Use `@CircuitInject` for screens with the appropriate scope (usually `UserScope`)
 - `@Parcelize` is multiplatform via expect/actual (see `ParcelizeConventionPlugin`)
 - Package structure: `app.campfire.[module].[submodule]`
+- Do not add comments to dependency notations in `build.gradle.kts` files or in `gradle/libs.versions.toml` — keep dependency declarations bare. If a dependency exists for a non-obvious reason, explain it in the PR/commit message instead.
 
 ## Changelog
 

--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -188,6 +188,7 @@ dependencies {
   implementation(libs.about.libraries.core)
 
   implementation(libs.androidx.activity.compose)
+  implementation(libs.androidx.fragment)
   implementation(libs.androidx.browser)
   implementation(libs.androidx.compose.ui)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ about-libraries = "15.1.0"
 accompanist = "0.37.3"
 androidxlifecycle = "2.11.0"
 androidxactivity = "1.13.0"
+androidxfragment = "1.8.9"
 androidxcomposeui = "1.12.0"
 androidxtracing = "2.0.0"
 androidxtracingperfetto = "1.0.1"
@@ -95,6 +96,7 @@ about-libraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3"
 #Android
 androidx-activity-activity = { module = "androidx.activity:activity", version.ref = "androidxactivity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxactivity" }
+androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidxfragment" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidxlifecycle" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxlifecycle" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }


### PR DESCRIPTION
## Summary
- Release workflow job **Build Android Play Release Bundle** failed in `:app:android:lintVitalStandardRelease` with `InvalidFragmentVersionForActivityResult` at `PlayUpdateFlowLauncher.kt:39` ([run](https://github.com/r0adkll/Campfire/actions/runs/32366805174/job/96417964377)).
- Cause: `:app:android` only got `androidx.fragment:fragment` transitively, resolving to **1.1.0** on the compile classpath, which lint inspects. Only the `standard` flavor has the Play update launcher, so FOSS/Beta jobs passed.
- Fix: declare `androidx.fragment:fragment` (1.8.9, via `androidxfragment` version ref) directly in `:app:android`.
- Also codifies in CLAUDE.md that dependency notations in Gradle files / `libs.versions.toml` should not carry comments.

## Test plan
- [x] `./gradlew :app:android:lintVitalStandardRelease` passes locally
- [x] `./scripts/ktlint --check` passes
- [ ] Re-run the 1.0.0 release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)