### PR TITLE
Make the FOSS build reproducible (keep baseline profile, drop DEX layout optimization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other Notes & Contributions
 
+- Made the FOSS (F-Droid) build reproducible while keeping the baseline profile for startup performance
+
 ## [1.0.3]
 
 ### Fixed

--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -160,6 +160,14 @@ baselineProfile {
   dexLayoutOptimization = true
   saveInSrc = true
   mergeIntoMain = true
+
+  // F-Droid does a byte-for-byte reproducible build of the foss flavor and startup profiles break these.
+  // (https://f-droid.org/docs/Reproducible_Builds/)
+  variants {
+    create("foss") {
+      dexLayoutOptimization = false
+    }
+  }
 }
 
 aboutLibraries {


### PR DESCRIPTION
F-Droid does a byte-for-byte reproducible build of the `foss` flavor and compares it to our published `campfire-foss-release.apk`. It never matched because `dexLayoutOptimization` feeds the startup profile to R8 to reorder `classes.dex`, which is [non-deterministic across build environments](https://f-droid.org/docs/Reproducible_Builds/) and cascades into the compiled `baseline.profm`.

## Fix
Disable `dexLayoutOptimization` **for the `foss` flavor only**, via the `androidx.baselineprofile` plugin's per-variant config:
```kotlin
baselineProfile {
  dexLayoutOptimization = true
  ...
  variants { create("foss") { dexLayoutOptimization = false } }
}
```
The baseline profile itself reproduces fine and **stays embedded** — the end-user AOT / cold-start win is kept. Only the minor DEX page-locality optimization is dropped, and only on the F-Droid build. `standard`/`alpha` keep the full optimization.

## Validation
Byte-compared multiple clean `assembleFossRelease` builds:

| | Result |
|---|---|
| `classes.dex` | IDENTICAL ✓ |
| `assets/dexopt/baseline.prof` | IDENTICAL ✓ (retained) |
| `assets/dexopt/baseline.profm` | IDENTICAL ✓ (retained) |

## Follow-ups
- Once merged, cut `1.0.4` — its published FOSS APK is reproducible with the profile intact; then the fdroiddata MR bumps to `1.0.4` and `fdroid build` should reproduce.
- A separate task-ordering flakiness in the whats-new `changelog.json` compose resource (missing from 1 of 4 cold builds) will be fixed in its own PR.