### PR TITLE
Generate baseline profiles once per release on emulator.wtf

### DIFF
--- a/.github/workflows/baseline-prof.yml
+++ b/.github/workflows/baseline-prof.yml
@@ -8,14 +8,14 @@ on:
   pull_request:
     paths:
       - 'app/baselineprofile/**'
-      - '.github/workflows/baseline-profile.yml'
+      - '.github/workflows/baseline-prof.yml'
 
 jobs:
   baseline-profile:
     # Skip on fork PRs — this workflow needs first-party secrets and pushes back to main.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v7
@@ -25,11 +25,23 @@ jobs:
           # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-fine-grained-personal-access-token
           token: ${{ secrets.CAMPFIRE_BOT_PAT }}
 
-      - name: Enable KVM
+      - name: Setup swap
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          sudo swapon --show
+          sudo swapoff -a
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon -s
+
+      - name: Free up disk space
+        run: |
+          sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|php)') \
+            firefox google-chrome-stable google-cloud-cli microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual powershell ruby
+          sudo apt autoremove -yq
+          sudo apt clean
+          sudo rm -fr /opt/ghc /opt/hostedtoolcache /opt/az /opt/microsoft /opt/google /usr/lib/node_modules /usr/local/share/boost /usr/share/dotnet /usr/share/swift
 
       - name: Set up JDK
         uses: actions/setup-java@v5
@@ -41,60 +53,26 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Accept Android SDK license
-        run: yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
-
       - name: Download Service Accounts
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
           echo $GOOGLE_SERVICES_JSON > app/android/google-services.json
 
-      - name: Build app and benchmark
-        run: ./gradlew assembleNonMinifiedRelease
-        env:
-          ORG_GRADLE_PROJECT_CAMPFIRE_SERVER_URL: ${{ secrets.SERVER_URL }}
-          ORG_GRADLE_PROJECT_CAMPFIRE_USERNAME: ${{ secrets.TEST_USER_NAME }}
-          ORG_GRADLE_PROJECT_CAMPFIRE_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-
-      - name: AVD cache
-        uses: actions/cache@v6
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-36
-
+      # The generator runs on an emulator.wtf managed device (see app/baselineprofile) rather
+      # than an emulator on the runner — hosted runners were too slow and hung regularly.
+      # The test credentials are read as Gradle properties by features/auth/ui, so the
+      # ORG_GRADLE_PROJECT_ names must match them exactly (lowercase).
       - name: Generate Baseline Profiles
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 36
-          target: google_apis
-          arch: x86_64
-          profile: pixel_7
-          ram-size: 4096M
-          disk-size: 6000M
-          heap-size: 600M
-          script: |
-            ./gradlew generateBaselineProfile \
-              -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile
+        run: |
+          ./gradlew :app:android:generateBaselineProfile \
+            -Pcampfire.config.useEmulatorWtf=true \
+            -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile
         env:
-          ORG_GRADLE_PROJECT_CAMPFIRE_SERVER_URL: ${{ secrets.SERVER_URL }}
-          ORG_GRADLE_PROJECT_CAMPFIRE_USERNAME: ${{ secrets.TEST_USER_NAME }}
-          ORG_GRADLE_PROJECT_CAMPFIRE_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-#
-#      - name: Generate Baseline Profiles
-#        run: |
-#          ./gradlew generateBaselineProfile \
-#            -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" \
-#            -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile \
-#            -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=10 \
-#            --no-configuration-cache
-#        env:
-#          ORG_GRADLE_PROJECT_CAMPFIRE_SERVER_URL: ${{ secrets.SERVER_URL }}
-#          ORG_GRADLE_PROJECT_CAMPFIRE_USERNAME: ${{ secrets.TEST_USER_NAME }}
-#          ORG_GRADLE_PROJECT_CAMPFIRE_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}
+          ORG_GRADLE_PROJECT_campfire_server_url: ${{ secrets.SERVER_URL }}
+          ORG_GRADLE_PROJECT_campfire_username: ${{ secrets.TEST_USER_NAME }}
+          ORG_GRADLE_PROJECT_campfire_password: ${{ secrets.TEST_USER_PASSWORD }}
 
       # If we're on main branch, copy over the baseline profile and
       # commit it to the repository (if changed)
@@ -106,7 +84,7 @@ jobs:
             git config user.name Rotom-Bot
             git config user.email veedubusc+deckbox@gmail.com
             git add app/android/src
-            git commit -m "Update app baseline profile"
+            git commit -m "Update app baseline profile [skip ci]"
             git pull --rebase
             git push
           fi
@@ -118,3 +96,4 @@ jobs:
           name: reports
           path: |
             **/build/reports/*
+            app/baselineprofile/build/outputs/managed_device_android_test_additional_output/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `scripts/release` to cut releases in one step; the Release workflow now bumps `campfire.version` automatically after a release
 - Alpha build release notes now describe the PR that produced the build instead of the cumulative Unreleased changelog
+- Baseline profiles are generated once per release (on emulator.wtf in CI, or locally via `scripts/release`) instead of once per flavor on a hosted-runner emulator
 
 ## [1.0.1]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,9 @@ Campfire is an unofficial Kotlin Multiplatform native client for [Audiobookshelf
 # Store screenshots (phone | seven | ten) → fastlane/metadata/android (see tools/screenshots/README.md)
 tools/screenshots/run.py --class phone
 
-# Cut a release of `campfire.version` (gradle.properties): rolls CHANGELOG.md, writes the
-# fastlane changelog, pushes main and creates the GitHub release. `prepare` / `publish`
-# run the two halves separately; `--dry-run` previews.
+# Cut a release of `campfire.version` (gradle.properties): regenerates baseline profiles,
+# rolls CHANGELOG.md, writes the fastlane changelog, pushes main and creates the GitHub
+# release. `baseline` / `prepare` / `publish` run one phase; `--skip-baseline`; `--dry-run`.
 scripts/release
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ tools/screenshots/run.py --class phone
 
 # Cut a release of `campfire.version` (gradle.properties): regenerates baseline profiles,
 # rolls CHANGELOG.md, writes the fastlane changelog, pushes main and creates the GitHub
-# release. `baseline` / `prepare` / `publish` run one phase; `--skip-baseline`; `--dry-run`.
+# release. `baseline` / `prepare` / `publish` run one phase; `--skip-baseline`;
+# `--emulator-wtf` (needs EW_API_TOKEN) instead of a local emulator; `--dry-run`.
 scripts/release
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ tools/screenshots/run.py --class phone
 # Cut a release of `campfire.version` (gradle.properties): regenerates baseline profiles,
 # rolls CHANGELOG.md, writes the fastlane changelog, pushes main and creates the GitHub
 # release. `baseline` / `prepare` / `publish` run one phase; `--skip-baseline`;
-# `--emulator-wtf` (needs EW_API_TOKEN) instead of a local emulator; `--dry-run`.
+# `--emulator-wtf` (token from Keychain via `scripts/release set-ew-token`); `--dry-run`.
 scripts/release
 ```
 

--- a/app/baselineprofile/build.gradle.kts
+++ b/app/baselineprofile/build.gradle.kts
@@ -2,38 +2,49 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import com.android.build.api.dsl.ManagedVirtualDevice
+import wtf.emulator.DeviceModel
+import wtf.emulator.ewDevices
 
 plugins {
   id("app.campfire.android.test")
   id("app.campfire.kotlin.android")
   alias(libs.plugins.baselineprofile)
+  alias(libs.plugins.emulatorwtf)
 }
+
+// Baseline profiles are merged into :app:android's src/main (mergeIntoMain), so every flavor
+// ships the same profile and the generator only needs to run against one of them. Pinning the
+// test module to the standard flavor means a single emulator session instead of one per flavor.
+// Set -Pcampfire.config.useEmulatorWtf=true (CI) to generate on emulator.wtf instead of a local
+// Gradle managed device; it needs EW_API_TOKEN in the environment.
+val useEmulatorWtf = providers.gradleProperty("campfire.config.useEmulatorWtf").orNull == "true"
 
 android {
   namespace = "app.campfire.baselineprofile"
 
   defaultConfig {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-  }
-
-  flavorDimensions += "default"
-  productFlavors {
-    create("standard") { dimension = "default" }
-    create("alpha") { dimension = "default" }
-    create("beta") { dimension = "default" }
+    missingDimensionStrategy("default", "standard")
   }
 
   targetProjectPath = ":app:android"
 
-  // This code creates the gradle managed device used to generate baseline profiles.
-  // To use GMD please invoke generation through the command line:
+  // Devices used to generate baseline profiles, invoked via
   // ./gradlew :app:android:generateBaselineProfile
-  testOptions.managedDevices.allDevices {
-    @Suppress("UnstableApiUsage")
-    create<ManagedVirtualDevice>("pixel6Api34") {
-      device = "Pixel 6"
-      apiLevel = 34
-      systemImageSource = "google"
+  testOptions.managedDevices {
+    allDevices {
+      @Suppress("UnstableApiUsage")
+      create<ManagedVirtualDevice>("pixel6Api34") {
+        device = "Pixel 6"
+        apiLevel = 34
+        systemImageSource = "google"
+      }
+    }
+    ewDevices {
+      register("ewPixel7Api34") {
+        device.set(DeviceModel.PIXEL_7)
+        apiLevel.set(34)
+      }
     }
   }
 }
@@ -41,7 +52,7 @@ android {
 // This is the configuration block for the Baseline Profile plugin.
 // You can specify to run the generators on a managed devices or connected devices.
 baselineProfile {
-  managedDevices += "pixel6Api34"
+  managedDevices += if (useEmulatorWtf) "ewPixel7Api34" else "pixel6Api34"
   useConnectedDevices = false
   // Uncomment this to enable the emulator display for testing
   // enableEmulatorDisplay = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ vlcj = "4.12.1"
 uiautomator = "2.4.0"
 benchmark-macro-junit4 = "1.4.1"
 baselineprofile = "1.5.0-rc01"
+emulatorwtf = "1.7.2"
 profileinstaller = "1.4.1"
 material = "1.14.0"
 swatchbuckler = "0.1.1"
@@ -83,6 +84,7 @@ firebase-crashlytics = "com.google.firebase.crashlytics:3.0.8"
 firebase-appdistribution = "com.google.firebase.appdistribution:5.3.0"
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
+emulatorwtf = { id = "wtf.emulator.gradle", version.ref = "emulatorwtf" }
 modulegraph = { id = "dev.iurysouza.modulegraph", version = "0.13.0" }
 
 [libraries]

--- a/scripts/release
+++ b/scripts/release
@@ -9,7 +9,8 @@ post-release job in .github/workflows/release.yml bumps it to the next version o
 release ships). The script:
 
   baseline 0. Regenerates the app baseline/startup profiles on a Gradle managed device
-              (app/android/src/main/generated/baselineProfiles). Needs a test server:
+              (app/android/src/main/generated/baselineProfiles) — a local emulator by
+              default, or emulator.wtf with --emulator-wtf (needs EW_API_TOKEN). Needs a test server:
               campfire_server_url / campfire_username / campfire_password as Gradle
               properties (~/.gradle/gradle.properties or ORG_GRADLE_PROJECT_* env vars)
   prepare  1. Validates the version (semver, not yet tagged, not yet in CHANGELOG.md)
@@ -26,6 +27,7 @@ release ships). The script:
 Usage:
   scripts/release                 # baseline + prepare + publish (asks for confirmation)
   scripts/release --skip-baseline # same, without regenerating baseline profiles
+  scripts/release --emulator-wtf  # generate the profiles on emulator.wtf instead of a local emulator
   scripts/release baseline        # only step 0
   scripts/release prepare         # only steps 1-3; edit the files, then `scripts/release publish`
   scripts/release publish         # steps 4-5 on an already prepared tree
@@ -55,6 +57,8 @@ BASELINE_GRADLE_ARGS = [
     "-Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile",
 ]
 BASELINE_PROPERTIES = ("campfire_server_url", "campfire_username", "campfire_password")
+EMULATOR_WTF_GRADLE_ARG = "-Pcampfire.config.useEmulatorWtf=true"
+EMULATOR_WTF_TOKEN_ENV = "EW_API_TOKEN"
 
 REPO = "r0adkll/Campfire"
 REPO_URL = f"https://github.com/{REPO}"
@@ -127,7 +131,7 @@ def has_gradle_property(name):
     return user_props.exists() and re.search(rf"^{name}=", user_props.read_text(), re.MULTILINE) is not None
 
 
-def generate_baseline_profiles(dry_run):
+def generate_baseline_profiles(dry_run, emulator_wtf):
     missing = [name for name in BASELINE_PROPERTIES if not has_gradle_property(name)]
     if missing:
         fail(
@@ -137,10 +141,15 @@ def generate_baseline_profiles(dry_run):
             "or re-run with --skip-baseline"
         )
     command = ["./gradlew", *BASELINE_GRADLE_ARGS]
+    if emulator_wtf:
+        if not os.environ.get(EMULATOR_WTF_TOKEN_ENV):
+            fail(f"--emulator-wtf needs {EMULATOR_WTF_TOKEN_ENV} in the environment")
+        command.append(EMULATOR_WTF_GRADLE_ARG)
     if dry_run:
         print(f"[dry-run] would run: {' '.join(command)}")
         return
-    print("Generating baseline profiles on the Gradle managed device (this takes a while)...")
+    where = "emulator.wtf" if emulator_wtf else "the local Gradle managed device"
+    print(f"Generating baseline profiles on {where} (this takes a while)...")
     run(command, capture=False)
     changed = git("status", "--porcelain", "--", str(BASELINE_PROFILES.relative_to(REPO_ROOT)))
     if changed:
@@ -357,6 +366,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("command", nargs="?", choices=["baseline", "prepare", "publish"], help="run only one phase")
     parser.add_argument("--skip-baseline", action="store_true", help="don't regenerate baseline profiles")
+    parser.add_argument("--emulator-wtf", action="store_true", help="generate baseline profiles on emulator.wtf (needs EW_API_TOKEN)")
     parser.add_argument("--dry-run", action="store_true", help="print what would happen without changing anything")
     parser.add_argument("-y", "--yes", action="store_true", help="skip the confirmation prompt")
     args = parser.parse_args()
@@ -365,7 +375,7 @@ def main():
     print(f"Releasing campfire.version={version}")
 
     if args.command == "baseline" or (args.command is None and not args.skip_baseline):
-        generate_baseline_profiles(args.dry_run)
+        generate_baseline_profiles(args.dry_run, args.emulator_wtf)
         if args.command == "baseline":
             return
     if args.command in (None, "prepare"):

--- a/scripts/release
+++ b/scripts/release
@@ -10,7 +10,9 @@ release ships). The script:
 
   baseline 0. Regenerates the app baseline/startup profiles on a Gradle managed device
               (app/android/src/main/generated/baselineProfiles) — a local emulator by
-              default, or emulator.wtf with --emulator-wtf (needs EW_API_TOKEN). Needs a test server:
+              default, or emulator.wtf with --emulator-wtf. The emulator.wtf token comes from
+              the macOS Keychain (store it once with `scripts/release set-ew-token`) or, as a
+              fallback, the EW_API_TOKEN environment variable. Needs a test server:
               campfire_server_url / campfire_username / campfire_password as Gradle
               properties (~/.gradle/gradle.properties or ORG_GRADLE_PROJECT_* env vars)
   prepare  1. Validates the version (semver, not yet tagged, not yet in CHANGELOG.md)
@@ -28,6 +30,7 @@ Usage:
   scripts/release                 # baseline + prepare + publish (asks for confirmation)
   scripts/release --skip-baseline # same, without regenerating baseline profiles
   scripts/release --emulator-wtf  # generate the profiles on emulator.wtf instead of a local emulator
+  scripts/release set-ew-token    # store the emulator.wtf API token in the macOS Keychain (prompts)
   scripts/release baseline        # only step 0
   scripts/release prepare         # only steps 1-3; edit the files, then `scripts/release publish`
   scripts/release publish         # steps 4-5 on an already prepared tree
@@ -40,8 +43,10 @@ from the tag.
 """
 
 import argparse
+import getpass
 import json
 import os
+import shutil
 import re
 import subprocess
 import sys
@@ -59,6 +64,8 @@ BASELINE_GRADLE_ARGS = [
 BASELINE_PROPERTIES = ("campfire_server_url", "campfire_username", "campfire_password")
 EMULATOR_WTF_GRADLE_ARG = "-Pcampfire.config.useEmulatorWtf=true"
 EMULATOR_WTF_TOKEN_ENV = "EW_API_TOKEN"
+KEYCHAIN_SERVICE = "emulator.wtf"
+KEYCHAIN_ACCOUNT = "campfire-release"
 
 REPO = "r0adkll/Campfire"
 REPO_URL = f"https://github.com/{REPO}"
@@ -131,6 +138,39 @@ def has_gradle_property(name):
     return user_props.exists() and re.search(rf"^{name}=", user_props.read_text(), re.MULTILINE) is not None
 
 
+def keychain_available():
+    return shutil.which("security") is not None
+
+
+def read_emulator_wtf_token():
+    """Keychain first (never in the shell environment), EW_API_TOKEN as a fallback."""
+    if keychain_available():
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", KEYCHAIN_ACCOUNT, "-w"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    return os.environ.get(EMULATOR_WTF_TOKEN_ENV)
+
+
+def store_emulator_wtf_token():
+    if not keychain_available():
+        fail("the macOS Keychain (`security`) is not available; export EW_API_TOKEN instead")
+    token = getpass.getpass("emulator.wtf API token (input hidden): ").strip()
+    if not token:
+        fail("no token entered")
+    # -U updates an existing item in place; the token is passed via -w so it never hits argv history.
+    run([
+        "security", "add-generic-password", "-U",
+        "-s", KEYCHAIN_SERVICE, "-a", KEYCHAIN_ACCOUNT,
+        "-l", "emulator.wtf API token (Campfire scripts/release)",
+        "-w", token,
+    ])
+    print(f"Stored in the login Keychain as service '{KEYCHAIN_SERVICE}', account '{KEYCHAIN_ACCOUNT}'.")
+    print("Remove it with: security delete-generic-password -s emulator.wtf -a campfire-release")
+
+
 def generate_baseline_profiles(dry_run, emulator_wtf):
     missing = [name for name in BASELINE_PROPERTIES if not has_gradle_property(name)]
     if missing:
@@ -141,16 +181,20 @@ def generate_baseline_profiles(dry_run, emulator_wtf):
             "or re-run with --skip-baseline"
         )
     command = ["./gradlew", *BASELINE_GRADLE_ARGS]
+    env = None
     if emulator_wtf:
-        if not os.environ.get(EMULATOR_WTF_TOKEN_ENV):
-            fail(f"--emulator-wtf needs {EMULATOR_WTF_TOKEN_ENV} in the environment")
+        token = read_emulator_wtf_token()
+        if not token:
+            fail("no emulator.wtf token found — run `scripts/release set-ew-token` (or export EW_API_TOKEN)")
         command.append(EMULATOR_WTF_GRADLE_ARG)
+        # Only the Gradle child process sees the token.
+        env = {**os.environ, EMULATOR_WTF_TOKEN_ENV: token}
     if dry_run:
         print(f"[dry-run] would run: {' '.join(command)}")
         return
     where = "emulator.wtf" if emulator_wtf else "the local Gradle managed device"
     print(f"Generating baseline profiles on {where} (this takes a while)...")
-    run(command, capture=False)
+    subprocess.run(command, cwd=REPO_ROOT, check=True, env=env)
     changed = git("status", "--porcelain", "--", str(BASELINE_PROFILES.relative_to(REPO_ROOT)))
     if changed:
         print("Baseline profiles updated:\n  " + "\n  ".join(baseline_profile_files()))
@@ -364,12 +408,19 @@ def publish(version, dry_run, assume_yes):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("command", nargs="?", choices=["baseline", "prepare", "publish"], help="run only one phase")
+    parser.add_argument(
+        "command", nargs="?", choices=["baseline", "prepare", "publish", "set-ew-token"],
+        help="run only one phase, or store the emulator.wtf token in the Keychain",
+    )
     parser.add_argument("--skip-baseline", action="store_true", help="don't regenerate baseline profiles")
-    parser.add_argument("--emulator-wtf", action="store_true", help="generate baseline profiles on emulator.wtf (needs EW_API_TOKEN)")
+    parser.add_argument("--emulator-wtf", action="store_true", help="generate baseline profiles on emulator.wtf")
     parser.add_argument("--dry-run", action="store_true", help="print what would happen without changing anything")
     parser.add_argument("-y", "--yes", action="store_true", help="skip the confirmation prompt")
     args = parser.parse_args()
+
+    if args.command == "set-ew-token":
+        store_emulator_wtf_token()
+        return
 
     version = read_version()
     print(f"Releasing campfire.version={version}")

--- a/scripts/release
+++ b/scripts/release
@@ -8,6 +8,10 @@ The version being released is always `campfire.version` in gradle.properties (th
 post-release job in .github/workflows/release.yml bumps it to the next version once a
 release ships). The script:
 
+  baseline 0. Regenerates the app baseline/startup profiles on a Gradle managed device
+              (app/android/src/main/generated/baselineProfiles). Needs a test server:
+              campfire_server_url / campfire_username / campfire_password as Gradle
+              properties (~/.gradle/gradle.properties or ORG_GRADLE_PROJECT_* env vars)
   prepare  1. Validates the version (semver, not yet tagged, not yet in CHANGELOG.md)
            2. Rolls `## [Unreleased]` in CHANGELOG.md into `## [<version>]` (dropping empty
               categories), inserts a fresh Unreleased skeleton and a compare link
@@ -20,7 +24,9 @@ release ships). The script:
               Release workflow that builds and attaches the APKs/AAB.
 
 Usage:
-  scripts/release                 # prepare + publish (asks for confirmation)
+  scripts/release                 # baseline + prepare + publish (asks for confirmation)
+  scripts/release --skip-baseline # same, without regenerating baseline profiles
+  scripts/release baseline        # only step 0
   scripts/release prepare         # only steps 1-3; edit the files, then `scripts/release publish`
   scripts/release publish         # steps 4-5 on an already prepared tree
   scripts/release --dry-run       # show everything that would happen without touching git/GitHub
@@ -33,6 +39,7 @@ from the tag.
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -42,6 +49,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 GRADLE_PROPERTIES = REPO_ROOT / "gradle.properties"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 FASTLANE_CHANGELOGS = REPO_ROOT / "fastlane/metadata/android/en-US/changelogs"
+BASELINE_PROFILES = REPO_ROOT / "app/android/src/main/generated/baselineProfiles"
+BASELINE_GRADLE_ARGS = [
+    ":app:android:generateBaselineProfile",
+    "-Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile",
+]
+BASELINE_PROPERTIES = ("campfire_server_url", "campfire_username", "campfire_password")
 
 REPO = "r0adkll/Campfire"
 REPO_URL = f"https://github.com/{REPO}"
@@ -98,6 +111,42 @@ def previous_tag():
     """The most recent tag reachable from HEAD, i.e. the last release cut from main."""
     tag = run(["git", "describe", "--tags", "--abbrev=0"], check=False).stdout.strip()
     return tag or None
+
+
+# --------------------------------------------------------------------------- baseline
+
+
+def baseline_profile_files():
+    return sorted(str(path.relative_to(REPO_ROOT)) for path in BASELINE_PROFILES.glob("*.txt"))
+
+
+def has_gradle_property(name):
+    if f"ORG_GRADLE_PROJECT_{name}" in os.environ:
+        return True
+    user_props = Path.home() / ".gradle" / "gradle.properties"
+    return user_props.exists() and re.search(rf"^{name}=", user_props.read_text(), re.MULTILINE) is not None
+
+
+def generate_baseline_profiles(dry_run):
+    missing = [name for name in BASELINE_PROPERTIES if not has_gradle_property(name)]
+    if missing:
+        fail(
+            "baseline profile generation needs a test server; set "
+            + ", ".join(missing)
+            + " in ~/.gradle/gradle.properties (or ORG_GRADLE_PROJECT_<name> env vars), "
+            "or re-run with --skip-baseline"
+        )
+    command = ["./gradlew", *BASELINE_GRADLE_ARGS]
+    if dry_run:
+        print(f"[dry-run] would run: {' '.join(command)}")
+        return
+    print("Generating baseline profiles on the Gradle managed device (this takes a while)...")
+    run(command, capture=False)
+    changed = git("status", "--porcelain", "--", str(BASELINE_PROFILES.relative_to(REPO_ROOT)))
+    if changed:
+        print("Baseline profiles updated:\n  " + "\n  ".join(baseline_profile_files()))
+    else:
+        print("Baseline profiles unchanged")
 
 
 # --------------------------------------------------------------------------- prepare
@@ -212,7 +261,7 @@ def check_publish_preconditions(version, dry_run):
         )
 
     # Only the release files may be dirty; anything else is probably unrelated work.
-    allowed = {"CHANGELOG.md", str(path.relative_to(REPO_ROOT))}
+    allowed = {"CHANGELOG.md", str(path.relative_to(REPO_ROOT)), *baseline_profile_files()}
     status = run(["git", "status", "--porcelain", "--untracked-files=all"]).stdout
     dirty = [line[3:].split(" -> ")[-1] for line in status.splitlines()]
     unexpected = sorted(set(dirty) - allowed)
@@ -284,7 +333,7 @@ def publish(version, dry_run, assume_yes):
             print("aborted — nothing was pushed")
             sys.exit(1)
 
-    files = ["CHANGELOG.md", str(fastlane_path(version).relative_to(REPO_ROOT))]
+    files = ["CHANGELOG.md", str(fastlane_path(version).relative_to(REPO_ROOT)), *baseline_profile_files()]
     if git("status", "--porcelain", "--", *files):
         run(["git", "add", *files])
         # [skip ci]: the release itself builds from the tag; no alpha needed for this commit.
@@ -306,7 +355,8 @@ def publish(version, dry_run, assume_yes):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("command", nargs="?", choices=["prepare", "publish"], help="run only one phase")
+    parser.add_argument("command", nargs="?", choices=["baseline", "prepare", "publish"], help="run only one phase")
+    parser.add_argument("--skip-baseline", action="store_true", help="don't regenerate baseline profiles")
     parser.add_argument("--dry-run", action="store_true", help="print what would happen without changing anything")
     parser.add_argument("-y", "--yes", action="store_true", help="skip the confirmation prompt")
     args = parser.parse_args()
@@ -314,6 +364,10 @@ def main():
     version = read_version()
     print(f"Releasing campfire.version={version}")
 
+    if args.command == "baseline" or (args.command is None and not args.skip_baseline):
+        generate_baseline_profiles(args.dry_run)
+        if args.command == "baseline":
+            return
     if args.command in (None, "prepare"):
         prepare(version, args.dry_run)
         if args.command == "prepare":

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,9 @@ pluginManagement {
     google()
     gradlePluginPortal()
     mavenCentral()
+    maven("https://maven.emulator.wtf/releases/") {
+      content { includeGroup("wtf.emulator") }
+    }
   }
 }
 
@@ -67,6 +70,9 @@ dependencyResolutionManagement {
 
     google()
     mavenCentral()
+    maven("https://maven.emulator.wtf/releases/") {
+      content { includeGroup("wtf.emulator") }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Pin `:app:baselineprofile` to the standard flavor (`missingDimensionStrategy`) so `generateBaselineProfile` runs a single emulator session — profiles were already merged into `src/main` for every flavor.
- Add an emulator.wtf Gradle managed device (`wtf.emulator.gradle` 1.7.2, maven.emulator.wtf repo) selected with `-Pcampfire.config.useEmulatorWtf=true`; local generation still uses the `pixel6Api34` GMD.
- Rewrite `baseline-prof.yml` around emulator.wtf: no runner emulator/KVM, fixes the credential property names (`ORG_GRADLE_PROJECT_campfire_server_url` etc. — Gradle properties are case-sensitive, so the generator never had credentials before), adds the swap/disk cleanup steps, `[skip ci]` on the profile commit, and uploads device test output.
- `scripts/release` gains a `baseline` phase (`--skip-baseline` / `scripts/release baseline`).

## Test plan
- [x] `./gradlew :app:android:generateBaselineProfile --dry-run` with and without `-Pcampfire.config.useEmulatorWtf=true` — single `nonMinifiedRelease` session; ew task chain selected by the property
- [x] `mergeAlphaReleaseArtProfile` / `mergeFossReleaseArtProfile` still resolve
- [x] Baseline profile generation workflow run on this PR completes on emulator.wtf (7.5 min device session, 17.5 min total) — https://github.com/r0adkll/Campfire/actions/runs/32582368469

🤖 Generated with [Claude Code](https://claude.com/claude-code)