### PR TITLE
Fix app widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- App widgets breaking due to large image size
+
 ### Other Notes & Contributions
 
 ## [1.0.5]

--- a/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/GlanceImage.kt
+++ b/ui/widgets/impl/src/androidMain/kotlin/app/campfire/widgets/composables/GlanceImage.kt
@@ -29,6 +29,13 @@ import coil3.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
+/**
+ * Now that Campfire will dynamically request images @ size
+ * the widgets could end up trying to render very large images
+ * that break them. So if not specified, let's cap widget image sizes.
+ */
+private const val DEFAULT_IMAGE_SIZE = 400
+
 @Composable
 internal fun GlanceImage(
   url: Any?,
@@ -44,7 +51,7 @@ internal fun GlanceImage(
     withContext(Dispatchers.IO) {
       val request = ImageRequest.Builder(context)
         .data(url)
-        .size { size ?: Size.ORIGINAL }
+        .size { size ?: Size(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE) }
         .build()
 
       bitmap = when (val result = context.imageLoader.execute(request)) {


### PR DESCRIPTION
<!--
Thanks for contributing to Campfire! Please fill out the sections below.
Feel free to delete sections that don't apply.
-->
## Summary

#898 This image responsive PR broke widgets by not capping their images (which previously were just blanket limited to 400x400px) and causing memory issues in widgets. This fixes this by setting a reasonable default on widgets.

## Related issues
<!-- Link any related issues. Use "Closes #123" to auto-close on merge. -->

Closes #982 
