### PR TITLE
Normalize R8 pg-map-id in foss builds (F-Droid reproducibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other Notes & Contributions
 
+- FOSS (F-Droid) builds are now byte-for-byte reproducible
+
 ## [1.0.4]
 
 ### Fixed

--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -6,6 +6,8 @@
 import app.campfire.convention.campfireVersionCode
 import app.campfire.convention.campfireVersionName
 import app.campfire.convention.deriveVersionCode
+import java.security.MessageDigest
+import java.util.zip.Adler32
 
 plugins {
   id("app.campfire.android.application")
@@ -153,6 +155,44 @@ tasks.register("verifyVersionCode") {
         "Update gradle.properties so the two agree."
     }
     logger.lifecycle("campfire.versionCode $actual matches campfire.version $name")
+  }
+}
+
+// F-Droid does a byte-for-byte reproducible build of the foss flavor. R8 embeds a `pg-map-id`
+// (a hash of the ProGuard/R8 mapping) in the DEX marker that varies by build environment even when
+// the bytecode is identical — the sole thing that broke reproducibility. The mapping isn't published
+// for the foss build, so the id is cosmetic: normalize it to a fixed value right after R8 and before
+// packaging, so both our CI and F-Droid's rebuild produce identical DEX (and, since baseline.prof is
+// compiled afterwards from this DEX, an identical profile too). standard/alpha are untouched.
+//
+// Inlined into the task action (no script-level helpers) so it stays configuration-cache compatible.
+tasks.matching { it.name == "minifyFossReleaseWithR8" }.configureEach {
+  val dexDir = layout.buildDirectory
+    .dir("intermediates/dex/fossRelease/minifyFossReleaseWithR8").get().asFile
+  val id = "0".repeat(64).toByteArray(Charsets.ISO_8859_1)
+  doLast {
+    val key = "\"pg-map-id\":\"".toByteArray(Charsets.ISO_8859_1)
+    dexDir.listFiles { f -> f.name.matches(Regex("classes\\d*\\.dex")) }?.forEach { dexFile ->
+      val bytes = dexFile.readBytes()
+      var at = -1
+      run {
+        outer@ for (i in 0..bytes.size - key.size) {
+          for (j in key.indices) if (bytes[i + j] != key[j]) continue@outer
+          at = i; return@run
+        }
+      }
+      if (at < 0) return@forEach
+      val start = at + key.size
+      var end = start
+      while (end < bytes.size && bytes[end] != '"'.code.toByte()) end++
+      require(end - start == id.size) { "unexpected pg-map-id length ${end - start}" }
+      id.copyInto(bytes, start)
+      // recompute DEX SHA-1 signature (bytes[32..] -> bytes[12..32]) and Adler-32 (bytes[12..] -> bytes[8..12])
+      MessageDigest.getInstance("SHA-1").digest(bytes.copyOfRange(32, bytes.size)).copyInto(bytes, 12)
+      val adler = Adler32().apply { update(bytes, 12, bytes.size - 12) }.value
+      for (i in 0 until 4) bytes[8 + i] = ((adler shr (8 * i)) and 0xffL).toByte()
+      dexFile.writeBytes(bytes)
+    }
   }
 }
 


### PR DESCRIPTION
The last thing blocking F-Droid's reproducible build of the `foss` flavor. After the [baseline-profile fix](https://github.com/r0adkll/Campfire/pull/978), `diffoscope` showed `classes.dex` was byte-identical to our published APK **except R8's embedded `pg-map-id`** — a hash of the ProGuard/R8 mapping that differs per build environment even when the bytecode is identical (`baseline.prof` then inherited the change through the DEX header/checksum). Everything else matched.

## Fix
Normalize the `pg-map-id` to a fixed value in the DEX **right after R8, before packaging** (`minifyFossReleaseWithR8.doLast`), foss-only:
- AGP then compiles `baseline.prof` against the fixed DEX and packages/zipaligns/signs it naturally — no post-processing, no re-zip, no re-sign.
- Both our CI and F-Droid's rebuild run this identical logic from source, so both produce the same id → reproducible by construction.
- The mapping isn't published for the foss build, so the id is cosmetic (and foss has no Crashlytics).
- Self-contained Kotlin (SHA-1 + Adler-32 recompute), inlined to stay configuration-cache compatible.

## Validation
`assembleFossRelease` across clean double-builds:

| | Result |
|---|---|
| full APK | BYTE-IDENTICAL ✓ |
| `classes.dex` | identical ✓ |
| `baseline.prof` / `baseline.profm` | identical ✓ |
| DEX validity (dexdump) | checksum/signature OK ✓ |

`standard`/`alpha` are untouched.

## Follow-up
Once merged, cut `1.0.5`. The fdroiddata MR then simplifies: bump to `1.0.5` and **drop the pg-map-id postbuild entirely** (the APK is now naturally reproducible), keeping just `Binaries` + `AllowedAPKSigningKeys` + autoupdate.