### PR TITLE
Make cast playback actually work: authenticated URLs and per-track queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - App widgets breaking due to large image size
 - Cast devices not appearing reliably, including the cast button vanishing after rotating the screen
 - Selecting a cast device could hang audio playback until the app was restarted — connection failures now show in the device picker and playback automatically falls back to this phone
+- Audiobooks now actually play on Chromecast, with chapter navigation and progress working the same as on-device playback
 
 ### Other Notes & Contributions
 

--- a/infra/audioplayer/cast/build.gradle.kts
+++ b/infra/audioplayer/cast/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
         implementation(projects.infra.audioplayer.api)
         implementation(projects.infra.audioplayer.impl)
         implementation(projects.core)
+        implementation(projects.data.account.api)
 
         // `api` because MediaRouterCastController's supertypes (CastStateListener,
         // MediaRouter.Callback) must be visible to the kimchi-generated component in the

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CampfireCastTransferCallback.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CampfireCastTransferCallback.kt
@@ -1,0 +1,108 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.cast
+
+import android.content.Context
+import androidx.media3.cast.CastPlayer
+import androidx.media3.cast.DefaultCastPlayerTransferCallback
+import androidx.media3.cast.RemoteCastPlayer
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.PlayerTransferState
+import androidx.media3.common.util.UnstableApi
+import app.campfire.audioplayer.AudioPlayerHolder
+import app.campfire.audioplayer.impl.asPlatformMediaItems
+import app.campfire.audioplayer.impl.mediaitem.MediaItemBuilder
+import app.campfire.core.logging.LogPriority
+import app.campfire.core.logging.bark
+
+/**
+ * Moves playback state across the local/remote player boundary, swapping the queue shape in the
+ * process: local playback uses chapter-granular items (with clipping the receiver can't honor),
+ * so the remote queue is rebuilt as one item per audio track and the position is translated
+ * through the absolute book timeline. Transferring back rebuilds the normal local queue.
+ *
+ * Falls back to media3's [DefaultCastPlayerTransferCallback] whenever there is no prepared
+ * session or the source queue's durations are unusable for timeline math.
+ */
+@UnstableApi
+internal class CampfireCastTransferCallback(
+  private val context: Context,
+  private val audioPlayerHolder: AudioPlayerHolder,
+) : CastPlayer.TransferCallback {
+
+  private val fallback = DefaultCastPlayerTransferCallback()
+
+  override fun transferState(sourcePlayer: Player, targetPlayer: Player) {
+    val session = audioPlayerHolder.currentPlayer.value?.preparedSession
+    if (session == null) {
+      fallback.transferState(sourcePlayer, targetPlayer)
+      return
+    }
+
+    try {
+      val state = PlayerTransferState.fromPlayer(sourcePlayer)
+      val absolutePositionMs = state.absolutePositionMs()
+      if (absolutePositionMs == null) {
+        fallback.transferState(sourcePlayer, targetPlayer)
+        return
+      }
+
+      val toRemote = targetPlayer is RemoteCastPlayer
+      val items = if (toRemote) {
+        MediaItemBuilder.buildTracks(session).map { it.asCastMediaItem() }
+      } else {
+        MediaItemBuilder.build(session).asPlatformMediaItems(context)
+      }
+      if (items.isEmpty()) {
+        fallback.transferState(sourcePlayer, targetPlayer)
+        return
+      }
+
+      val (index, positionInItemMs) = items.positionAt(absolutePositionMs)
+      bark {
+        "Transferring playback ${if (toRemote) "to" else "from"} cast: " +
+          "absolute=${absolutePositionMs}ms -> item=$index @ ${positionInItemMs}ms"
+      }
+
+      state.buildUpon()
+        .setMediaItems(items)
+        .setCurrentMediaItemIndex(index)
+        .setCurrentPosition(positionInItemMs)
+        .build()
+        .setToPlayer(targetPlayer)
+    } catch (e: Throwable) {
+      bark(LogPriority.ERROR, throwable = e) { "Cast queue transfer failed; falling back to direct state transfer" }
+      fallback.transferState(sourcePlayer, targetPlayer)
+    }
+  }
+
+  /**
+   * The absolute book position of this state: the summed durations of every item before the
+   * current one, plus the in-item position. Null when any preceding item lacks a duration.
+   */
+  private fun PlayerTransferState.absolutePositionMs(): Long? {
+    var offsetMs = 0L
+    for (index in 0 until currentMediaItemIndex) {
+      val durationMs = mediaItems.getOrNull(index)?.mediaMetadata?.durationMs ?: return null
+      offsetMs += durationMs
+    }
+    return offsetMs + currentPosition
+  }
+
+  /** Maps an absolute position onto (item index, position within that item), clamping to the end. */
+  private fun List<MediaItem>.positionAt(absolutePositionMs: Long): Pair<Int, Long> {
+    var offsetMs = 0L
+    forEachIndexed { index, item ->
+      val durationMs = item.mediaMetadata.durationMs ?: return index to (absolutePositionMs - offsetMs).coerceAtLeast(
+        0L,
+      )
+      if (absolutePositionMs < offsetMs + durationMs) {
+        return index to (absolutePositionMs - offsetMs).coerceAtLeast(0L)
+      }
+      offsetMs += durationMs
+    }
+    return lastIndex to (absolutePositionMs - (offsetMs - (last().mediaMetadata.durationMs ?: 0L))).coerceAtLeast(0L)
+  }
+}

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CampfireMediaItemConverter.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CampfireMediaItemConverter.kt
@@ -1,0 +1,45 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.cast
+
+import androidx.media3.cast.DefaultMediaItemConverter
+import androidx.media3.cast.MediaItemConverter
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import com.google.android.gms.cast.MediaQueueItem
+
+/**
+ * [MediaItemConverter] that authenticates outgoing media for the Cast receiver.
+ *
+ * The receiver fetches media and artwork URLs itself, so the sender's Authorization header (the
+ * local player's ResolvingDataSource) never applies. Audiobookshelf accepts the access token as
+ * a `?token=` query parameter instead, appended here — at conversion time, so each load uses the
+ * freshest snapshot [CastMediaTokenHolder] has.
+ */
+@UnstableApi
+internal class CampfireMediaItemConverter(
+  private val tokenHolder: CastMediaTokenHolder,
+) : MediaItemConverter {
+
+  private val delegate = DefaultMediaItemConverter()
+
+  override fun toMediaQueueItem(mediaItem: MediaItem): MediaQueueItem {
+    val token = tokenHolder.accessToken ?: return delegate.toMediaQueueItem(mediaItem)
+    val localConfiguration = mediaItem.localConfiguration ?: return delegate.toMediaQueueItem(mediaItem)
+
+    val authenticated = mediaItem.buildUpon()
+      .setUri(localConfiguration.uri.withAccessToken(token))
+      .setMediaMetadata(
+        mediaItem.mediaMetadata.buildUpon()
+          .setArtworkUri(mediaItem.mediaMetadata.artworkUri?.withAccessToken(token))
+          .build(),
+      )
+      .build()
+    return delegate.toMediaQueueItem(authenticated)
+  }
+
+  override fun toMediaItem(mediaQueueItem: MediaQueueItem): MediaItem {
+    return delegate.toMediaItem(mediaQueueItem)
+  }
+}

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastMediaItems.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastMediaItems.kt
@@ -1,0 +1,51 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.cast
+
+import android.net.Uri
+import androidx.media3.common.MediaItem as PlatformMediaItem
+import androidx.media3.common.MediaMetadata
+import app.campfire.audioplayer.impl.mediaitem.MediaItem as CampfireMediaItem
+
+/**
+ * Converts a common [CampfireMediaItem] into a platform media3 item shaped for the Cast
+ * receiver. Unlike the local conversion this keeps the server HTTPS cover URL (a receiver
+ * cannot resolve the app's `content://` artwork provider) and never applies clipping.
+ */
+internal fun CampfireMediaItem.asCastMediaItem(): PlatformMediaItem {
+  val metadata = metadata
+  return PlatformMediaItem.Builder()
+    .setMediaId(id)
+    .setUri(uri)
+    .setMimeType(mimeType)
+    .apply {
+      if (metadata != null) {
+        setMediaMetadata(
+          MediaMetadata.Builder()
+            .setTitle(metadata.title)
+            .setArtist(metadata.artist)
+            .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
+            .setDescription(metadata.description)
+            .setSubtitle(metadata.subtitle)
+            .setAlbumTitle(metadata.albumTitle)
+            .setArtworkUri(metadata.artworkUri?.let(Uri::parse))
+            .setDurationMs(metadata.durationMs)
+            .build(),
+        )
+      }
+    }
+    .build()
+}
+
+/**
+ * Appends the ABS `?token=` query parameter so the receiver can authenticate its own fetch of
+ * this URL. Only applies to http(s) URLs, and never twice.
+ */
+internal fun Uri.withAccessToken(token: String): Uri {
+  if (scheme != "http" && scheme != "https") return this
+  if (getQueryParameter("token") != null) return this
+  return buildUpon()
+    .appendQueryParameter("token", token)
+    .build()
+}

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastMediaTokenHolder.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastMediaTokenHolder.kt
@@ -1,0 +1,54 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.cast
+
+import app.campfire.account.api.AccountManager
+import app.campfire.account.api.UserSessionManager
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.qualifier.ForScope
+import app.campfire.core.logging.LogPriority
+import app.campfire.core.logging.bark
+import app.campfire.core.session.userId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Synchronous snapshot of the current ABS access token for the cast path.
+ *
+ * The Cast receiver fetches media URLs itself, so authentication must ride in the URL — but
+ * [CampfireMediaItemConverter] runs synchronously on the main thread while [AccountManager]'s
+ * token accessor suspends. This holder bridges the two: [refresh] is fired at the moments a cast
+ * flow begins (player construction, device connect), and the converter reads the latest snapshot.
+ *
+ * Best-effort by design: ABS access tokens expire (~1h) and this holder makes no attempt to keep
+ * a long cast session alive past that — the dead-cast watchdog recovers, and the proper fix is
+ * the planned `/api/items/{id}/play` session flow with credential-free public track URLs.
+ */
+@SingleIn(AppScope::class)
+@Inject
+class CastMediaTokenHolder(
+  private val accountManager: AccountManager,
+  private val userSessionManager: UserSessionManager,
+  private val dispatcherProvider: DispatcherProvider,
+  @ForScope(AppScope::class) private val applicationScope: CoroutineScope,
+) {
+
+  @Volatile
+  var accessToken: String? = null
+    private set
+
+  fun refresh() {
+    applicationScope.launch(dispatcherProvider.io) {
+      try {
+        val userId = userSessionManager.current.userId ?: return@launch
+        accessToken = accountManager.getToken(userId)?.accessToken
+      } catch (e: Throwable) {
+        bark(LogPriority.WARN, throwable = e) { "Unable to refresh cast media token" }
+      }
+    }
+  }
+}

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastRemotePlayerFactory.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastRemotePlayerFactory.kt
@@ -40,16 +40,20 @@ class CastRemotePlayerFactory(
     // in a process-wide static for its lifetime.
     val appContext = context.applicationContext
     SafeCastContext.initialize(appContext)
+    // Gate only on the module being genuinely absent — never on init still being in flight.
+    // The playback service is created in the same startup burst that kicks the async
+    // CastContext load, so a readiness gate loses that race on every cold start and the
+    // process runs without any cast integration. media3's players handle a late-arriving
+    // CastContext themselves (session listeners are deferred until it loads).
+    if (SafeCastContext.isModuleUnavailable) return null
     tokenHolder.refresh()
-    return SafeCastContext.getIfReady()?.let {
-      val remotePlayer = RemoteCastPlayer.Builder(appContext)
-        .setMediaItemConverter(CampfireMediaItemConverter(tokenHolder))
-        .build()
-      CastPlayer.Builder(appContext)
-        .setLocalPlayer(localPlayer)
-        .setRemotePlayer(remotePlayer)
-        .setTransferCallback(CampfireCastTransferCallback(appContext, audioPlayerHolder))
-        .build()
-    }
+    val remotePlayer = RemoteCastPlayer.Builder(appContext)
+      .setMediaItemConverter(CampfireMediaItemConverter(tokenHolder))
+      .build()
+    return CastPlayer.Builder(appContext)
+      .setLocalPlayer(localPlayer)
+      .setRemotePlayer(remotePlayer)
+      .setTransferCallback(CampfireCastTransferCallback(appContext, audioPlayerHolder))
+      .build()
   }
 }

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastRemotePlayerFactory.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastRemotePlayerFactory.kt
@@ -6,9 +6,11 @@ package app.campfire.audioplayer.impl.cast
 import android.content.Context
 import androidx.annotation.OptIn
 import androidx.media3.cast.CastPlayer
+import androidx.media3.cast.RemoteCastPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.audioplayer.impl.RemotePlayerFactory
 import app.campfire.core.di.AppScope
 import com.r0adkll.kimchi.annotations.ContributesBinding
@@ -20,20 +22,33 @@ import me.tatarka.inject.annotations.Inject
  * itself. Returns null on devices without the Play Services Cast module, or when the
  * async [CastContext][com.google.android.gms.cast.framework.CastContext] initialization
  * hasn't completed yet (e.g. a cold start straight into the playback service).
+ *
+ * The remote player is configured for Audiobookshelf receivers: media URLs are authenticated
+ * via [CampfireMediaItemConverter], and [CampfireCastTransferCallback] swaps the queue between
+ * the local chapter-granular shape and the per-track shape the receiver requires.
  */
 @OptIn(UnstableApi::class)
 @ContributesBinding(AppScope::class)
 @Inject
-class CastRemotePlayerFactory : RemotePlayerFactory {
+class CastRemotePlayerFactory(
+  private val tokenHolder: CastMediaTokenHolder,
+  private val audioPlayerHolder: AudioPlayerHolder,
+) : RemotePlayerFactory {
 
   override fun create(context: Context, localPlayer: ExoPlayer): Player? {
     // The application context, not the service: media3's Cast singleton retains this Context
     // in a process-wide static for its lifetime.
     val appContext = context.applicationContext
     SafeCastContext.initialize(appContext)
+    tokenHolder.refresh()
     return SafeCastContext.getIfReady()?.let {
+      val remotePlayer = RemoteCastPlayer.Builder(appContext)
+        .setMediaItemConverter(CampfireMediaItemConverter(tokenHolder))
+        .build()
       CastPlayer.Builder(appContext)
         .setLocalPlayer(localPlayer)
+        .setRemotePlayer(remotePlayer)
+        .setTransferCallback(CampfireCastTransferCallback(appContext, audioPlayerHolder))
         .build()
     }
   }

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
@@ -69,6 +69,7 @@ class MediaRouterCastController(
   private val application: Application,
   private val localNetworkPermission: LocalNetworkPermissionController,
   private val dispatcherProvider: DispatcherProvider,
+  private val tokenHolder: CastMediaTokenHolder,
   @ForScope(AppScope::class) private val applicationScope: CoroutineScope,
 ) : CastController,
   CastStateListener,
@@ -146,6 +147,9 @@ class MediaRouterCastController(
       }
       ibark { "Connecting route: $route" }
       if (device.requiresSession) {
+        // Snapshot a fresh access token while the session establishes — the media item
+        // converter needs it synchronously when the queue is sent to the receiver.
+        tokenHolder.refresh()
         connectToCastRoute(device.id, route)
       } else {
         // Instant output switches (this phone, Bluetooth, …). Moving off a cast route also

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
@@ -77,6 +77,7 @@ class MediaRouterCastController(
   Cork {
 
   override val tag: String = "CastContextController"
+  override val enabled: Boolean = true
 
   override val state = MutableStateFlow(CastState.Unavailable)
   override val availableDevices = MutableStateFlow<List<CastDevice>>(emptyList())
@@ -464,13 +465,24 @@ class MediaRouterCastController(
     val selectedRoute = router.selectedRoute
     val selectedCastDeviceId = selectedRoute.castDeviceId
 
-    availableDevices.value = router.routes
+    val routes = router.routes
       .filter { it.isEnabled }
       .filter { it.description != MULTIZONE_MEMBER_DESCRIPTION }
       // The Cast provider publishes an extra session-scoped route for a connected device
       // alongside the device's own route; drop the duplicate.
       .filter { route -> route.extras?.getString(EXTRA_SESSION_ID) == null }
       .distinctBy { route -> route.castDeviceId ?: route.id }
+
+    // The system output-switcher provider publishes its own copy of every Cast device,
+    // identically named but without the Cast extras. Selecting that copy performs a plain
+    // system transfer instead of starting a Cast session (and Pixels bounce it entirely when
+    // Bluetooth audio is connected), so only the Cast provider's route may represent a device.
+    val castRouteNames = routes.mapNotNullTo(mutableSetOf()) { route ->
+      route.name.takeIf { route.castDeviceId != null }
+    }
+
+    availableDevices.value = routes
+      .filter { route -> route.castDeviceId != null || route.name !in castRouteNames }
       .sortedBy {
         when {
           it.isSystemRoute -> 0

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/SafeCastContext.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/SafeCastContext.kt
@@ -66,6 +66,9 @@ object SafeCastContext {
   /** The shared [CastContext] if initialization has completed, without waiting. */
   fun getIfReady(): CastContext? = _castContext.value
 
+  /** True when the Play services cast module is known to be missing from this device. */
+  val isModuleUnavailable: Boolean get() = moduleUnavailable
+
   private fun onInitializationFailed(error: Throwable?) {
     val isModuleUnavailable = generateSequence(error) { it.cause }
       .any { it is ModuleUnavailableException }

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -84,6 +84,7 @@ class ExoPlayerAudioPlayer(
 ) : AudioPlayer, Player.Listener, Cork {
 
   override val tag: String = AUDIO_TAG
+  override val enabled: Boolean = true
 
   // Re-enable to emit verbose logging around Player.Listener events for
   // debugging.

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -41,6 +41,7 @@ import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.core.extensions.seconds
 import app.campfire.core.logging.Cork
 import app.campfire.core.logging.Corked
+import app.campfire.core.model.Chapter
 import app.campfire.core.model.Session
 import app.campfire.core.model.loggableId
 import app.campfire.core.toast.GlobalToaster
@@ -410,11 +411,26 @@ class ExoPlayerAudioPlayer(
   }
 
   override fun seekTo(itemIndex: Int) {
+    if (isRemotePlayback) {
+      val absolute = absoluteTimeOfLocalQueueIndex(itemIndex)
+      if (absolute != null) {
+        remoteSeekTo(absolute, play = true)
+        return
+      }
+    }
     player.seekToDefaultPosition(itemIndex)
     player.play()
   }
 
   override fun seekTo(progress: Float) {
+    if (isRemotePlayback) {
+      val chapter = chapterAt(overallTime.value)
+      if (chapter != null) {
+        remoteSeekTo(chapter.start.seconds + chapter.duration * progress.toDouble(), play = false)
+        currentTime.value = chapter.duration * progress.toDouble()
+        return
+      }
+    }
     val positionMs = (progress * player.duration).toLong()
     player.seekTo(positionMs)
     currentTime.value = positionMs.milliseconds
@@ -425,6 +441,10 @@ class ExoPlayerAudioPlayer(
   }
 
   private fun seekTo(timestamp: Duration, play: Boolean) {
+    if (isRemotePlayback) {
+      remoteSeekTo(timestamp, play)
+      return
+    }
     val timestampInMillis = timestamp.inWholeMilliseconds
     var mediaItemOffsetMs = 0L
 
@@ -445,10 +465,31 @@ class ExoPlayerAudioPlayer(
   }
 
   override fun skipToNext() {
+    if (isRemotePlayback) {
+      // The remote queue is per-track; skip by chapter on the absolute timeline instead
+      val chapter = chapterAt(overallTime.value)
+      if (chapter != null) {
+        remoteSeekTo(chapter.end.seconds, play = false)
+        return
+      }
+    }
     player.seekToNextMediaItem()
   }
 
   override fun skipToPrevious() {
+    if (isRemotePlayback) {
+      val chapter = chapterAt(overallTime.value)
+      if (chapter != null) {
+        val progressInChapter = (overallTime.value - chapter.start.seconds).coerceAtLeast(Duration.ZERO)
+        val target = if (progressInChapter > settings.trackResetThreshold) {
+          chapter.start.seconds
+        } else {
+          chapterAt(chapter.start.seconds - 1.milliseconds)?.start?.seconds ?: chapter.start.seconds
+        }
+        remoteSeekTo(target, play = false)
+        return
+      }
+    }
     if (player.currentPosition.milliseconds > settings.trackResetThreshold) {
       player.seekToDefaultPosition()
       player.play()
@@ -501,6 +542,7 @@ class ExoPlayerAudioPlayer(
       dbark { "onDeviceInfoChanged: Local Player" }
       isRemotePlayback = false
       armCastWatchdog(null)
+      updateProgress(player)
     } else if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
       dbark { "onDeviceInfoChanged: Remote Player" }
       if (!isRemotePlayback) {
@@ -509,6 +551,7 @@ class ExoPlayerAudioPlayer(
         // (unreachable/unauthorized media, dead receiver) — a handoff that never reaches
         // READY is the only signal, so give it a deadline.
         armCastWatchdog(CAST_HANDOFF_READY_TIMEOUT_MS)
+        updateProgress(player)
       }
     }
   }
@@ -541,6 +584,9 @@ class ExoPlayerAudioPlayer(
         delay(100)
       }
     }
+    // Sync from actual state rather than the listener event, which may not have landed yet —
+    // the seek below must use local (chapter-queue) semantics
+    isRemotePlayback = player.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_LOCAL
 
     player.pause()
     seekTo(resumeTime, play = false)
@@ -584,10 +630,24 @@ class ExoPlayerAudioPlayer(
   }
 
   override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+    if (isRemotePlayback) {
+      updateProgress(player)
+      return
+    }
     currentDuration.value = player.duration.milliseconds
   }
 
   override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+    if (isRemotePlayback) {
+      // Item metadata is track-granular while remote; chapter-relative title/duration are
+      // derived from the absolute position in updateProgress instead
+      currentMetadata.value = currentMetadata.value.copy(
+        artworkUri = mediaMetadata.artworkUri?.toString()
+          ?: currentMetadata.value.artworkUri,
+      )
+      updateProgress(player)
+      return
+    }
     currentDuration.value = player.duration.milliseconds
     currentMetadata.value = Metadata(
       title = mediaMetadata.title?.toString(),
@@ -662,9 +722,94 @@ class ExoPlayerAudioPlayer(
   }
 
   private fun updateProgress(player: Player) {
+    if (isRemotePlayback) {
+      val overallMs = remoteOverallPositionMs(player)
+      if (overallMs != null) {
+        overallTime.value = overallMs.milliseconds
+        updateRemoteChapterState(overallMs.milliseconds, player)
+        return
+      }
+    }
     currentTime.value = player.currentPosition.milliseconds
     currentDuration.value = player.duration.milliseconds
     overallTime.value = player.overallPosition.milliseconds
+  }
+
+  /**
+   * Absolute position while remote, derived from the session's track table rather than item
+   * metadata: the remote queue is one item per audio track, and items in the cast timeline
+   * may not carry our duration metadata.
+   */
+  private fun remoteOverallPositionMs(player: Player): Long? {
+    val session = preparedSession ?: return null
+    if (session.episode != null) return player.currentPosition
+    val track = session.libraryItem.media.tracks.getOrNull(player.currentMediaItemIndex) ?: return null
+    return track.startOffset.seconds.inWholeMilliseconds + player.currentPosition
+  }
+
+  /**
+   * While remote the queue is per-track but the UI speaks chapters: re-derive chapter-relative
+   * time, duration, and title from the absolute position so the playback UI matches local
+   * playback exactly.
+   */
+  private fun updateRemoteChapterState(overall: Duration, player: Player) {
+    val chapter = chapterAt(overall)
+    if (chapter != null) {
+      currentTime.value = (overall - chapter.start.seconds).coerceAtLeast(Duration.ZERO)
+      currentDuration.value = chapter.duration
+      if (currentMetadata.value.title != chapter.title) {
+        currentMetadata.value = currentMetadata.value.copy(title = chapter.title)
+      }
+    } else {
+      currentTime.value = player.currentPosition.milliseconds
+      currentDuration.value = player.duration.milliseconds
+    }
+  }
+
+  /** The chapter containing [time] on the absolute book/episode timeline, if any. */
+  private fun chapterAt(time: Duration): Chapter? {
+    val session = preparedSession ?: return null
+    val timeMs = time.inWholeMilliseconds
+    return session.episode?.chapters?.find { chapter ->
+      timeMs >= chapter.start.seconds.inWholeMilliseconds && timeMs < chapter.end.seconds.inWholeMilliseconds
+    } ?: session.libraryItem.getChapterForDuration(timeMs)
+  }
+
+  /**
+   * Seeks while remote using the session's track table (the remote queue is per-track and its
+   * timeline metadata may not survive the cast round-trip).
+   */
+  private fun remoteSeekTo(timestamp: Duration, play: Boolean) {
+    val session = preparedSession ?: return
+    if (session.episode != null) {
+      player.seekTo(timestamp.inWholeMilliseconds)
+    } else {
+      val track = session.libraryItem.getAudioTrackForDuration(timestamp.inWholeMilliseconds) ?: return
+      val trackIndex = session.libraryItem.media.tracks.indexOf(track)
+      if (trackIndex < 0) return
+      val offsetMs = timestamp.inWholeMilliseconds - track.startOffset.seconds.inWholeMilliseconds
+      player.seekTo(trackIndex, offsetMs.coerceAtLeast(0L))
+    }
+    overallTime.value = timestamp
+    if (play) {
+      player.play()
+    }
+  }
+
+  /**
+   * The UI addresses seeks by local-queue index (chapter id when the item has chapters, track
+   * ordinal otherwise). While remote the player's queue is per-track, so translate the local
+   * index to absolute time first. Null when no translation applies (podcasts, unknown index).
+   */
+  private fun absoluteTimeOfLocalQueueIndex(itemIndex: Int): Duration? {
+    val session = preparedSession ?: return null
+    if (session.episode != null) return null
+    val chapters = session.libraryItem.media.chapters
+    return if (chapters.isNotEmpty()) {
+      chapters.find { it.id == itemIndex }?.start?.seconds
+    } else {
+      session.libraryItem.media.tracks.getOrNull(itemIndex)?.startOffset?.seconds
+    }
   }
 }
 

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaControllerConnector.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaControllerConnector.kt
@@ -95,5 +95,6 @@ class MediaControllerConnector(private val application: Application) {
 
   companion object : Cork {
     override val tag: String = "MediaControllerConnector"
+    override val enabled: Boolean = true
   }
 }

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItemBuilder.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItemBuilder.kt
@@ -52,6 +52,24 @@ object MediaItemBuilder : Corked("MediaItemBuilders") {
     )
   }
 
+  /**
+   * Builds one [MediaItem] per audio track, ignoring chapters entirely. This is the queue shape
+   * used for remote (Cast) playback: clipped chapter items can't cross the cast boundary
+   * (receivers don't honor clipping), so the remote queue is whole files and chapter semantics
+   * are re-derived from the absolute position.
+   */
+  fun buildTracks(session: Session): List<MediaItem> {
+    val episode = session.episode
+    if (episode != null) {
+      return buildPodcastEpisode(session.libraryItem, episode)
+    }
+    return buildTracks(session.libraryItem)
+  }
+
+  fun buildTracks(item: LibraryItem): List<MediaItem> = with(item) {
+    media.tracks.map { track -> createMediaItem(track, media, id) }
+  }
+
   fun build(item: LibraryItem): List<MediaItem> = with(item) {
     val chapters = media.chapters
     val audioTracks = media.tracks

--- a/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItemBuilderTest.kt
+++ b/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/mediaitem/MediaItemBuilderTest.kt
@@ -141,6 +141,46 @@ class MediaItemBuilderTest {
 
   // endregion
 
+  // region buildTracks — remote (cast) queue shape
+
+  @Test
+  fun `buildTracks ignores chapters and returns one unclipped item per track`() {
+    val tracks = listOf(
+      track(index = 0, startOffset = 0f, duration = 300f),
+      track(index = 1, startOffset = 300f, duration = 400f),
+    )
+    val chapters = listOf(
+      chapter(id = 0, start = 0f, end = 150f),
+      chapter(id = 1, start = 150f, end = 300f),
+      chapter(id = 2, start = 300f, end = 700f),
+    )
+    val item = libraryItem(media = media(tracks = tracks, chapters = chapters))
+
+    val result = MediaItemBuilder.buildTracks(item)
+
+    assertThat(result).hasSize(2)
+    assertThat(result[0].id).isEqualTo("media-1_0")
+    assertThat(result[0].clipping).isNull()
+    assertThat(result[1].id).isEqualTo("media-1_1")
+    assertThat(result[1].clipping).isNull()
+  }
+
+  @Test
+  fun `buildTracks carries track durations for absolute timeline math`() {
+    val tracks = listOf(
+      track(index = 0, startOffset = 0f, duration = 300f),
+      track(index = 1, startOffset = 300f, duration = 400f),
+    )
+    val item = libraryItem(media = media(tracks = tracks))
+
+    val result = MediaItemBuilder.buildTracks(item)
+
+    assertThat(result[0].metadata?.durationMs).isEqualTo(300_000L)
+    assertThat(result[1].metadata?.durationMs).isEqualTo(400_000L)
+  }
+
+  // endregion
+
   // region No chapters — tracks only
 
   @Test

--- a/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
+++ b/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -66,6 +67,7 @@ import app.campfire.analytics.events.ScreenType
 import app.campfire.analytics.events.ScreenViewEvent
 import app.campfire.audioplayer.cast.CastController
 import app.campfire.audioplayer.cast.CastDevice
+import app.campfire.audioplayer.cast.CastDevice.Type
 import app.campfire.audioplayer.cast.CastState
 import app.campfire.audioplayer.cast.ConnectionAttempt
 import app.campfire.common.compose.analytics.Impression
@@ -75,6 +77,7 @@ import app.campfire.common.compose.icons.rounded.Cast
 import app.campfire.common.compose.icons.rounded.CastConnected
 import app.campfire.common.compose.icons.rounded.CastConnecting
 import app.campfire.common.compose.icons.rounded.CastWarning
+import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.util.withDensity
 import app.campfire.common.compose.widgets.IconButtonTooltip
@@ -574,5 +577,93 @@ private fun CastDeviceListItem(
         }
       }
     }
+  }
+}
+
+/*
+ * Previews — the connect failure and progress states are hard to catch on a device
+ * (discovery recovers faster than the failure can be observed), so verify them here.
+ */
+
+private class PreviewCastDevice(
+  id: String,
+  name: String,
+  type: Type,
+  isSelected: Boolean = false,
+  requiresSession: Boolean = true,
+) : CastDevice(
+  id = id,
+  name = name,
+  description = null,
+  iconUri = null,
+  type = type,
+  isSelected = isSelected,
+  requiresSession = requiresSession,
+)
+
+private val PreviewDevices = listOf(
+  PreviewCastDevice(CastDevice.DEFAULT_ID, "Phone", Type.SMARTPHONE, requiresSession = false),
+  PreviewCastDevice("office-speaker", "Office speaker", Type.SPEAKER),
+  PreviewCastDevice("kitchen-speaker", "Kitchen speaker", Type.SPEAKER),
+  PreviewCastDevice("living-room-tv", "Living room TV", Type.TV, isSelected = true),
+)
+
+@Preview
+@Composable
+private fun CastDevicesCardFailedPreview() {
+  CampfireTheme {
+    CastDevicesCard(
+      devices = PreviewDevices,
+      connectionAttempt = ConnectionAttempt("office-speaker", ConnectionAttempt.Status.Failed),
+      showLocalNetworkPermission = true,
+      onRequestLocalNetworkPermission = {},
+      onDeviceClick = {},
+      onDismissRequest = {},
+    )
+  }
+}
+
+@Preview
+@Composable
+private fun CastDevicesCardFailedOnSelectedPreview() {
+  CampfireTheme {
+    CastDevicesCard(
+      devices = PreviewDevices,
+      connectionAttempt = ConnectionAttempt("living-room-tv", ConnectionAttempt.Status.Failed),
+      showLocalNetworkPermission = false,
+      onRequestLocalNetworkPermission = {},
+      onDeviceClick = {},
+      onDismissRequest = {},
+    )
+  }
+}
+
+@Preview
+@Composable
+private fun CastDevicesCardConnectingPreview() {
+  CampfireTheme {
+    CastDevicesCard(
+      devices = PreviewDevices,
+      connectionAttempt = ConnectionAttempt("office-speaker", ConnectionAttempt.Status.Connecting),
+      showLocalNetworkPermission = false,
+      onRequestLocalNetworkPermission = {},
+      onDeviceClick = {},
+      onDismissRequest = {},
+    )
+  }
+}
+
+@Preview
+@Composable
+private fun CastDevicesCardDarkFailedPreview() {
+  CampfireTheme(useDarkColors = true) {
+    CastDevicesCard(
+      devices = PreviewDevices,
+      connectionAttempt = ConnectionAttempt("office-speaker", ConnectionAttempt.Status.Failed),
+      showLocalNetworkPermission = true,
+      onRequestLocalNetworkPermission = {},
+      onDeviceClick = {},
+      onDismissRequest = {},
+    )
   }
 }

--- a/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
+++ b/infra/audioplayer/public-ui/src/commonMain/kotlin/app/campfire/audioplayer/ui/cast/CastButton.kt
@@ -552,10 +552,17 @@ private fun CastDeviceListItem(
         )
 
         if (attemptStatus == ConnectionAttempt.Status.Failed) {
+          // errorContainer/onErrorContainer is a guaranteed-contrast pair in every theme,
+          // unlike bare `error` over this row's variable container colors
           Text(
             text = stringResource(Res.string.label_couldnt_connect),
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.error,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            modifier = Modifier
+              .padding(top = 2.dp)
+              .clip(CircleShape)
+              .background(MaterialTheme.colorScheme.errorContainer)
+              .padding(horizontal = 8.dp, vertical = 2.dp),
           )
         } else {
           device.description?.let { desc ->


### PR DESCRIPTION
## Summary

Phase 2B of the Cast overhaul, stacked on #988 ([analysis](https://claude.ai/code/artifact/d862e987-57f1-4c1a-9a27-cc5adae02d44)). #988 made *connecting* honest; this makes *playback* work.

### Receiver auth — the root cause of the silent death
The Chromecast fetches media URLs itself, so the local player's `Authorization` header (injected via `ResolvingDataSource`) never applied — every cast attempt 401'd on the receiver with no error surfaced. `CampfireMediaItemConverter` now appends the ABS access token as `?token=` to media and artwork URLs at conversion time, reading a synchronous snapshot from the new `CastMediaTokenHolder` (refreshed on device connect and player construction — the converter runs on the main thread where the suspend token accessor can't).

### Queue shape across the boundary
Local playback keeps chapter-granular items, whose `ClippingConfiguration` a receiver can't honor. `CampfireCastTransferCallback` rebuilds the queue as **one item per audio track** (`MediaItemBuilder.buildTracks`) on local→remote, translates the position through the absolute book timeline in both directions, and falls back to media3's `DefaultCastPlayerTransferCallback` when no session is prepared. Cast-shaped items carry the server HTTPS cover URL (not the `content://` artwork provider a receiver can't resolve), the audiobook media type, and per-track durations.

### Chapter semantics while remote
The UI speaks chapters; the remote queue is tracks. `ExoPlayerAudioPlayer` re-derives everything from the absolute position while remote so the playback UI is pixel-identical to local: chapter-relative time/duration/title from the session's chapter list, chapter-addressed seeks translated to track+offset, chapter-based skip next/previous, and scrubber progress within the current chapter. Track-table math is used instead of player item metadata, which may not survive the cast timeline round-trip (androidx/media#25).

### Known limitation (decided, not forgotten)
ABS access tokens expire after ~1h and nothing refreshes a live cast queue's URLs — a long session dies at expiry and #988's watchdog recovers to local playback. The proper fix is the planned fast-follow: the `/api/items/{id}/play` server-session flow with credential-free `/public/session/{id}/track/{index}` URLs (ABS ≥ 2.22.0), which also removes tokens from URLs entirely. Also deferred: a pre-flight "server unreachable" message in the picker (no connectivity primitive exists in the codebase; the watchdog covers it).

## Testing
- `./gradlew test` passes (new `buildTracks` unit tests); `alphaDebug`, `fossDebug`, and desktop compile; ktlint clean
- Device verification checklist: cast a multi-file book mid-chapter → audio starts at the right position on the receiver; chapter list seek, skip next/prev, and scrubber behave as locally; disconnect via "This phone" → local resume at position; cast a downloaded (but online) book → plays from server; podcast episode → plays (mapped generically, books are the verified path)

Mostly `androidMain` platform code → likely needs `skip-coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)