### PR TITLE
Fix unreliable Cast device discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - App widgets breaking due to large image size
+- Cast devices not appearing reliably, including the cast button vanishing after rotating the screen
 
 ### Other Notes & Contributions
+
+- The cast device list now offers to request local network access on Android 16+ when it may be needed to find devices
 
 ## [1.0.5]
 

--- a/app/android/src/main/java/app/campfire/android/MainActivity.kt
+++ b/app/android/src/main/java/app/campfire/android/MainActivity.kt
@@ -56,10 +56,6 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    // Initialize the CastContext used for Google Cast
-    // https://developers.google.com/cast/docs/android_sender/integrate#kotlin
-    component.castController.initialize()
-
     // Register all flow launchers
     component.componentActivityPlugins.forEach { launcher ->
       launcher.register(this)
@@ -125,27 +121,13 @@ class MainActivity : ComponentActivity() {
   override fun onStart() {
     super.onStart()
     bark { "MainActivity::onStart()" }
-    with(component) {
-      mediaControllerConnector.connect()
-      castController.scanForDevices()
-      offlineDownloadManager.resumeDownloads()
-    }
-  }
-
-  override fun onStop() {
-    super.onStop()
-    bark { "MainActivity::onStop()" }
-    with(component) {
-      mediaControllerConnector.disconnect()
-      castController.stopScanningForDevices()
-    }
+    component.offlineDownloadManager.resumeDownloads()
   }
 
   override fun onDestroy() {
     super.onDestroy()
     bark { "MainActivity::onDestroy()" }
     GlobalToaster.unregister()
-    component.castController.destroy()
     component.componentActivityPlugins.forEach { launcher ->
       launcher.unregister()
     }

--- a/app/android/src/main/java/app/campfire/android/di/ActivityComponent.kt
+++ b/app/android/src/main/java/app/campfire/android/di/ActivityComponent.kt
@@ -6,8 +6,6 @@ package app.campfire.android.di
 import android.app.Activity
 import androidx.core.os.ConfigurationCompat
 import app.campfire.account.api.UserSessionManager
-import app.campfire.audioplayer.cast.CastController
-import app.campfire.audioplayer.impl.MediaControllerConnector
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.root.CampfireContent
 import app.campfire.core.ComponentActivityPlugin
@@ -26,8 +24,6 @@ import me.tatarka.inject.annotations.Provides
 )
 interface ActivityComponent {
   val campfireContent: CampfireContent
-  val mediaControllerConnector: MediaControllerConnector
-  val castController: CastController
   val componentActivityPlugins: Set<ComponentActivityPlugin>
   val offlineDownloadManager: OfflineDownloadManager
   val userSessionManager: UserSessionManager

--- a/app/android/src/main/java/app/campfire/android/permission/AndroidLocalNetworkPermissionController.kt
+++ b/app/android/src/main/java/app/campfire/android/permission/AndroidLocalNetworkPermissionController.kt
@@ -59,6 +59,27 @@ class AndroidLocalNetworkPermissionController(
     return granted
   }
 
+  override fun isPermissionMissing(): Boolean {
+    if (Build.VERSION.SDK_INT < LNP_MIN_SDK) return false
+    return !isGranted()
+  }
+
+  override suspend fun request(): Boolean {
+    if (Build.VERSION.SDK_INT < LNP_MIN_SDK) return true
+    if (isGranted()) return true
+
+    // User-initiated, so don't gate on requestedThisSession — but record the attempt so the
+    // automatic server-url path doesn't prompt again afterwards.
+    mutex.withLock {
+      if (isGranted()) return true
+      requestedThisSession = true
+    }
+
+    val granted = launcher.launch(ACCESS_LOCAL_NETWORK).getOrDefault(false)
+    bark { "ACCESS_LOCAL_NETWORK permission ${if (granted) "granted" else "denied"} (explicit request)" }
+    return granted
+  }
+
   /**
    * A public-looking hostname can still resolve to a LAN address via split-horizon DNS
    * (e.g. `abs.example.com` overridden to `192.168.x.x` on the local resolver), which LNP

--- a/core/src/commonMain/kotlin/app/campfire/core/permission/LocalNetworkPermissionController.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/permission/LocalNetworkPermissionController.kt
@@ -23,4 +23,20 @@ interface LocalNetworkPermissionController {
    * work — so callers may proceed regardless.
    */
   suspend fun requestIfNeeded(serverUrl: String): Boolean
+
+  /**
+   * True when the platform gates local-network traffic behind a permission that has not been
+   * granted yet. Unlike [requestIfNeeded], this is independent of the server address — features
+   * that are inherently LAN-bound (e.g. Google Cast) need the permission even when the
+   * Audiobookshelf server itself is remote.
+   */
+  fun isPermissionMissing(): Boolean = false
+
+  /**
+   * Explicitly prompts for the local-network permission, regardless of the server address.
+   * Intended for user-initiated flows (e.g. an "allow access" action in the cast device picker),
+   * so it bypasses the once-per-session throttle of [requestIfNeeded]; a permanent denial
+   * resolves immediately without UI. Returns `true` when access is available afterwards.
+   */
+  suspend fun request(): Boolean = true
 }

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/cast/CastController.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/cast/CastController.kt
@@ -3,6 +3,7 @@
 
 package app.campfire.audioplayer.cast
 
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 interface CastController {
@@ -10,17 +11,29 @@ interface CastController {
   val state: StateFlow<CastState>
   val availableDevices: StateFlow<List<CastDevice>>
 
+  /**
+   * True when discovering devices may require a platform permission the user hasn't granted
+   * (Android 16+ local network access). The device picker surfaces an opt-in action for it —
+   * the permission is never requested automatically.
+   */
+  val needsLocalNetworkPermission: StateFlow<Boolean> get() = MutableStateFlow(false)
+
   fun connect(device: CastDevice)
 
   /*
-   * Lifecycle hooks driven by the host Activity. Default no-ops so implementations on
-   * platforms (or build flavors) without cast support don't need to override them.
+   * Default no-ops so implementations on platforms (or build flavors) without cast
+   * support don't need to override them.
    */
 
-  fun initialize() {}
-  fun destroy() {}
-  fun scanForDevices() {}
-  fun stopScanningForDevices() {}
+  /**
+   * Requests intensive device discovery while the device picker is visible. Callers must pair
+   * every call with [stopActiveScan] when the picker closes — active scanning is expensive.
+   */
+  fun startActiveScan() {}
+  fun stopActiveScan() {}
+
+  /** User-initiated request for the permission reported by [needsLocalNetworkPermission]. */
+  fun requestLocalNetworkPermission() {}
 }
 
 enum class CastState {

--- a/infra/audioplayer/cast/build.gradle.kts
+++ b/infra/audioplayer/cast/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
         // relying on it arriving transitively through the cast framework.
         api(libs.androidx.mediarouter)
         api(libs.play.services.cast.framework)
+        implementation(libs.androidx.lifecycle.process)
         implementation(libs.media3.cast)
       }
     }

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastControllerInitializer.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastControllerInitializer.kt
@@ -1,0 +1,27 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.cast
+
+import app.campfire.core.app.AppInitializer
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.di.AppScope
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Hooks [MediaRouterCastController] into the app startup sequence so its process-lifecycle
+ * observation begins at launch, without the controller doing work at construction time.
+ */
+@ContributesMultibinding(AppScope::class)
+@Inject
+class CastControllerInitializer(
+  private val castController: MediaRouterCastController,
+  private val dispatcherProvider: DispatcherProvider,
+) : AppInitializer {
+
+  override suspend fun onInitialize() = withContext(dispatcherProvider.main) {
+    castController.initialize()
+  }
+}

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastRemotePlayerFactory.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastRemotePlayerFactory.kt
@@ -17,7 +17,9 @@ import me.tatarka.inject.annotations.Inject
 /**
  * Real [RemotePlayerFactory] contributed when this module is included in the build,
  * wrapping the local player in a media3 [CastPlayer] that handles local/remote switching
- * itself. Returns null on devices without the Play Services Cast module.
+ * itself. Returns null on devices without the Play Services Cast module, or when the
+ * async [CastContext][com.google.android.gms.cast.framework.CastContext] initialization
+ * hasn't completed yet (e.g. a cold start straight into the playback service).
  */
 @OptIn(UnstableApi::class)
 @ContributesBinding(AppScope::class)
@@ -25,8 +27,12 @@ import me.tatarka.inject.annotations.Inject
 class CastRemotePlayerFactory : RemotePlayerFactory {
 
   override fun create(context: Context, localPlayer: ExoPlayer): Player? {
-    return SafeCastContext.getContext(context)?.let {
-      CastPlayer.Builder(context)
+    // The application context, not the service: media3's Cast singleton retains this Context
+    // in a process-wide static for its lifetime.
+    val appContext = context.applicationContext
+    SafeCastContext.initialize(appContext)
+    return SafeCastContext.getIfReady()?.let {
+      CastPlayer.Builder(appContext)
         .setLocalPlayer(localPlayer)
         .build()
     }

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
@@ -4,25 +4,54 @@
 package app.campfire.audioplayer.impl.cast
 
 import android.app.Application
-import android.os.Bundle
 import androidx.annotation.MainThread
-import androidx.mediarouter.media.MediaControlIntent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.media3.cast.DefaultCastOptionsProvider
+import androidx.media3.common.util.UnstableApi
 import androidx.mediarouter.media.MediaRouteSelector
 import androidx.mediarouter.media.MediaRouter
 import androidx.mediarouter.media.MediaRouter.RouteInfo
 import app.campfire.audioplayer.cast.CastController
 import app.campfire.audioplayer.cast.CastDevice
 import app.campfire.audioplayer.cast.CastState
+import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
+import app.campfire.core.di.qualifier.ForScope
 import app.campfire.core.logging.Cork
-import app.campfire.core.logging.LogPriority
+import app.campfire.core.permission.LocalNetworkPermissionController
+import com.google.android.gms.cast.CastDevice as GmsCastDevice
+import com.google.android.gms.cast.CastMediaControlIntent
+import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.CastState as GoogleCastState
 import com.google.android.gms.cast.framework.CastStateListener
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
+/**
+ * Discovers Google Cast (and system output) routes and exposes them to the shared cast UI.
+ *
+ * Lifecycle is driven by [ProcessLifecycleOwner] rather than the host Activity: an app-scoped
+ * singleton torn down from `Activity.onStop`/`onDestroy` loses its MediaRouter callback on every
+ * configuration change, because the old activity's teardown runs *after* the new activity's
+ * startup and unregisters what was just registered.
+ *
+ * Discovery intensity follows the SDK's own UI conventions: passive
+ * [MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY] while the app is foregrounded, and
+ * [MediaRouter.CALLBACK_FLAG_PERFORM_ACTIVE_SCAN] only while the device picker is open. Active
+ * scans self-suppress after 30 seconds, so the picker re-registers the callback on a timer to
+ * keep the window fresh.
+ */
 @SingleIn(AppScope::class)
 @ContributesBinding(
   scope = AppScope::class,
@@ -32,6 +61,9 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class MediaRouterCastController(
   private val application: Application,
+  private val localNetworkPermission: LocalNetworkPermissionController,
+  private val dispatcherProvider: DispatcherProvider,
+  @ForScope(AppScope::class) private val applicationScope: CoroutineScope,
 ) : CastController,
   CastStateListener,
   MediaRouter.Callback(),
@@ -41,77 +73,181 @@ class MediaRouterCastController(
 
   override val state = MutableStateFlow(CastState.Unavailable)
   override val availableDevices = MutableStateFlow<List<CastDevice>>(emptyList())
+  override val needsLocalNetworkPermission = MutableStateFlow(false)
 
+  private var initialized = false
+  private var castContext: CastContext? = null
+  private var foregrounded = false
+  private var devicePickerOpen = false
+  private var activeScanRefreshJob: Job? = null
+
+  private val processLifecycleObserver = object : DefaultLifecycleObserver {
+    override fun onStart(owner: LifecycleOwner) {
+      foregrounded = true
+      SafeCastContext.initialize(application)
+      updateDiscovery()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+      foregrounded = false
+      updateDiscovery()
+    }
+  }
+
+  /**
+   * Called once at app startup by [CastControllerInitializer]. Registers the process-lifecycle
+   * observer that drives discovery from app foreground state.
+   */
   @MainThread
-  override fun initialize() {
-    try {
-      val castContext = SafeCastContext.getContext(application) ?: return
-      castContext.addCastStateListener(this)
+  fun initialize() {
+    if (initialized) return
+    initialized = true
 
-      // Emit the current state, if any
-      state.value = castContext.castState.asDomain()
-
-      ibark { "CastController:initialize(state = ${castContext.castState.asDomain()})" }
-    } catch (e: Throwable) {
-      wbark(throwable = e) { "Unable to initialize CastContext" }
+    needsLocalNetworkPermission.value = localNetworkPermission.isPermissionMissing()
+    ProcessLifecycleOwner.get().lifecycle.addObserver(processLifecycleObserver)
+    applicationScope.launch(dispatcherProvider.main) {
+      val context = SafeCastContext.castContext.filterNotNull().first()
+      onCastContextReady(context)
     }
   }
 
   @MainThread
-  override fun destroy() {
-    try {
-      SafeCastContext.getContext(application)?.removeCastStateListener(this)
-    } catch (e: Throwable) {
-      wbark(throwable = e) { "Failed to destroy CastContext" }
-    } finally {
-      state.value = CastState.Unavailable
-      availableDevices.value = emptyList()
-    }
-  }
-
-  @MainThread
-  override fun scanForDevices() {
-    try {
-      val selector = MediaRouteSelector.Builder()
-        .addControlCategory(MediaControlIntent.CATEGORY_LIVE_AUDIO)
-        .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_AUDIO_PLAYBACK)
-        .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
-        .build()
-
-      val mediaRouter = MediaRouter.getInstance(application)
-
-      mediaRouter.addCallback(selector, this, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY)
-
-      // Enumerate existing routes immediately so devices that are already
-      // available appear without waiting for a callback event.
-      updateDevices(mediaRouter)
-
-      ibark { "CastController:scanForDevices()" }
-    } catch (e: Throwable) {
-      wbark(throwable = e) { "Failed to start device scan" }
-    }
-  }
-
-  @MainThread
-  override fun stopScanningForDevices() {
-    try {
-      val mediaRouter = MediaRouter.getInstance(application)
-      mediaRouter.removeCallback(this)
-      ibark { "Stop scanning for devices" }
-    } catch (e: Throwable) {
-      wbark(throwable = e) { "Failed to stop scanning for devices" }
-    }
+  private fun onCastContextReady(context: CastContext) {
+    castContext = context
+    context.addCastStateListener(this)
+    state.value = context.castState.asDomain()
+    updateDiscovery()
+    ibark { "CastController:ready(state = ${context.castState.asDomain()})" }
   }
 
   override fun connect(device: CastDevice) {
     try {
-      val mediaRouteCastDevice = device as MediaRouterCastDevice
       val mediaRouter = MediaRouter.getInstance(application)
-      ibark { "Connecting route: ${mediaRouteCastDevice.route}" }
-      mediaRouter.selectRoute(mediaRouteCastDevice.route)
+      // Re-find the live route by id: MediaRouter silently ignores selection of a RouteInfo
+      // instance that is no longer in its current route list.
+      val route = mediaRouter.routes.find { it.id == device.id }
+      if (route == null) {
+        wbark { "Route ${device.id} is no longer available; ignoring connect request" }
+        return
+      }
+      ibark { "Connecting route: $route" }
+      mediaRouter.selectRoute(route)
     } catch (e: Throwable) {
       wbark(throwable = e) { "Failed to connect to device" }
     }
+  }
+
+  @MainThread
+  override fun startActiveScan() {
+    devicePickerOpen = true
+    needsLocalNetworkPermission.value = localNetworkPermission.isPermissionMissing()
+    activeScanRefreshJob?.cancel()
+    activeScanRefreshJob = applicationScope.launch(dispatcherProvider.main) {
+      while (isActive) {
+        updateDiscovery()
+        delay(ACTIVE_SCAN_REFRESH_MS)
+      }
+    }
+    ibark { "CastController:startActiveScan()" }
+  }
+
+  @MainThread
+  override fun stopActiveScan() {
+    devicePickerOpen = false
+    activeScanRefreshJob?.cancel()
+    activeScanRefreshJob = null
+    updateDiscovery()
+    ibark { "CastController:stopActiveScan()" }
+  }
+
+  override fun requestLocalNetworkPermission() {
+    applicationScope.launch(dispatcherProvider.main) {
+      localNetworkPermission.request()
+      val missing = localNetworkPermission.isPermissionMissing()
+      needsLocalNetworkPermission.value = missing
+      if (!missing) {
+        restartDiscovery()
+      }
+    }
+  }
+
+  /**
+   * Fully stops and restarts route discovery. Needed after the local-network permission is
+   * granted mid-session: enforcement happens per socket operation, so the cast module's mDNS
+   * sockets — created while access was denied, with failed multicast group joins — stay dead
+   * after the grant. Dropping every discovery request and cycling the receiver application id
+   * makes the Cast route provider tear down its scanner and recreate those sockets under the
+   * granted permission.
+   */
+  @OptIn(UnstableApi::class)
+  private suspend fun restartDiscovery() {
+    try {
+      activeScanRefreshJob?.cancel()
+      activeScanRefreshJob = null
+      MediaRouter.getInstance(application).removeCallback(this)
+
+      // No session can exist here (discovery was dead without the permission), so cycling the
+      // receiver id only affects the provider's discovery configuration.
+      castContext?.let { context ->
+        context.setReceiverApplicationId(CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID)
+        delay(DISCOVERY_RESTART_DELAY_MS)
+        context.setReceiverApplicationId(DefaultCastOptionsProvider.APP_ID_DEFAULT_RECEIVER_WITH_DRM)
+      }
+      delay(DISCOVERY_RESTART_DELAY_MS)
+
+      // In case CastContext initialization itself failed while the permission was missing
+      SafeCastContext.initialize(application)
+
+      if (devicePickerOpen) {
+        startActiveScan()
+      } else {
+        updateDiscovery()
+      }
+      ibark { "CastController:restartDiscovery()" }
+    } catch (e: Throwable) {
+      wbark(throwable = e) { "Failed to restart discovery after permission grant" }
+    }
+  }
+
+  /**
+   * Single point of (de)registration for the MediaRouter callback. Re-invoking
+   * [MediaRouter.addCallback] with the same callback updates its selector and flags in place.
+   */
+  @MainThread
+  private fun updateDiscovery() {
+    try {
+      val mediaRouter = MediaRouter.getInstance(application)
+      val context = castContext
+      if (context == null || !foregrounded) {
+        mediaRouter.removeCallback(this)
+        return
+      }
+
+      // The Cast route provider only reports devices for selectors containing its own
+      // category; the merged selector is the SDK's source of truth for that.
+      val selector = context.mergedSelector ?: defaultSelector()
+      val flags = if (devicePickerOpen) {
+        MediaRouter.CALLBACK_FLAG_PERFORM_ACTIVE_SCAN
+      } else {
+        MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY
+      }
+      mediaRouter.addCallback(selector, this, flags)
+
+      // Enumerate existing routes immediately so devices that are already
+      // available appear without waiting for a callback event.
+      updateDevices(mediaRouter)
+    } catch (e: Throwable) {
+      wbark(throwable = e) { "Failed to update device discovery" }
+    }
+  }
+
+  @OptIn(UnstableApi::class)
+  private fun defaultSelector(): MediaRouteSelector {
+    return MediaRouteSelector.Builder()
+      .addControlCategory(
+        CastMediaControlIntent.categoryForCast(DefaultCastOptionsProvider.APP_ID_DEFAULT_RECEIVER_WITH_DRM),
+      )
+      .build()
   }
 
   /*
@@ -140,12 +276,12 @@ class MediaRouterCastController(
       "CastController:onRouteSelected(device = ${selectedRoute.id}, reason = $reason, " +
         "requestedRoute = ${requestedRoute.id})"
     }
-    updateDevicesAndState(router)
+    updateDevices(router)
   }
 
   override fun onRouteUnselected(router: MediaRouter, route: RouteInfo, reason: Int) {
     ibark { "CastController:onRouteUnselected(device = ${route.id}, reason = $reason)" }
-    updateDevicesAndState(router)
+    updateDevices(router)
   }
 
   override fun onRouteAdded(
@@ -153,7 +289,7 @@ class MediaRouterCastController(
     route: RouteInfo,
   ) {
     ibark { "CastController:onRouteAdded(route = ${route.id})" }
-    updateDevicesAndState(router)
+    updateDevices(router)
   }
 
   override fun onRouteRemoved(
@@ -161,7 +297,7 @@ class MediaRouterCastController(
     route: RouteInfo,
   ) {
     ibark { "CastController:onRouteRemoved(route = ${route.id})" }
-    updateDevicesAndState(router)
+    updateDevices(router)
   }
 
   override fun onRouteChanged(
@@ -169,44 +305,20 @@ class MediaRouterCastController(
     route: RouteInfo,
   ) {
     ibark { "CastController:onRouteChanged(route = ${route.id})" }
-    updateDevicesAndState(router)
-  }
-
-  /**
-   * Update both the device list and derive connection state from
-   * the MediaRouter's selected route so non-Cast devices (Bluetooth,
-   * wired headphones, etc.) are accurately reflected.
-   */
-  private fun updateDevicesAndState(router: MediaRouter) {
     updateDevices(router)
-
-    val selected = router.selectedRoute
-    if (!selected.isDefaultOrBluetooth()) {
-      // A non-default, non-system route is selected – treat as connected
-      state.value = CastState.Connected
-    }
-    // Otherwise let the CastStateListener drive the state value
   }
 
   private fun updateDevices(router: MediaRouter) {
-    val selectedRouteId = router.selectedRoute.id
+    val selectedRoute = router.selectedRoute
+    val selectedCastDeviceId = selectedRoute.castDeviceId
 
     availableDevices.value = router.routes
       .filter { it.isEnabled }
-      .filter { it.description != "Google Cast Multizone Member" }
-      .filter { route ->
-        val extras: Bundle? = route.extras
-        if (extras != null) {
-          try {
-            if (extras.getString("com.google.android.gms.cast.EXTRA_SESSION_ID") != null) {
-              return@filter false
-            }
-          } catch (t: Throwable) {
-            bark(LogPriority.ERROR, throwable = t) { "Unable to find class for EXTRA_SESSION_ID" }
-          }
-        }
-        true
-      }
+      .filter { it.description != MULTIZONE_MEMBER_DESCRIPTION }
+      // The Cast provider publishes an extra session-scoped route for a connected device
+      // alongside the device's own route; drop the duplicate.
+      .filter { route -> route.extras?.getString(EXTRA_SESSION_ID) == null }
+      .distinctBy { route -> route.castDeviceId ?: route.id }
       .sortedBy {
         when {
           it.isSystemRoute -> 0
@@ -214,8 +326,33 @@ class MediaRouterCastController(
         }
       }
       .map { route ->
-        MediaRouterCastDevice(route, isSelected = route.id == selectedRouteId)
+        // Selection may land on the session-scoped duplicate we filtered out, so match the
+        // underlying device by its Cast device id as well as by route id.
+        val isSelected = route.id == selectedRoute.id ||
+          (selectedCastDeviceId != null && route.castDeviceId == selectedCastDeviceId)
+        MediaRouterCastDevice(route, isSelected = isSelected)
       }
+  }
+
+  private val RouteInfo.castDeviceId: String?
+    get() = try {
+      GmsCastDevice.getFromBundle(extras ?: return null)?.deviceId
+    } catch (t: Throwable) {
+      null
+    }
+
+  companion object {
+    private const val EXTRA_SESSION_ID = "com.google.android.gms.cast.EXTRA_SESSION_ID"
+    private const val MULTIZONE_MEMBER_DESCRIPTION = "Google Cast Multizone Member"
+
+    // Active scans are suppressed 30s after registration
+    // (MediaRouterActiveScanThrottlingHelper.MAX_ACTIVE_SCAN_DURATION_MS); re-register
+    // just under that to keep scanning while the picker stays open.
+    private const val ACTIVE_SCAN_REFRESH_MS = 25_000L
+
+    // Propagation window for an empty discovery request / receiver-id change to reach the
+    // Cast route provider before discovery is re-registered.
+    private const val DISCOVERY_RESTART_DELAY_MS = 500L
   }
 }
 

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/SafeCastContext.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/SafeCastContext.kt
@@ -4,42 +4,82 @@
 package app.campfire.audioplayer.impl.cast
 
 import android.content.Context
+import androidx.annotation.MainThread
 import app.campfire.core.logging.LogPriority
 import app.campfire.core.logging.bark
 import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.ModuleUnavailableException
-import kotlin.concurrent.atomics.AtomicBoolean
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import java.util.concurrent.Executors
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
-@OptIn(ExperimentalAtomicApi::class)
+/**
+ * Owns the async, Task-based initialization of the shared [CastContext]. The synchronous
+ * `CastContext.getSharedInstance(Context)` overload is deprecated and blocks the main thread on
+ * IPC + dex-loading of the Play services cast module (a documented ANR source), so all access
+ * goes through the async overload and consumers observe [castContext] for readiness.
+ *
+ * Only [ModuleUnavailableException] locks the feature out for the process — the device has no
+ * usable cast module. Any other failure (e.g. Play services mid-update at cold start) is
+ * transient: the next [initialize] call retries.
+ */
 object SafeCastContext {
 
-  private var isUnavailable = AtomicBoolean(false)
+  private val _castContext = MutableStateFlow<CastContext?>(null)
+
+  /** Emits the shared [CastContext] once the Play services cast module has loaded. */
+  val castContext: StateFlow<CastContext?> = _castContext.asStateFlow()
+
+  private var moduleUnavailable = false
+  private var initializing = false
 
   /**
-   * Attempt to get the current [CastContext], and returning null
-   * if it fails
+   * Starts (or retries) async initialization. Safe to call repeatedly; no-ops while an attempt
+   * is in flight, once initialized, or after the cast module was found to be missing entirely.
    */
-  fun getContext(context: Context): CastContext? {
-    // If we've already determined that this device doesn't have the
-    // Cast module (i.e. PlayServices) installed then short circuit.
-    if (isUnavailable.load()) return null
+  @MainThread
+  fun initialize(context: Context) {
+    if (_castContext.value != null || moduleUnavailable || initializing) return
+    initializing = true
 
-    return try {
-      CastContext.getSharedInstance(context)
-    } catch (e: ModuleUnavailableException) {
-      isUnavailable.store(true)
+    try {
+      val moduleLoadExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "CastContextInit").apply { isDaemon = true }
+      }
+      CastContext.getSharedInstance(context.applicationContext, moduleLoadExecutor)
+        .addOnCompleteListener { task ->
+          moduleLoadExecutor.shutdown()
+          initializing = false
+          if (task.isSuccessful) {
+            _castContext.value = task.result
+          } else {
+            onInitializationFailed(task.exception)
+          }
+        }
+    } catch (e: Throwable) {
+      initializing = false
+      onInitializationFailed(e)
+    }
+  }
+
+  /** The shared [CastContext] if initialization has completed, without waiting. */
+  fun getIfReady(): CastContext? = _castContext.value
+
+  private fun onInitializationFailed(error: Throwable?) {
+    val isModuleUnavailable = generateSequence(error) { it.cause }
+      .any { it is ModuleUnavailableException }
+    if (isModuleUnavailable) {
+      moduleUnavailable = true
       bark(
         LogPriority.WARN,
-        throwable = e,
+        throwable = error,
       ) { "PlayServices Cast module is unavailable, locking the feature out for the session" }
-      null
-    } catch (e: Exception) {
+    } else {
       bark(
         LogPriority.ERROR,
-        throwable = e,
-      ) { "Unable to get CastContext" }
-      null
+        throwable = error,
+      ) { "Unable to initialize CastContext; will retry on the next attempt" }
     }
   }
 }

--- a/infra/audioplayer/impl/build.gradle.kts
+++ b/infra/audioplayer/impl/build.gradle.kts
@@ -74,6 +74,7 @@ kotlin {
         implementation(libs.media3.exoplayer.hls)
         implementation(libs.media3.session)
         implementation(libs.androidx.lifecycle.runtime)
+        implementation(libs.androidx.lifecycle.process)
         implementation(libs.androidx.activity.compose)
         implementation(libs.kotlinx.coroutines.guava)
         implementation(libs.coil)

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaControllerConnector.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaControllerConnector.kt
@@ -5,7 +5,11 @@ package app.campfire.audioplayer.impl
 
 import android.app.Application
 import android.content.ComponentName
+import androidx.annotation.MainThread
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import app.campfire.core.di.AppScope
@@ -22,6 +26,10 @@ import me.tatarka.inject.annotations.Inject
  * for any audio playback session. This is how you spool up, and down, the androidx media3 [AudioPlayerService]
  * for creating our [androidx.media3.exoplayer.ExoPlayer] instance and attaching all the media session
  * related integrations to get playback via notifications, watch, etc.
+ *
+ * Connection follows [ProcessLifecycleOwner] rather than the host Activity: activity recreation
+ * runs the old activity's `onStop` after the new activity's `onStart`, which would release the
+ * controller the new activity just acquired.
  */
 @SingleIn(AppScope::class)
 @Inject
@@ -31,24 +39,46 @@ class MediaControllerConnector(private val application: Application) {
 
   private var controllerFuture: ListenableFuture<MediaController>? = null
 
+  private var initialized = false
+
+  private val processLifecycleObserver = object : DefaultLifecycleObserver {
+    override fun onStart(owner: LifecycleOwner) = connect()
+    override fun onStop(owner: LifecycleOwner) = disconnect()
+  }
+
+  /**
+   * Called once at app startup by [MediaControllerConnectorInitializer]. Registers the
+   * process-lifecycle observer that connects/disconnects with app foreground state.
+   */
+  @MainThread
+  fun initialize() {
+    if (initialized) return
+    initialized = true
+    ProcessLifecycleOwner.get().lifecycle.addObserver(processLifecycleObserver)
+  }
+
   fun connect() {
+    if (controllerFuture != null) return
     ibark { "~~> Requesting new MediaController connection" }
 
     // Create new token and build new controller
     val sessionToken = SessionToken(application, ComponentName(application, AudioPlayerService::class.java))
-    controllerFuture = MediaController.Builder(application, sessionToken).buildAsync()
-    controllerFuture!!.addListener(
+    val future = MediaController.Builder(application, sessionToken).buildAsync()
+    controllerFuture = future
+    future.addListener(
       {
         try {
-          mediaControllerFlow.value = controllerFuture!!.get().also {
+          mediaControllerFlow.value = future.get().also {
             ibark { "<-- Acquired MediaController ($it)" }
           }
         } catch (e: CancellationException) {
           ebark(throwable = e) { "MediaController connection was cancelled" }
         } catch (e: ExecutionException) {
           ebark(throwable = e) { "MediaController connection threw an exception" }
+          if (controllerFuture === future) controllerFuture = null
         } catch (e: InterruptedException) {
           ebark(throwable = e) { "MediaController connection was interrupted" }
+          if (controllerFuture === future) controllerFuture = null
         }
       },
       ContextCompat.getMainExecutor(application),
@@ -58,6 +88,7 @@ class MediaControllerConnector(private val application: Application) {
   fun disconnect() {
     ibark { "<!-- Disposing of media controller" }
     controllerFuture?.let { MediaController.releaseFuture(it) }
+    controllerFuture = null
     mediaControllerFlow.value?.release()
     mediaControllerFlow.value = null
   }

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaControllerConnectorInitializer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaControllerConnectorInitializer.kt
@@ -1,0 +1,27 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl
+
+import app.campfire.core.app.AppInitializer
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.di.AppScope
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import kotlinx.coroutines.withContext
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Hooks [MediaControllerConnector] into the app startup sequence so its process-lifecycle
+ * observation begins at launch, without the connector doing work at construction time.
+ */
+@ContributesMultibinding(AppScope::class)
+@Inject
+class MediaControllerConnectorInitializer(
+  private val connector: MediaControllerConnector,
+  private val dispatcherProvider: DispatcherProvider,
+) : AppInitializer {
+
+  override suspend fun onInitialize() = withContext(dispatcherProvider.main) {
+    connector.initialize()
+  }
+}

--- a/infra/audioplayer/public-ui/src/commonMain/composeResources/values/audioplayer_ui_strings.xml
+++ b/infra/audioplayer/public-ui/src/commonMain/composeResources/values/audioplayer_ui_strings.xml
@@ -9,6 +9,8 @@
   <string name="label_connecting">Connecting…</string>
   <string name="media_route_dialog_title">Devices</string>
   <string name="action_cast">Cast</string>
+  <string name="action_allow_local_network">Allow local network access</string>
+  <string name="label_local_network_rationale">Needed to find cast devices on your network</string>
 
   <string name="option_shake_to_reset_title">Shake-to-reset</string>
   <string name="option_shake_to_reset_subtitle">Enable shaking to reset the current or previous timer</string>

--- a/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
+++ b/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -72,14 +73,17 @@ import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Cast
 import app.campfire.common.compose.icons.rounded.CastConnected
 import app.campfire.common.compose.icons.rounded.CastConnecting
+import app.campfire.common.compose.icons.rounded.CastWarning
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.util.withDensity
 import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.core.di.AppScope
 import app.campfire.core.extensions.fluentIf
 import campfire.infra.audioplayer.public_ui.generated.resources.Res
+import campfire.infra.audioplayer.public_ui.generated.resources.action_allow_local_network
 import campfire.infra.audioplayer.public_ui.generated.resources.action_cast
 import campfire.infra.audioplayer.public_ui.generated.resources.label_connecting
+import campfire.infra.audioplayer.public_ui.generated.resources.label_local_network_rationale
 import campfire.infra.audioplayer.public_ui.generated.resources.media_route_dialog_title
 import coil3.compose.AsyncImage
 import com.r0adkll.kimchi.annotations.ContributesTo
@@ -125,8 +129,23 @@ fun CastButton(
   }
 
   if (showDevices) {
+    // Intensive discovery only while the picker is visible; the controller keeps the
+    // active-scan window fresh until this leaves composition.
+    DisposableEffect(component) {
+      component.castController.startActiveScan()
+      onDispose { component.castController.stopActiveScan() }
+    }
+
+    val needsLocalNetworkPermission by remember(component) {
+      component.castController.needsLocalNetworkPermission
+    }.collectAsState()
+
     CastDevices(
       devices = devices,
+      showLocalNetworkPermission = needsLocalNetworkPermission,
+      onRequestLocalNetworkPermission = {
+        component.castController.requestLocalNetworkPermission()
+      },
       onDeviceClick = { device ->
         component.castController.connect(device)
         showDevices = false
@@ -242,6 +261,8 @@ private fun CurrentDeviceButton(
 @Composable
 private fun CastDevices(
   devices: List<CastDevice>,
+  showLocalNetworkPermission: Boolean,
+  onRequestLocalNetworkPermission: () -> Unit,
   onDeviceClick: (CastDevice) -> Unit,
   onDismissRequest: () -> Unit,
 ) {
@@ -294,6 +315,8 @@ private fun CastDevices(
       ) {
         CastDevicesCard(
           devices = devices,
+          showLocalNetworkPermission = showLocalNetworkPermission,
+          onRequestLocalNetworkPermission = onRequestLocalNetworkPermission,
           onDeviceClick = onDeviceClick,
           onDismissRequest = onDismissRequest,
         )
@@ -305,6 +328,8 @@ private fun CastDevices(
 @Composable
 private fun CastDevicesCard(
   devices: List<CastDevice>,
+  showLocalNetworkPermission: Boolean,
+  onRequestLocalNetworkPermission: () -> Unit,
   onDeviceClick: (CastDevice) -> Unit,
   onDismissRequest: () -> Unit,
   modifier: Modifier = Modifier,
@@ -345,6 +370,71 @@ private fun CastDevicesCard(
           onClick = {
             onDeviceClick(device)
           },
+        )
+      }
+
+      if (showLocalNetworkPermission) {
+        item(key = "local_network_permission") {
+          LocalNetworkPermissionListItem(
+            onClick = onRequestLocalNetworkPermission,
+          )
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Opt-in action shown when finding cast devices may require the platform's local network
+ * permission. Never triggered automatically — the user chooses to grant it from here.
+ */
+@Composable
+private fun LocalNetworkPermissionListItem(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val shape = RoundedCornerShape(16.dp)
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .clip(shape)
+      .border(
+        width = 1.dp,
+        color = MaterialTheme.colorScheme.outlineVariant,
+        shape = shape,
+      )
+      .clickable(onClick = onClick),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    CompositionLocalProvider(
+      LocalContentColor provides MaterialTheme.colorScheme.onSurfaceVariant,
+    ) {
+      Box(
+        modifier = Modifier
+          .padding(16.dp),
+      ) {
+        Icon(
+          CampfireIcons.Rounded.CastWarning,
+          contentDescription = null,
+        )
+      }
+
+      Column(
+        modifier = Modifier
+          .weight(1f)
+          .padding(
+            end = 16.dp,
+            top = 8.dp,
+            bottom = 8.dp,
+          ),
+      ) {
+        Text(
+          text = stringResource(Res.string.action_allow_local_network),
+          style = MaterialTheme.typography.titleMedium,
+        )
+        Text(
+          text = stringResource(Res.string.label_local_network_rationale),
+          style = MaterialTheme.typography.labelSmall,
         )
       }
     }


### PR DESCRIPTION
## Summary

Phase 1 of the Cast overhaul (see the [root-cause analysis](https://claude.ai/code/artifact/d862e987-57f1-4c1a-9a27-cc5adae02d44)): makes device discovery actually work. The handoff hang (receiver auth, session brokering, chapter mapping) is Phase 2.

### Discovery was broken by design
- **Wrong selector**: `MediaRouterCastController` subscribed with generic `MediaControlIntent` categories that no Cast route matches — devices only leaked in via the system output-switcher provider, which is why they appeared intermittently. Discovery now uses `CastContext.getMergedSelector()` (the SDK's source of truth), with a fallback selector for the media3 default receiver.
- **Lifecycle inversion**: the `AppScope` singleton controller was driven by `MainActivity`, and recreation order (`new.onStart` → `old.onStop` → `old.onDestroy`) meant every rotation/config change unregistered the freshly-registered MediaRouter callback and hard-reset state to `Unavailable`, hiding the cast button until process restart. The controller (and `MediaControllerConnector`, which had the same inversion) now follows `ProcessLifecycleOwner`, wired through the existing `AppInitializer` startup sequence instead of construction-time side effects, using the injected app-scoped `CoroutineScope`.
- **Scan intensity**: passive `CALLBACK_FLAG_REQUEST_DISCOVERY` while foregrounded; `CALLBACK_FLAG_PERFORM_ACTIVE_SCAN` only while the device picker is open, re-registered inside MediaRouter's 30-second active-scan suppression window.
- **Blocking init**: the deprecated synchronous `CastContext.getSharedInstance` (documented ANR source) is replaced with the async Task API. Only `ModuleUnavailableException` locks cast out for the session; transient failures (Play services mid-update) retry.

### Honest state & device list
- `CastState` now derives only from `CastStateListener` — no more fabricating `Connected` from any non-default route selection.
- The connected device stays in the list (matched by Cast device id across the session-scoped duplicate route) instead of being filtered out; routes dedupe by device id.
- `connect()` re-finds the live route by id, since MediaRouter silently ignores stale `RouteInfo` instances.

### Android 16 local network permission (opt-in, never auto-prompted)
Cast discovery is LAN-bound regardless of where the ABS server lives, but the permission is only requested automatically for private server URLs. The device picker now shows an opt-in row ("Allow local network access") when the permission may be needed. On grant, discovery is fully restarted — callback dropped, receiver app id cycled — so the cast module recreates the mDNS sockets it built while access was denied (a runtime grant doesn't repair sockets whose multicast joins already failed).

### Misc
- `CastPlayer.Builder` gets `applicationContext` so the playback service instance no longer leaks into a process-wide GMS static.

## Testing
- `./gradlew test` passes; `alphaDebug`, `fossDebug`, and desktop compile
- ktlint clean

Most changes are `androidMain` platform code with no host-test coverage, so this will likely need the `skip-coverage` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)