### PR TITLE
Broker Cast sessions and fall back to local playback on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - App widgets breaking due to large image size
 - Cast devices not appearing reliably, including the cast button vanishing after rotating the screen
+- Selecting a cast device could hang audio playback until the app was restarted — connection failures now show in the device picker and playback automatically falls back to this phone
 
 ### Other Notes & Contributions
 

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/cast/CastController.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/cast/CastController.kt
@@ -18,7 +18,17 @@ interface CastController {
    */
   val needsLocalNetworkPermission: StateFlow<Boolean> get() = MutableStateFlow(false)
 
+  /**
+   * The in-flight or failed attempt to connect to a device that [CastDevice.requiresSession],
+   * or null when no attempt is pending. Cleared to null on success; a [ConnectionAttempt.Status.Failed]
+   * value persists until the next attempt or until the device picker closes.
+   */
+  val connectionAttempt: StateFlow<ConnectionAttempt?> get() = MutableStateFlow(null)
+
   fun connect(device: CastDevice)
+
+  /** Ends the active cast session, if any, returning playback to this device. */
+  fun disconnect() {}
 
   /*
    * Default no-ops so implementations on platforms (or build flavors) without cast
@@ -44,6 +54,16 @@ enum class CastState {
   Unavailable,
 }
 
+data class ConnectionAttempt(
+  val deviceId: String,
+  val status: Status,
+) {
+  enum class Status {
+    Connecting,
+    Failed,
+  }
+}
+
 abstract class CastDevice(
   val id: String,
   val name: String,
@@ -51,6 +71,12 @@ abstract class CastDevice(
   val iconUri: String?,
   val type: Type,
   val isSelected: Boolean,
+  /**
+   * True when connecting to this device is asynchronous (a Google Cast session must be
+   * established) rather than an instant output switch (Bluetooth, built-in speaker). The
+   * picker keeps itself open and shows progress for these via [CastController.connectionAttempt].
+   */
+  val requiresSession: Boolean = false,
 ) {
 
   override fun toString(): String {

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastOptionsProvider.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastOptionsProvider.kt
@@ -23,6 +23,12 @@ class CastOptionsProvider : OptionsProvider {
           .setNotificationOptions(null)
           .build(),
       )
+      // Match media3's DefaultCastOptionsProvider: media3 owns playback state, so saved-session
+      // resume and the GMS reconnection service only resurrect sessions it doesn't know about.
+      .setResumeSavedSession(false)
+      .setEnableReconnectionService(false)
+      .setRemoteToLocalEnabled(true)
+      .setStopReceiverApplicationWhenEndingSession(true)
       .build()
   }
 

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
@@ -8,6 +8,7 @@ import androidx.annotation.MainThread
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.media3.cast.Cast as Media3Cast
 import androidx.media3.cast.DefaultCastOptionsProvider
 import androidx.media3.common.util.UnstableApi
 import androidx.mediarouter.media.MediaRouteSelector
@@ -16,6 +17,7 @@ import androidx.mediarouter.media.MediaRouter.RouteInfo
 import app.campfire.audioplayer.cast.CastController
 import app.campfire.audioplayer.cast.CastDevice
 import app.campfire.audioplayer.cast.CastState
+import app.campfire.audioplayer.cast.ConnectionAttempt
 import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
@@ -24,9 +26,12 @@ import app.campfire.core.logging.Cork
 import app.campfire.core.permission.LocalNetworkPermissionController
 import com.google.android.gms.cast.CastDevice as GmsCastDevice
 import com.google.android.gms.cast.CastMediaControlIntent
+import com.google.android.gms.cast.CastStatusCodes
 import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.CastState as GoogleCastState
 import com.google.android.gms.cast.framework.CastStateListener
+import com.google.android.gms.cast.framework.SessionManagerListener
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -52,6 +57,7 @@ import me.tatarka.inject.annotations.Inject
  * scans self-suppress after 30 seconds, so the picker re-registers the callback on a timer to
  * keep the window fresh.
  */
+@OptIn(UnstableApi::class)
 @SingleIn(AppScope::class)
 @ContributesBinding(
   scope = AppScope::class,
@@ -74,12 +80,16 @@ class MediaRouterCastController(
   override val state = MutableStateFlow(CastState.Unavailable)
   override val availableDevices = MutableStateFlow<List<CastDevice>>(emptyList())
   override val needsLocalNetworkPermission = MutableStateFlow(false)
+  override val connectionAttempt = MutableStateFlow<ConnectionAttempt?>(null)
 
   private var initialized = false
   private var castContext: CastContext? = null
   private var foregrounded = false
   private var devicePickerOpen = false
   private var activeScanRefreshJob: Job? = null
+
+  private var connectListener: SessionManagerListener<CastSession>? = null
+  private var connectTimeoutJob: Job? = null
 
   private val processLifecycleObserver = object : DefaultLifecycleObserver {
     override fun onStart(owner: LifecycleOwner) {
@@ -120,6 +130,7 @@ class MediaRouterCastController(
     ibark { "CastController:ready(state = ${context.castState.asDomain()})" }
   }
 
+  @MainThread
   override fun connect(device: CastDevice) {
     try {
       val mediaRouter = MediaRouter.getInstance(application)
@@ -128,13 +139,146 @@ class MediaRouterCastController(
       val route = mediaRouter.routes.find { it.id == device.id }
       if (route == null) {
         wbark { "Route ${device.id} is no longer available; ignoring connect request" }
+        if (device.requiresSession) {
+          connectionAttempt.value = ConnectionAttempt(device.id, ConnectionAttempt.Status.Failed)
+        }
         return
       }
       ibark { "Connecting route: $route" }
-      mediaRouter.selectRoute(route)
+      if (device.requiresSession) {
+        connectToCastRoute(device.id, route)
+      } else {
+        // Instant output switches (this phone, Bluetooth, …). Moving off a cast route also
+        // ends the active session, if any.
+        if (route.isDefault) disconnect()
+        mediaRouter.selectRoute(route)
+      }
     } catch (e: Throwable) {
       wbark(throwable = e) { "Failed to connect to device" }
+      if (device.requiresSession) {
+        connectionAttempt.value = ConnectionAttempt(device.id, ConnectionAttempt.Status.Failed)
+      }
     }
+  }
+
+  @MainThread
+  override fun disconnect() {
+    try {
+      cleanupConnectionAttempt()
+      connectionAttempt.value = null
+      // stopCasting = true: also stop the receiver app, mirroring
+      // setStopReceiverApplicationWhenEndingSession in CastOptionsProvider
+      Media3Cast.getSingletonInstance(application).endCurrentSession(true)
+    } catch (e: Throwable) {
+      wbark(throwable = e) { "Failed to end cast session" }
+    }
+  }
+
+  /**
+   * Establishes a Cast session for [route]. Route selection is only the trigger — the Cast
+   * SDK's SessionManager observes MediaRouter selection and drives the session, so success and
+   * failure are read from a one-shot [SessionManagerListener]. Retry policy follows
+   * jellyfin-android's battle-tested ChromecastConnection: transient network/timeout start
+   * failures and ghost ended-before-started events are retried by re-selecting the live route.
+   */
+  @MainThread
+  private fun connectToCastRoute(deviceId: String, route: RouteInfo) {
+    cleanupConnectionAttempt()
+    connectionAttempt.value = ConnectionAttempt(deviceId, ConnectionAttempt.Status.Connecting)
+
+    val mediaCast = Media3Cast.getSingletonInstance(application)
+
+    // When switching devices mid-session, SessionManager ends the current session before
+    // starting the new one; that end event must not count against the new attempt.
+    val previousSessionId = mediaCast.currentCastSession?.sessionId
+
+    var startFailureRetries = 0
+    var endedBeforeStartRetries = 0
+
+    val listener = object : SessionManagerListener<CastSession> {
+      override fun onSessionStarted(session: CastSession, sessionId: String) = succeedConnection()
+      override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) = succeedConnection()
+
+      override fun onSessionStartFailed(session: CastSession, error: Int) {
+        val retryable = error == CastStatusCodes.NETWORK_ERROR || error == CastStatusCodes.TIMEOUT
+        if (retryable && startFailureRetries < MAX_START_FAILURE_RETRIES) {
+          startFailureRetries++
+          wbark { "Cast session start failed (error=$error), retrying ($startFailureRetries)" }
+          reselectRoute(deviceId)
+        } else {
+          failConnection(deviceId, "session start failed (error=$error)")
+        }
+      }
+
+      override fun onSessionResumeFailed(session: CastSession, error: Int) {
+        failConnection(deviceId, "session resume failed (error=$error)")
+      }
+
+      override fun onSessionEnded(session: CastSession, error: Int) {
+        if (session.sessionId != null && session.sessionId == previousSessionId) return
+        if (endedBeforeStartRetries < MAX_ENDED_BEFORE_START_RETRIES) {
+          endedBeforeStartRetries++
+          wbark { "Cast session ended before starting, retrying ($endedBeforeStartRetries)" }
+          reselectRoute(deviceId)
+        } else {
+          failConnection(deviceId, "session repeatedly ended before starting")
+        }
+      }
+
+      override fun onSessionStarting(session: CastSession) = Unit
+      override fun onSessionEnding(session: CastSession) = Unit
+      override fun onSessionResuming(session: CastSession, sessionId: String) = Unit
+      override fun onSessionSuspended(session: CastSession, reason: Int) = Unit
+    }
+
+    connectListener = listener
+    mediaCast.addSessionManagerListener(listener)
+
+    connectTimeoutJob = applicationScope.launch(dispatcherProvider.main) {
+      delay(CONNECT_TIMEOUT_MS)
+      failConnection(deviceId, "timed out after ${CONNECT_TIMEOUT_MS}ms")
+    }
+
+    MediaRouter.getInstance(application).selectRoute(route)
+  }
+
+  @MainThread
+  private fun reselectRoute(deviceId: String) {
+    val mediaRouter = MediaRouter.getInstance(application)
+    val route = mediaRouter.routes.find { it.id == deviceId }
+    if (route != null) {
+      mediaRouter.selectRoute(route)
+    } else {
+      failConnection(deviceId, "route disappeared during retry")
+    }
+  }
+
+  @MainThread
+  private fun succeedConnection() {
+    ibark { "Cast session established" }
+    cleanupConnectionAttempt()
+    connectionAttempt.value = null
+  }
+
+  @MainThread
+  private fun failConnection(deviceId: String, reason: String) {
+    wbark { "Cast connect failed: $reason" }
+    cleanupConnectionAttempt()
+    connectionAttempt.value = ConnectionAttempt(deviceId, ConnectionAttempt.Status.Failed)
+  }
+
+  @MainThread
+  private fun cleanupConnectionAttempt() {
+    connectTimeoutJob?.cancel()
+    connectTimeoutJob = null
+    connectListener?.let { listener ->
+      try {
+        Media3Cast.getSingletonInstance(application).removeSessionManagerListener(listener)
+      } catch (e: Throwable) {
+        wbark(throwable = e) { "Failed to remove session manager listener" }
+      }
+    }
+    connectListener = null
   }
 
   @MainThread
@@ -156,6 +300,10 @@ class MediaRouterCastController(
     devicePickerOpen = false
     activeScanRefreshJob?.cancel()
     activeScanRefreshJob = null
+    // A failure message is only meaningful while the picker is showing it
+    if (connectionAttempt.value?.status == ConnectionAttempt.Status.Failed) {
+      connectionAttempt.value = null
+    }
     updateDiscovery()
     ibark { "CastController:stopActiveScan()" }
   }
@@ -328,9 +476,14 @@ class MediaRouterCastController(
       .map { route ->
         // Selection may land on the session-scoped duplicate we filtered out, so match the
         // underlying device by its Cast device id as well as by route id.
+        val castDeviceId = route.castDeviceId
         val isSelected = route.id == selectedRoute.id ||
-          (selectedCastDeviceId != null && route.castDeviceId == selectedCastDeviceId)
-        MediaRouterCastDevice(route, isSelected = isSelected)
+          (selectedCastDeviceId != null && castDeviceId == selectedCastDeviceId)
+        MediaRouterCastDevice(
+          route = route,
+          isSelected = isSelected,
+          requiresSession = castDeviceId != null,
+        )
       }
   }
 
@@ -353,12 +506,17 @@ class MediaRouterCastController(
     // Propagation window for an empty discovery request / receiver-id change to reach the
     // Cast route provider before discovery is re-registered.
     private const val DISCOVERY_RESTART_DELAY_MS = 500L
+
+    private const val CONNECT_TIMEOUT_MS = 15_000L
+    private const val MAX_START_FAILURE_RETRIES = 3
+    private const val MAX_ENDED_BEFORE_START_RETRIES = 10
   }
 }
 
 class MediaRouterCastDevice(
   internal val route: RouteInfo,
   isSelected: Boolean,
+  requiresSession: Boolean,
 ) : CastDevice(
   id = route.id,
   name = route.name,
@@ -366,6 +524,7 @@ class MediaRouterCastDevice(
   iconUri = route.iconUri?.toString(),
   type = route.deviceType.asType(),
   isSelected = isSelected,
+  requiresSession = requiresSession,
 )
 
 private fun Int.asDomain(): CastState = when (this) {

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -25,6 +25,7 @@ import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.OnFinishedListener
+import app.campfire.audioplayer.cast.CastController
 import app.campfire.audioplayer.history.PlaybackHistoryRecorder
 import app.campfire.audioplayer.impl.forwarding.PlaybackHistoryForwardingPlayer
 import app.campfire.audioplayer.impl.forwarding.RemoteControlForwardingPlayer
@@ -42,7 +43,10 @@ import app.campfire.core.logging.Cork
 import app.campfire.core.logging.Corked
 import app.campfire.core.model.Session
 import app.campfire.core.model.loggableId
+import app.campfire.core.toast.GlobalToaster
+import app.campfire.core.toast.Toast
 import app.campfire.crashreporting.CrashReporter
+import app.campfire.infra.audioplayer.impl.R
 import app.campfire.settings.api.PlaybackSettings
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -58,7 +62,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import me.tatarka.inject.annotations.Inject
+
+// The remote cast player surfaces no PlaybackException for receiver-side failures, so dead
+// handoffs and vanished receivers are detected by deadline instead (see armCastWatchdog).
+private const val CAST_HANDOFF_READY_TIMEOUT_MS = 20_000L
+private const val CAST_STALL_TIMEOUT_MS = 30_000L
+private const val CAST_FALLBACK_SWAP_TIMEOUT_MS = 5_000L
 
 @OptIn(UnstableApi::class)
 class ExoPlayerAudioPlayer(
@@ -66,6 +77,7 @@ class ExoPlayerAudioPlayer(
   private val settings: PlaybackSettings,
   private val sleepTimerManagerFactory: SleepTimerManager.Factory,
   private val playbackHistoryRecorder: PlaybackHistoryRecorder,
+  private val castController: CastController,
   private val mediaSourceFactory: MediaSource.Factory = DefaultMediaSourceFactory(context),
   private val remotePlayerFactory: RemotePlayerFactory = RemotePlayerFactory.NoOp,
 ) : AudioPlayer, Player.Listener, Cork {
@@ -82,6 +94,7 @@ class ExoPlayerAudioPlayer(
     private val mediaSourceFactory: MediaSource.Factory,
     private val sleepTimerManagerFactory: SleepTimerManager.Factory,
     private val playbackHistoryRecorder: PlaybackHistoryRecorder,
+    private val castController: CastController,
     // Defaults to NoOp when the optional :infra:audioplayer:cast module isn't in this build.
     private val remotePlayerFactory: RemotePlayerFactory = RemotePlayerFactory.NoOp,
   ) {
@@ -93,6 +106,7 @@ class ExoPlayerAudioPlayer(
         mediaSourceFactory = mediaSourceFactory,
         playbackHistoryRecorder = playbackHistoryRecorder,
         sleepTimerManagerFactory = sleepTimerManagerFactory,
+        castController = castController,
         remotePlayerFactory = remotePlayerFactory,
       )
     }
@@ -181,6 +195,8 @@ class ExoPlayerAudioPlayer(
   private var progressJob: Job? = null
   private var fadeJob: Job? = null
   private var previousVolumeLevel: Float = 0f
+  private var isRemotePlayback = false
+  private var castWatchdogJob: Job? = null
 
   override var preparedSession: Session? = null
   private var finishedListener: OnFinishedListener? = null
@@ -405,6 +421,10 @@ class ExoPlayerAudioPlayer(
   }
 
   override fun seekTo(timestamp: Duration) {
+    seekTo(timestamp, play = true)
+  }
+
+  private fun seekTo(timestamp: Duration, play: Boolean) {
     val timestampInMillis = timestamp.inWholeMilliseconds
     var mediaItemOffsetMs = 0L
 
@@ -415,7 +435,9 @@ class ExoPlayerAudioPlayer(
       if (timestampInMillis in mediaItemOffsetMs until mediaItemEnd) {
         val progressInMediaItem = timestampInMillis - mediaItemOffsetMs
         player.seekTo(index, progressInMediaItem)
-        player.play()
+        if (play) {
+          player.play()
+        }
         return
       }
       mediaItemOffsetMs = mediaItemEnd
@@ -477,9 +499,55 @@ class ExoPlayerAudioPlayer(
   override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) {
     if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_LOCAL) {
       dbark { "onDeviceInfoChanged: Local Player" }
+      isRemotePlayback = false
+      armCastWatchdog(null)
     } else if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
       dbark { "onDeviceInfoChanged: Remote Player" }
+      if (!isRemotePlayback) {
+        isRemotePlayback = true
+        // The remote player surfaces no PlaybackException for receiver-side failures
+        // (unreachable/unauthorized media, dead receiver) — a handoff that never reaches
+        // READY is the only signal, so give it a deadline.
+        armCastWatchdog(CAST_HANDOFF_READY_TIMEOUT_MS)
+      }
     }
+  }
+
+  /**
+   * (Re)arms the dead-cast watchdog with [timeoutMs], or cancels it when null. If the deadline
+   * elapses before READY is observed, the cast session is ended and playback falls back to the
+   * local player, paused at the last known position.
+   */
+  private fun armCastWatchdog(timeoutMs: Long?) {
+    castWatchdogJob?.cancel()
+    castWatchdogJob = if (timeoutMs == null) {
+      null
+    } else {
+      scope.launch {
+        delay(timeoutMs)
+        onCastPlaybackDead()
+      }
+    }
+  }
+
+  private suspend fun onCastPlaybackDead() {
+    wbark { "Cast playback failed to reach READY in time; falling back to local playback" }
+    val resumeTime = overallTime.value
+    castController.disconnect()
+
+    // The composite CastPlayer swaps back to the local player when the session ends
+    withTimeoutOrNull(CAST_FALLBACK_SWAP_TIMEOUT_MS) {
+      while (player.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_LOCAL) {
+        delay(100)
+      }
+    }
+
+    player.pause()
+    seekTo(resumeTime, play = false)
+    GlobalToaster.show(
+      context.getString(R.string.cast_failed_resumed_locally),
+      Toast.Duration.LONG,
+    )
   }
 
   override fun onPlayerError(error: PlaybackException) {
@@ -489,6 +557,17 @@ class ExoPlayerAudioPlayer(
   }
 
   override fun onPlaybackStateChanged(playbackState: Int) {
+    if (isRemotePlayback) {
+      when (playbackState) {
+        // Receiver is healthy; a later stall (powered off, network drop) re-arms below
+        Player.STATE_READY -> armCastWatchdog(null)
+        // A receiver that vanishes mid-playback leaves the player buffering forever
+        // (androidx/media #2182), so bound it
+        Player.STATE_BUFFERING -> armCastWatchdog(CAST_STALL_TIMEOUT_MS)
+        else -> Unit
+      }
+    }
+
     if (playbackState == Player.STATE_ENDED) {
       dbark { "Playback has ended! Mark the item as finished" }
       scope.launch {

--- a/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
+++ b/infra/audioplayer/impl/src/androidMain/res/values/strings.xml
@@ -6,6 +6,8 @@
     to the controller</string>
   <string name="notification_channel_name">Audio Playback Notifications</string>
 
+  <string name="cast_failed_resumed_locally">Casting failed — resumed on this phone, paused</string>
+
   <string name="download_notification_channel_name">Offline Download Notifications</string>
   <string name="download_notification_channel_description">Notifications about downloading media for
     offline playback will appear in this channel</string>

--- a/infra/audioplayer/public-ui/src/commonMain/composeResources/values/audioplayer_ui_strings.xml
+++ b/infra/audioplayer/public-ui/src/commonMain/composeResources/values/audioplayer_ui_strings.xml
@@ -9,6 +9,7 @@
   <string name="label_connecting">Connecting…</string>
   <string name="media_route_dialog_title">Devices</string>
   <string name="action_cast">Cast</string>
+  <string name="label_couldnt_connect">Couldn\'t connect</string>
   <string name="action_allow_local_network">Allow local network access</string>
   <string name="label_local_network_rationale">Needed to find cast devices on your network</string>
 

--- a/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
+++ b/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
@@ -67,6 +67,7 @@ import app.campfire.analytics.events.ScreenViewEvent
 import app.campfire.audioplayer.cast.CastController
 import app.campfire.audioplayer.cast.CastDevice
 import app.campfire.audioplayer.cast.CastState
+import app.campfire.audioplayer.cast.ConnectionAttempt
 import app.campfire.common.compose.analytics.Impression
 import app.campfire.common.compose.di.rememberComponent
 import app.campfire.common.compose.icons.CampfireIcons
@@ -83,6 +84,7 @@ import campfire.infra.audioplayer.public_ui.generated.resources.Res
 import campfire.infra.audioplayer.public_ui.generated.resources.action_allow_local_network
 import campfire.infra.audioplayer.public_ui.generated.resources.action_cast
 import campfire.infra.audioplayer.public_ui.generated.resources.label_connecting
+import campfire.infra.audioplayer.public_ui.generated.resources.label_couldnt_connect
 import campfire.infra.audioplayer.public_ui.generated.resources.label_local_network_rationale
 import campfire.infra.audioplayer.public_ui.generated.resources.media_route_dialog_title
 import coil3.compose.AsyncImage
@@ -140,15 +142,38 @@ fun CastButton(
       component.castController.needsLocalNetworkPermission
     }.collectAsState()
 
+    val connectionAttempt by remember(component) {
+      component.castController.connectionAttempt
+    }.collectAsState()
+
+    // A brokered connect keeps the picker open showing progress; close it once the
+    // attempt resolves successfully (Connecting -> null).
+    var sawConnecting by remember { mutableStateOf(false) }
+    LaunchedEffect(connectionAttempt) {
+      when (connectionAttempt?.status) {
+        ConnectionAttempt.Status.Connecting -> sawConnecting = true
+        ConnectionAttempt.Status.Failed -> sawConnecting = false
+        null -> if (sawConnecting) {
+          sawConnecting = false
+          showDevices = false
+        }
+      }
+    }
+
     CastDevices(
       devices = devices,
+      connectionAttempt = connectionAttempt,
       showLocalNetworkPermission = needsLocalNetworkPermission,
       onRequestLocalNetworkPermission = {
         component.castController.requestLocalNetworkPermission()
       },
       onDeviceClick = { device ->
         component.castController.connect(device)
-        showDevices = false
+        // Session-based devices (Google Cast) resolve asynchronously and drive the
+        // popup through connectionAttempt; instant output switches close it directly.
+        if (!device.requiresSession) {
+          showDevices = false
+        }
       },
       onDismissRequest = { showDevices = false },
     )
@@ -261,6 +286,7 @@ private fun CurrentDeviceButton(
 @Composable
 private fun CastDevices(
   devices: List<CastDevice>,
+  connectionAttempt: ConnectionAttempt?,
   showLocalNetworkPermission: Boolean,
   onRequestLocalNetworkPermission: () -> Unit,
   onDeviceClick: (CastDevice) -> Unit,
@@ -315,6 +341,7 @@ private fun CastDevices(
       ) {
         CastDevicesCard(
           devices = devices,
+          connectionAttempt = connectionAttempt,
           showLocalNetworkPermission = showLocalNetworkPermission,
           onRequestLocalNetworkPermission = onRequestLocalNetworkPermission,
           onDeviceClick = onDeviceClick,
@@ -328,6 +355,7 @@ private fun CastDevices(
 @Composable
 private fun CastDevicesCard(
   devices: List<CastDevice>,
+  connectionAttempt: ConnectionAttempt?,
   showLocalNetworkPermission: Boolean,
   onRequestLocalNetworkPermission: () -> Unit,
   onDeviceClick: (CastDevice) -> Unit,
@@ -367,6 +395,7 @@ private fun CastDevicesCard(
       ) { device ->
         CastDeviceListItem(
           device = device,
+          attemptStatus = connectionAttempt?.status?.takeIf { connectionAttempt.deviceId == device.id },
           onClick = {
             onDeviceClick(device)
           },
@@ -444,6 +473,7 @@ private fun LocalNetworkPermissionListItem(
 @Composable
 private fun CastDeviceListItem(
   device: CastDevice,
+  attemptStatus: ConnectionAttempt.Status?,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -487,35 +517,53 @@ private fun CastDeviceListItem(
         modifier = Modifier
           .padding(16.dp),
       ) {
-        device.iconUri?.let { uri ->
-          AsyncImage(
-            model = uri,
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(contentColor),
-            modifier = Modifier
-              .size(24.dp),
+        if (attemptStatus == ConnectionAttempt.Status.Connecting) {
+          CircularProgressIndicator(
+            modifier = Modifier.size(24.dp),
+            color = LocalContentColor.current,
+            strokeWidth = 3.dp,
           )
-        } ?: run {
-          Icon(
-            device.asIcon(),
-            contentDescription = null,
-          )
+        } else {
+          device.iconUri?.let { uri ->
+            AsyncImage(
+              model = uri,
+              contentDescription = null,
+              colorFilter = ColorFilter.tint(contentColor),
+              modifier = Modifier
+                .size(24.dp),
+            )
+          } ?: run {
+            Icon(
+              device.asIcon(),
+              contentDescription = null,
+            )
+          }
         }
       }
 
       Column(
-        modifier = Modifier.weight(1f),
+        modifier = Modifier
+          .weight(1f)
+          .padding(vertical = 8.dp),
       ) {
         Text(
           text = device.displayName,
           style = MaterialTheme.typography.titleMedium,
         )
 
-        device.description?.let { desc ->
+        if (attemptStatus == ConnectionAttempt.Status.Failed) {
           Text(
-            text = desc,
+            text = stringResource(Res.string.label_couldnt_connect),
             style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.error,
           )
+        } else {
+          device.description?.let { desc ->
+            Text(
+              text = desc,
+              style = MaterialTheme.typography.labelMedium,
+            )
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Phase 2A of the Cast overhaul (root causes + plan: [analysis](https://claude.ai/code/artifact/d862e987-57f1-4c1a-9a27-cc5adae02d44); discovery fixes landed in #986). This PR makes the **connection lifecycle honest end-to-end** — the companion PR (2B) will make playback itself work by rewriting media URLs and queue shape for the receiver.

### Session brokering
`connect()` for a Google Cast device is now an observed operation instead of fire-and-forget `selectRoute`:
- One-shot `SessionManagerListener` registered through media3's `Cast` singleton (defers registration until CastContext finishes loading)
- Retries transient start failures (`NETWORK_ERROR`/`TIMEOUT`) and ghost ended-before-started events by re-selecting the **live** route (MediaRouter silently ignores stale `RouteInfo`s), 15s overall timeout
- Policy follows jellyfin-android's battle-tested `ChromecastConnection`
- New `CastController.disconnect()`; selecting "This phone" ends the session too

### Device picker states
New `CastController.connectionAttempt` flow + `CastDevice.requiresSession`: the picker stays open during a brokered connect with a per-row spinner, closes on success, and shows an inline "Couldn't connect" on failure (tap to retry). Instant output switches (phone speaker, Bluetooth) close immediately as before.

### Dead-cast watchdog
media3's remote player hard-codes `getPlayerError()` to `null`, so receiver-side failures (unreachable/unauthorized media — which is currently *every* cast attempt until PR 2B — or a powered-off receiver, androidx/media#2182) produce no error event. `ExoPlayerAudioPlayer` now bounds it: 20s handoff-to-READY, 30s continuous mid-playback buffering → end the session and resume on the local player, **paused** at the last known overall position, with a toast. This alone converts the old "restart the app" hang into a 20-second self-recovery.

### CastOptions completed
Now matches media3's `DefaultCastOptionsProvider`: `setResumeSavedSession(false)`, `setEnableReconnectionService(false)`, `setRemoteToLocalEnabled(true)`, `setStopReceiverApplicationWhenEndingSession(true)` — media3 owns playback state, so GMS-side session resurrection only produced ghost sessions. (Evaluated media3 1.11's `CastParams`: it only carries receiver id / remote-to-local / output-switcher and explicitly falls back to the manifest provider for the rest, so the manifest `CastOptionsProvider` remains the mechanism.)

## Testing
- `./gradlew test` passes; `alphaDebug`, `fossDebug`, and desktop compile; ktlint clean
- Device verification: connect/timeout/fallback behavior needs a real Chromecast — expected behavior on this PR alone is: connect succeeds, playback fails auth on the receiver, watchdog resumes locally within ~20s with the toast

Mostly `androidMain` platform code → likely needs `skip-coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)