### PR TITLE
Fix changelog.json intermittently missing from release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- What's New screen could occasionally ship without its changelog content
+
 ### Other Notes & Contributions
 
 ## [1.0.3]

--- a/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/changelog/ChangelogConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/app/campfire/convention/changelog/ChangelogConventionPlugin.kt
@@ -39,19 +39,14 @@ class ChangelogConventionPlugin : Plugin<Project> {
         extensions.configure<ResourcesExtension> {
           customDirectory(
             sourceSetName = "commonMain",
-            directoryProvider = generatedResources,
+            // Derive the directory from the task provider so it carries generateChangelog as an
+            // implicit dependency: every compose-resource consumer — including the Android asset
+            // packaging — then waits for it, rather than relying on a brittle task-name match that
+            // could miss a consumer and drop changelog.json from the APK on a cold build.
+            directoryProvider = generateChangelog.map { generatedResources.get() },
           )
         }
       }
-    }
-
-    tasks.matching {
-      it.name.startsWith("generateComposeResClass") ||
-        it.name.startsWith("copyNonXmlValueResourcesFor") ||
-        it.name.startsWith("prepareComposeResourcesTaskFor") ||
-        it.name.startsWith("generateResourceAccessorsFor")
-    }.configureEach {
-      dependsOn(generateChangelog)
     }
   }
 }


### PR DESCRIPTION
## Problem
On some **cold** builds the APK shipped without `assets/composeResources/…whats_new.impl…/files/changelog.json`, leaving the What's New screen empty. Found while validating F-Droid reproducibility (1 of 4 cold builds missed it).

## Root cause
`ChangelogConventionPlugin` registered `build/generated/composeResources` as a Compose resource directory using a **plain** `layout.buildDirectory.dir(...)` provider — which carries **no task dependency** on `generateChangelog`. It compensated with a `tasks.matching { name.startsWith(...) }.dependsOn(generateChangelog)`, but that name match didn't cover the Android asset-packaging consumer. So the asset merge could race ahead of `generateChangelog` and package an empty resource dir.

## Fix
Derive the custom-directory provider from the task provider itself:
```kotlin
directoryProvider = generateChangelog.map { generatedResources.get() }
```
Now the dependency is carried implicitly to **every** consumer (including Android asset packaging), and the brittle task-name match is removed.

## Validation
- build-logic compiles + tests pass
- `changelog.json` present across **5/5** cold `assembleFossRelease` builds (was intermittent before)

Split out from the FOSS-reproducibility work (#978); independent of it.