### PR TITLE
Show file sizes with one decimal place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - App freezing on the search empty state when system animations are disabled (e.g. the "Remove animations" accessibility setting)
 - Series with decimal sequence numbers (1.1, 1.2, …) now sort in the correct order instead of jumping to the end
 - Covers updated on the server now refresh in the app instead of showing the old image until the cache expires
+- Download and file sizes showing two decimal places (e.g. 1.00 MB) instead of one
 
 ### Other Notes & Contributions
 

--- a/core/src/commonMain/kotlin/app/campfire/core/extensions/Int.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/extensions/Int.kt
@@ -21,6 +21,9 @@ fun Long.asDateTime(): LocalDateTime = Instant.fromEpochMilliseconds(this)
 
 fun Long.asDate(): LocalDate = asDateTime().date
 
+/**
+ * Human readable binary size with one decimal place (e.g. 1536 -> "1.5 KB", 10 MiB -> "10.0 MB").
+ */
 fun Long.asReadableBytes(): String {
   val kb = this.toDouble() / 1024.0
   val mb = kb / 1024.0
@@ -28,13 +31,13 @@ fun Long.asReadableBytes(): String {
   val tb = gb / 1024.0
 
   return if (tb >= 1.0) {
-    tb.toFloat().toString(2) + " TB"
+    tb.toFloat().toString(1) + " TB"
   } else if (gb >= 1.0) {
-    gb.toFloat().toString(2) + " GB"
+    gb.toFloat().toString(1) + " GB"
   } else if (mb >= 1.0) {
-    mb.toFloat().toString(2) + " MB"
+    mb.toFloat().toString(1) + " MB"
   } else if (kb >= 1.0) {
-    kb.toFloat().toString(2) + " KB"
+    kb.toFloat().toString(1) + " KB"
   } else {
     "$this B"
   }

--- a/core/src/commonTest/kotlin/app/campfire/core/extensions/LongExtensionsTest.kt
+++ b/core/src/commonTest/kotlin/app/campfire/core/extensions/LongExtensionsTest.kt
@@ -1,0 +1,32 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.core.extensions
+
+import app.cash.burst.Burst
+import app.cash.burst.burstValues
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+@Burst
+class LongExtensionsTest {
+
+  @Test
+  fun asReadableBytes(
+    case: Pair<Long, String> = burstValues(
+      Pair(0L, "0 B"),
+      Pair(1023L, "1023 B"),
+      Pair(1024L, "1.0 KB"),
+      Pair(1536L, "1.5 KB"),
+      Pair(1024L * 1024L, "1.0 MB"),
+      Pair(10L * 1024L * 1024L, "10.0 MB"),
+      Pair((1.5 * 1024 * 1024).toLong(), "1.5 MB"),
+      Pair((1.75 * 1024 * 1024 * 1024).toLong(), "1.8 GB"),
+      Pair(2L * 1024L * 1024L * 1024L * 1024L, "2.0 TB"),
+    ),
+  ) {
+    val (bytes, expected) = case
+    assertThat(bytes.asReadableBytes()).isEqualTo(expected)
+  }
+}


### PR DESCRIPTION
## Summary
- `Float.toString(numOfDec)` was corrected in #953 to zero-pad the fraction (`1.03x` playback speed). `Long.asReadableBytes()` used `toString(2)` and relied on the old formatter dropping zeros, so sizes started rendering as `1.00 MB` and `ExpressiveControlSlotTest` has been failing on `main` since (only visible on PRs — `code-coverage` is skipped on pushes to `main`).
- Format sizes at one decimal place explicitly (`1.5 KB`, `10.0 MB`, `1.8 GB`) and add `LongExtensionsTest` covering the unit boundaries.

## Test plan
- [x] `./gradlew :core:jvmTest :features:libraries:ui:jvmTest` — all green locally, including the two previously failing `ExpressiveControlSlotTest` cases
- [x] `code-coverage` job passes on this PR — https://github.com/r0adkll/Campfire/actions/runs/32589959972

🤖 Generated with [Claude Code](https://claude.com/claude-code)