### PR TITLE
Use credential-free server session URLs for cast playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cast playback stopping after about an hour — the receiver now streams through credential-free session links on servers running Audiobookshelf 2.22.0 or newer
 - App widgets breaking due to large image size
 - Cast devices not appearing reliably, including the cast button vanishing after rotating the screen
 - Selecting a cast device could hang audio playback until the app was restarted — connection failures now show in the device picker and playback automatically falls back to this phone

--- a/infra/audioplayer/cast/build.gradle.kts
+++ b/infra/audioplayer/cast/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
         implementation(projects.infra.audioplayer.impl)
         implementation(projects.core)
         implementation(projects.data.account.api)
+        implementation(projects.data.network.api)
+        implementation(projects.features.settings.api)
 
         // `api` because MediaRouterCastController's supertypes (CastStateListener,
         // MediaRouter.Callback) must be visible to the kimchi-generated component in the

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CampfireCastTransferCallback.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CampfireCastTransferCallback.kt
@@ -30,6 +30,7 @@ import app.campfire.core.logging.bark
 internal class CampfireCastTransferCallback(
   private val context: Context,
   private val audioPlayerHolder: AudioPlayerHolder,
+  private val playSessionHolder: CastPlaySessionHolder,
 ) : CastPlayer.TransferCallback {
 
   private val fallback = DefaultCastPlayerTransferCallback()
@@ -39,6 +40,13 @@ internal class CampfireCastTransferCallback(
     if (session == null) {
       fallback.transferState(sourcePlayer, targetPlayer)
       return
+    }
+
+    if (targetPlayer is RemoteCastPlayer) {
+      // Covers connecting before anything was playing: the broker's connect-time staging
+      // found no prepared session, so stage here. Fire-and-forget — if the queue is sent
+      // before the session lands, the converter's token fallback carries this load.
+      playSessionHolder.openForCurrentSession()
     }
 
     try {

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CampfireMediaItemConverter.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CampfireMediaItemConverter.kt
@@ -3,6 +3,7 @@
 
 package app.campfire.audioplayer.impl.cast
 
+import android.net.Uri
 import androidx.media3.cast.DefaultMediaItemConverter
 import androidx.media3.cast.MediaItemConverter
 import androidx.media3.common.MediaItem
@@ -13,26 +14,37 @@ import com.google.android.gms.cast.MediaQueueItem
  * [MediaItemConverter] that authenticates outgoing media for the Cast receiver.
  *
  * The receiver fetches media and artwork URLs itself, so the sender's Authorization header (the
- * local player's ResolvingDataSource) never applies. Audiobookshelf accepts the access token as
- * a `?token=` query parameter instead, appended here — at conversion time, so each load uses the
- * freshest snapshot [CastMediaTokenHolder] has.
+ * local player's ResolvingDataSource) never applies. Media URLs prefer the credential-free
+ * public session form staged by [CastPlaySessionHolder] (no token, immune to token expiry);
+ * when no session is staged they fall back to the `?token=` query parameter, appended at
+ * conversion time from the freshest snapshot [CastMediaTokenHolder] has. Artwork has no public
+ * session form and always uses the token.
  */
 @UnstableApi
 internal class CampfireMediaItemConverter(
   private val tokenHolder: CastMediaTokenHolder,
+  private val playSessionHolder: CastPlaySessionHolder,
 ) : MediaItemConverter {
 
   private val delegate = DefaultMediaItemConverter()
 
   override fun toMediaQueueItem(mediaItem: MediaItem): MediaQueueItem {
-    val token = tokenHolder.accessToken ?: return delegate.toMediaQueueItem(mediaItem)
     val localConfiguration = mediaItem.localConfiguration ?: return delegate.toMediaQueueItem(mediaItem)
+    val token = tokenHolder.accessToken
+
+    val mediaUri = playSessionHolder.publicUrlFor(localConfiguration.uri.toString())
+      ?.let(Uri::parse)
+      ?: token?.let { localConfiguration.uri.withAccessToken(it) }
+      ?: return delegate.toMediaQueueItem(mediaItem)
 
     val authenticated = mediaItem.buildUpon()
-      .setUri(localConfiguration.uri.withAccessToken(token))
+      .setUri(mediaUri)
       .setMediaMetadata(
         mediaItem.mediaMetadata.buildUpon()
-          .setArtworkUri(mediaItem.mediaMetadata.artworkUri?.withAccessToken(token))
+          .setArtworkUri(
+            token?.let { mediaItem.mediaMetadata.artworkUri?.withAccessToken(it) }
+              ?: mediaItem.mediaMetadata.artworkUri,
+          )
           .build(),
       )
       .build()

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastPlaySessionHolder.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastPlaySessionHolder.kt
@@ -1,0 +1,187 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.cast
+
+import app.campfire.account.api.ServerRepository
+import app.campfire.account.api.UserSessionManager
+import app.campfire.audioplayer.AudioPlayerHolder
+import app.campfire.core.app.ApplicationInfo
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.ComponentHolder
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import app.campfire.core.di.qualifier.ForScope
+import app.campfire.core.logging.LogPriority
+import app.campfire.core.logging.bark
+import app.campfire.core.model.ServerVersion
+import app.campfire.core.model.Session
+import app.campfire.core.session.serverUrl
+import app.campfire.network.AudioBookShelfApi
+import app.campfire.network.models.DeviceInfo
+import app.campfire.settings.api.CampfireSettings
+import com.r0adkll.kimchi.annotations.ContributesTo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import me.tatarka.inject.annotations.Inject
+
+@ContributesTo(UserScope::class)
+interface CastPlaySessionUserComponent {
+  val audioBookShelfApi: AudioBookShelfApi
+}
+
+/**
+ * Stages a server playback session whose id is the Cast receiver's media credential.
+ *
+ * `/public/session/{id}/track/{index}` serves track bytes with the session UUID as the sole
+ * bearer credential (no auth headers, no expiry short of the server's 36h idle reaper), which
+ * frees cast playback from the ~1h access-token TTL that `?token=` URLs carry. The session is
+ * opened with `forceDirectPlay` (a ~10ms metadata call, no ffmpeg) on a `-cast`-suffixed device
+ * id so the server's per-device session dedupe never collides with any future session the phone
+ * opens for itself, and it is deliberately never synced — the phone's local accounting remains
+ * the sole stats writer, and this session records zero listening time.
+ *
+ * Everything is fire-and-forget and best-effort: when staging hasn't happened (old server,
+ * offline, /play failure, race with the queue send), [CampfireMediaItemConverter] falls back to
+ * the `?token=` rewrite, which is exactly the previously shipped behavior.
+ */
+@SingleIn(AppScope::class)
+@Inject
+class CastPlaySessionHolder(
+  private val serverRepository: ServerRepository,
+  private val userSessionManager: UserSessionManager,
+  private val campfireSettings: CampfireSettings,
+  private val applicationInfo: ApplicationInfo,
+  private val audioPlayerHolder: AudioPlayerHolder,
+  private val dispatcherProvider: DispatcherProvider,
+  @ForScope(AppScope::class) private val applicationScope: CoroutineScope,
+) {
+
+  @Volatile
+  private var publicTrackUrls: Map<String, String> = emptyMap()
+
+  @Volatile
+  private var sessionId: String? = null
+
+  @Volatile
+  private var sessionItemKey: String? = null
+
+  private val mutex = Mutex()
+
+  /** The credential-free receiver URL for [trackContentUrl], if a session is staged for it. */
+  fun publicUrlFor(trackContentUrl: String): String? = publicTrackUrls[trackContentUrl]
+
+  /**
+   * Opens (or re-opens, when the prepared item changed) a credential session for the currently
+   * prepared playback session. Fire-and-forget; safe to call redundantly.
+   */
+  fun openForCurrentSession() {
+    val session = audioPlayerHolder.currentPlayer.value?.preparedSession ?: return
+    val key = itemKey(session)
+    if (key == sessionItemKey && sessionId != null) return
+    applicationScope.launch(dispatcherProvider.io) {
+      mutex.withLock { open(session, key) }
+    }
+  }
+
+  /** Closes any staged credential session (empty body — never a zero-delta sync). */
+  fun close() {
+    if (sessionId == null) return
+    applicationScope.launch(dispatcherProvider.io) {
+      mutex.withLock { closeCurrent() }
+    }
+  }
+
+  private suspend fun open(session: Session, key: String) {
+    try {
+      val versionRaw = serverRepository.getCurrentServer()?.settings?.version ?: return
+      val version = ServerVersion.parse(versionRaw)
+      if (version == null || version < PUBLIC_SESSION_MIN_VERSION) {
+        bark { "Server $versionRaw predates public session URLs; cast stays on token URLs" }
+        return
+      }
+
+      val api = ComponentHolder.maybeComponent<CastPlaySessionUserComponent>()?.audioBookShelfApi ?: return
+      val serverUrl = userSessionManager.current.serverUrl ?: return
+
+      closeCurrent()
+
+      val deviceId = "${campfireSettings.deviceId}$CAST_DEVICE_ID_SUFFIX"
+      val playSession = api.startPlaybackSession(
+        libraryItemId = session.libraryItem.id,
+        episodeId = session.episodeId,
+        deviceInfo = DeviceInfo(
+          id = deviceId,
+          userId = session.userId,
+          deviceId = deviceId,
+          osName = applicationInfo.osName,
+          osVersion = applicationInfo.osVersion,
+          clientName = "Campfire",
+          clientVersion = applicationInfo.versionName,
+          manufacturer = applicationInfo.manufacturer,
+          model = applicationInfo.model,
+          sdkVersion = applicationInfo.sdkVersion?.toString(),
+        ),
+        mediaPlayer = CAST_MEDIA_PLAYER,
+        // forceDirectPlay wins server-side before mime negotiation is consulted
+        supportedMimeTypes = emptyList(),
+        forceDirectPlay = true,
+      ).getOrElse { error ->
+        bark(LogPriority.WARN, throwable = error) { "Unable to open cast credential session" }
+        return
+      }
+
+      val episode = session.episode
+      val urls = if (episode != null) {
+        // Podcast sessions always expose exactly one server-side track, at index 1
+        val track = episode.audioTrack ?: return
+        mapOf(track.contentUrl to publicTrackUrl(serverUrl, playSession.id, 1))
+      } else {
+        session.libraryItem.media.tracks.associate { track ->
+          track.contentUrl to publicTrackUrl(serverUrl, playSession.id, track.index)
+        }
+      }
+
+      sessionId = playSession.id
+      sessionItemKey = key
+      publicTrackUrls = urls
+      bark { "Staged cast credential session ${playSession.id} (${urls.size} tracks)" }
+    } catch (e: Throwable) {
+      bark(LogPriority.WARN, throwable = e) { "Failed to stage cast credential session" }
+    }
+  }
+
+  private suspend fun closeCurrent() {
+    val id = sessionId ?: return
+    sessionId = null
+    sessionItemKey = null
+    publicTrackUrls = emptyMap()
+    try {
+      val api = ComponentHolder.maybeComponent<CastPlaySessionUserComponent>()?.audioBookShelfApi ?: return
+      api.closePlaybackSession(id)
+        .onFailure { error ->
+          // Best-effort: the server's per-device dedupe and 36h reaper clean up strays
+          bark(LogPriority.WARN, throwable = error) { "Unable to close cast credential session $id" }
+        }
+    } catch (e: Throwable) {
+      bark(LogPriority.WARN, throwable = e) { "Unable to close cast credential session $id" }
+    }
+  }
+
+  private fun itemKey(session: Session): String {
+    return "${session.libraryItem.id}:${session.episodeId.orEmpty()}"
+  }
+
+  private fun publicTrackUrl(serverUrl: String, sessionId: String, trackIndex: Int): String {
+    return "$serverUrl/public/session/$sessionId/track/$trackIndex"
+  }
+
+  companion object {
+    private val PUBLIC_SESSION_MIN_VERSION = ServerVersion(2, 22, 0)
+    private const val CAST_DEVICE_ID_SUFFIX = "-cast"
+    private const val CAST_MEDIA_PLAYER = "chromecast"
+  }
+}

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastRemotePlayerFactory.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastRemotePlayerFactory.kt
@@ -32,6 +32,7 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class CastRemotePlayerFactory(
   private val tokenHolder: CastMediaTokenHolder,
+  private val playSessionHolder: CastPlaySessionHolder,
   private val audioPlayerHolder: AudioPlayerHolder,
 ) : RemotePlayerFactory {
 
@@ -48,12 +49,12 @@ class CastRemotePlayerFactory(
     if (SafeCastContext.isModuleUnavailable) return null
     tokenHolder.refresh()
     val remotePlayer = RemoteCastPlayer.Builder(appContext)
-      .setMediaItemConverter(CampfireMediaItemConverter(tokenHolder))
+      .setMediaItemConverter(CampfireMediaItemConverter(tokenHolder, playSessionHolder))
       .build()
     return CastPlayer.Builder(appContext)
       .setLocalPlayer(localPlayer)
       .setRemotePlayer(remotePlayer)
-      .setTransferCallback(CampfireCastTransferCallback(appContext, audioPlayerHolder))
+      .setTransferCallback(CampfireCastTransferCallback(appContext, audioPlayerHolder, playSessionHolder))
       .build()
   }
 }

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/MediaRouterCastController.kt
@@ -70,6 +70,7 @@ class MediaRouterCastController(
   private val localNetworkPermission: LocalNetworkPermissionController,
   private val dispatcherProvider: DispatcherProvider,
   private val tokenHolder: CastMediaTokenHolder,
+  private val playSessionHolder: CastPlaySessionHolder,
   @ForScope(AppScope::class) private val applicationScope: CoroutineScope,
 ) : CastController,
   CastStateListener,
@@ -148,9 +149,12 @@ class MediaRouterCastController(
       }
       ibark { "Connecting route: $route" }
       if (device.requiresSession) {
-        // Snapshot a fresh access token while the session establishes — the media item
-        // converter needs it synchronously when the queue is sent to the receiver.
+        // Stage receiver credentials while the session establishes — the media item
+        // converter needs them synchronously when the queue is sent: a credential-free
+        // public session URL map when the server supports it, and a fresh access token
+        // as the fallback either way.
         tokenHolder.refresh()
+        playSessionHolder.openForCurrentSession()
         connectToCastRoute(device.id, route)
       } else {
         // Instant output switches (this phone, Bluetooth, …). Moving off a cast route also
@@ -171,6 +175,7 @@ class MediaRouterCastController(
     try {
       cleanupConnectionAttempt()
       connectionAttempt.value = null
+      playSessionHolder.close()
       // stopCasting = true: also stop the receiver app, mirroring
       // setStopReceiverApplicationWhenEndingSession in CastOptionsProvider
       Media3Cast.getSingletonInstance(application).endCurrentSession(true)
@@ -410,6 +415,12 @@ class MediaRouterCastController(
   override fun onCastStateChanged(castState: Int) {
     state.value = castState.asDomain()
     ibark { "CastController:onCastStateChanged(state = ${castState.asDomain()})" }
+
+    // Catch-all for session ends we didn't initiate (receiver idle timeout, TV home,
+    // Google Home app): release the receiver's credential session when casting stops.
+    if (castState == GoogleCastState.NOT_CONNECTED || castState == GoogleCastState.NO_DEVICES_AVAILABLE) {
+      playSessionHolder.close()
+    }
 
     // Refresh device list so isSelected stays in sync with Cast state changes
     try {


### PR DESCRIPTION
## Summary

Phase 2 of the [/play adoption plan](https://claude.ai/code/artifact/ef6c4bdb-c6d7-45c2-a59d-b2b93a9dcbdb), stacked on #991. Retires the last known cast limitation: media URLs handed to the receiver no longer carry the ~1h-TTL access token on servers ≥ 2.22.0.

### How it works
- **`CastPlaySessionHolder`** stages a server playback session when a cast connect starts (and again at transfer time, covering connect-before-play): a `forceDirectPlay` `/play` (measured ~10ms, no ffmpeg) on a `{deviceId}-cast` device id, producing a per-track map of `/public/session/{id}/track/{index}` URLs (index 1 for podcast episodes — the server hardcodes a single track for them). The session UUID is the receiver's entire credential — verified against server source and live: the endpoint checks nothing else, no expiry short of the 36h idle reaper.
- **The session is deliberately never synced** — the phone's local accounting stays the sole stats writer, and per the live verification, a never-synced session persists nothing server-side.
- **`CampfireMediaItemConverter`** prefers the staged public URL for media; artwork keeps the `?token=` rewrite (no public-session form exists for covers). Every gap — server < 2.22.0, offline, `/play` failure, staging losing the race to the queue send, book-switch mid-cast — falls back to the token path, i.e. exactly what ships today.
- **Close is an empty-body `POST /close`** (a zero-delta sync payload would plant a stray MediaProgress row — live-verified), fired from `disconnect()` and from a `CastStateListener` NOT_CONNECTED catch-all for receiver-side ends (idle timeout, TV home, Google Home app). Strays fall to the server's per-device dedupe + 36h reaper.
- Version-gated via the new `ServerVersion` comparator from #991; UserScope API access follows the `CoverContentUserComponent` precedent since the cast module's singletons are AppScope.

### Device verification checklist
- Cast a book on ABS ≥ 2.22.0 → logcat shows "Staged cast credential session", playback survives past the 1h token expiry
- Same flow against an older server (or with staging failing) → token path, identical to current behavior
- Disconnect / stop from the receiver side → session closed (or reaped)
- Podcast episode cast → plays via `track/1`

## Testing
- `./gradlew test` passes; `alphaDebug`, `fossDebug`, and desktop compile; ktlint clean
- Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)