### PR TITLE
Use declarative store title "Campfire for Audiobookshelf"

### DIFF
--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Campfire
+Campfire for Audiobookshelf


### PR DESCRIPTION
Updates the Play Store listing title (`fastlane/metadata/android/en-US/title.txt`) from **Campfire** to **Campfire for Audiobookshelf** for discoverability. The launcher/app name is unchanged — this only affects the store listing title.

Matches the F-Droid listing name set in the fdroiddata submission ([MR !46619](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/46619)). At 27 characters it's within Google Play's 30-character title limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)