### PR TITLE
Attach server playback sessions with ownership-aware sync routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Listening activity now reports to the server in real time while playing, using Audiobookshelf's native session flow, instead of only syncing after pausing
+
 ### Deprecated
 
 ### Removed

--- a/core/src/commonMain/kotlin/app/campfire/core/model/Session.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/model/Session.kt
@@ -33,6 +33,21 @@ data class Session(
 
   // Podcast-only: the episode currently being played. Null for book sessions.
   val episodeId: PodcastEpisodeId? = null,
+
+  /**
+   * The id of the server-side playback session this row reports through, when one was
+   * opened via /api/items/{id}/play. Null means locally owned: listening time syncs
+   * after the fact through the local-session batch endpoint as before.
+   */
+  val serverSessionId: String? = null,
+
+  /**
+   * How much of [timeListening] has already been delivered to [serverSessionId] via
+   * /api/session/{id}/sync. If the server session dies, only the remainder may be
+   * uploaded through the local-session path — the server sums listening stats across
+   * session rows, so re-reporting server-delivered time would double-count it.
+   */
+  val reportedTimeListening: Duration = Duration.ZERO,
 ) {
   /**
    * If this is a podcast session and a matching episode is found on the library item,

--- a/data/db/core/src/commonMain/kotlin/app/campfire/db/DatabaseFactory.kt
+++ b/data/db/core/src/commonMain/kotlin/app/campfire/db/DatabaseFactory.kt
@@ -125,6 +125,7 @@ class DatabaseFactory(
       startedAtAdapter = LocalDateTimeAdapter,
       updatedAtAdapter = LocalDateTimeAdapter,
       lastPlayedAtAdapter = LocalDateTimeAdapter,
+      reportedTimeListeningAdapter = DurationAdapter,
     ),
     bookmarksAdapter = Bookmarks.Adapter(
       timeInSecondsAdapter = IntColumnAdapter,

--- a/data/db/core/src/commonMain/sqldelight/app/campfire/data/session.sq
+++ b/data/db/core/src/commonMain/sqldelight/app/campfire/data/session.sq
@@ -27,6 +27,18 @@ CREATE TABLE IF NOT EXISTS session (
   -- null-safe `IS` comparisons.
   episodeId TEXT NOT NULL DEFAULT '',
 
+  -- The id of the server-side playback session this row is attached to, when one was
+  -- opened via /api/items/{id}/play. Null means the row is locally owned: its listening
+  -- time syncs after the fact through /api/session/local-all as before.
+  serverSessionId TEXT,
+
+  -- How much of timeListening has already been delivered to the server session via
+  -- /api/session/{id}/sync. When a server session dies mid-row, only the remainder
+  -- (timeListening - reportedTimeListening) may be uploaded through the local-session
+  -- path — the server sums listening stats across session rows, so re-reporting
+  -- server-delivered time would double-count it.
+  reportedTimeListening INTEGER AS Duration NOT NULL DEFAULT 0,
+
   PRIMARY KEY(userId, libraryItemId),
   FOREIGN KEY (userId) REFERENCES user(id) ON DELETE CASCADE
 );
@@ -128,3 +140,26 @@ SET currentTime = :currentTime,
 WHERE libraryItemId = :libraryItemId
   AND userId = :userId
   AND episodeId = :episodeId;
+
+-- Attaching resets the watermark: a fresh server session has been told nothing yet.
+attachServerSession:
+UPDATE session
+SET serverSessionId = :serverSessionId,
+    reportedTimeListening = 0
+WHERE libraryItemId = :libraryItemId
+  AND userId = :userId
+  AND episodeId = :episodeId;
+
+-- Detaching keeps the watermark: it marks how much listening time the dead server session
+-- already recorded, so the local-session path only ever uploads the remainder.
+clearServerSession:
+UPDATE session
+SET serverSessionId = NULL
+WHERE libraryItemId = :libraryItemId
+  AND userId = :userId;
+
+updateReportedTimeListening:
+UPDATE session
+SET reportedTimeListening = :reportedTimeListening
+WHERE libraryItemId = :libraryItemId
+  AND userId = :userId;

--- a/data/db/core/src/commonMain/sqldelight/migrations/10.sqm
+++ b/data/db/core/src/commonMain/sqldelight/migrations/10.sqm
@@ -1,0 +1,5 @@
+-- Server playback session attachment (see session.sq): the id of the /play session this
+-- row reports through while attached, and the watermark of listening time already
+-- delivered to it so the local-session sync path can never double-report.
+ALTER TABLE session ADD COLUMN serverSessionId TEXT;
+ALTER TABLE session ADD COLUMN reportedTimeListening INTEGER NOT NULL DEFAULT 0;

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/DefaultSessionsRepository.kt
@@ -14,6 +14,7 @@ import app.campfire.core.time.FatherTime
 import app.campfire.libraries.api.LibraryItemRepository
 import app.campfire.sessions.api.SessionsRepository
 import app.campfire.sessions.db.SessionDataSource
+import app.campfire.sessions.sync.ServerSessionAttacher
 import app.campfire.user.api.MediaProgressRepository
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlin.time.Duration
@@ -29,6 +30,7 @@ class DefaultSessionsRepository(
   private val mediaProgressRepository: MediaProgressRepository,
   private val offlineDownloadManager: OfflineDownloadManager,
   private val dataSource: SessionDataSource,
+  private val serverSessionAttacher: ServerSessionAttacher,
 ) : SessionsRepository {
 
   override fun observeCurrentSession(): Flow<Session?> {
@@ -52,7 +54,7 @@ class DefaultSessionsRepository(
     val progress = mediaProgressRepository.getProgress(libraryItemId, episodeId)
     val offlineDownload = offlineDownloadManager.getForItem(libraryItem)
 
-    return dataSource.createOrStartSession(
+    val session = dataSource.createOrStartSession(
       libraryItemId = libraryItemId,
       playMethod = if (offlineDownload.isCompleted) {
         PlayMethod.Local
@@ -62,6 +64,12 @@ class DefaultSessionsRepository(
       progress = progress,
       episodeId = episodeId,
     )
+
+    // Opportunistic, fire-and-forget: playback never waits on this. If it lands, the row
+    // reports through the server session; if not, nothing changes.
+    serverSessionAttacher.attachAsync(session)
+
+    return session
   }
 
   override suspend fun markDeleted(libraryItemId: LibraryItemId, episodeId: PodcastEpisodeId?) {

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SessionDataSource.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SessionDataSource.kt
@@ -62,4 +62,22 @@ interface SessionDataSource {
     libraryItemId: LibraryItemId,
     episodeId: PodcastEpisodeId? = null,
   )
+
+  /** Attaches a server playback session to the row, resetting its reported watermark. */
+  suspend fun attachServerSession(
+    libraryItemId: LibraryItemId,
+    serverSessionId: String,
+    episodeId: PodcastEpisodeId? = null,
+  )
+
+  /**
+   * Detaches the server session, keeping the reported watermark so the local-session sync
+   * path only ever uploads the unreported remainder of the row's listening time.
+   */
+  suspend fun clearServerSession(libraryItemId: LibraryItemId)
+
+  suspend fun updateReportedTimeListening(
+    libraryItemId: LibraryItemId,
+    reported: Duration,
+  )
 }

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SqlDelightSessionDataSource.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/db/SqlDelightSessionDataSource.kt
@@ -229,6 +229,8 @@ class SqlDelightSessionDataSource(
         startedAt = now,
         updatedAt = now,
         episodeId = episodeId.orEmpty(),
+        serverSessionId = null,
+        reportedTimeListening = Duration.ZERO,
       )
 
       // Insert, replacing any existing session and disable any other active sessions
@@ -323,6 +325,46 @@ class SqlDelightSessionDataSource(
     }
   }
 
+  override suspend fun attachServerSession(
+    libraryItemId: LibraryItemId,
+    serverSessionId: String,
+    episodeId: PodcastEpisodeId?,
+  ) {
+    val currentUserId = userSession.userId ?: return
+    write {
+      db.sessionQueries.attachServerSession(
+        serverSessionId = serverSessionId,
+        libraryItemId = libraryItemId,
+        userId = currentUserId,
+        episodeId = episodeId.orEmpty(),
+      )
+    }
+  }
+
+  override suspend fun clearServerSession(libraryItemId: LibraryItemId) {
+    val currentUserId = userSession.userId ?: return
+    write {
+      db.sessionQueries.clearServerSession(
+        libraryItemId = libraryItemId,
+        userId = currentUserId,
+      )
+    }
+  }
+
+  override suspend fun updateReportedTimeListening(
+    libraryItemId: LibraryItemId,
+    reported: Duration,
+  ) {
+    val currentUserId = userSession.userId ?: return
+    write {
+      db.sessionQueries.updateReportedTimeListening(
+        reportedTimeListening = reported,
+        libraryItemId = libraryItemId,
+        userId = currentUserId,
+      )
+    }
+  }
+
   private suspend fun hydrateSession(session: DbSession): Session {
     val libraryItem = libraryItemRepository.getLibraryItem(session.libraryItemId)
     return Session(
@@ -340,6 +382,8 @@ class SqlDelightSessionDataSource(
       updatedAt = session.updatedAt,
       // '' is the DB sentinel for "no episode" (book progress) — surface as null.
       episodeId = session.episodeId.takeIf { it.isNotEmpty() },
+      serverSessionId = session.serverSessionId,
+      reportedTimeListening = session.reportedTimeListening,
     )
   }
 

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/LocalSessionUpdateSynchronizer.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/LocalSessionUpdateSynchronizer.kt
@@ -91,8 +91,12 @@ class LocalSessionUpdateSynchronizer(
       }
     }
 
-    // Trigger an update if conditions are right
-//    component.remoteSessionsUpdater.update()
+    // Periodic sync while playing (throttled to 15s/60s-metered inside the updater).
+    // This was disabled in #682 out of caution for multi-device sync, but the protection
+    // was never write-avoidance: the MediaProgress source-of-truth freshness guard is what
+    // keeps a device's own server echoes from clobbering fresher local state, and the
+    // progress PATCH path pushed on this same cadence all along.
+    component.remoteSessionsUpdater.update()
   }
 
   companion object : Corked("LocalSessionUpdateSynchronizer") {

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/RemoteSessionsUpdater.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/RemoteSessionsUpdater.kt
@@ -7,14 +7,17 @@ import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.logging.Cork
+import app.campfire.core.model.Session
 import app.campfire.core.session.UserSession
 import app.campfire.core.session.userId
 import app.campfire.core.time.FatherTime
+import app.campfire.network.ApiException
 import app.campfire.network.AudioBookShelfApi
 import app.campfire.sessions.db.SessionDataSource
 import app.campfire.sessions.network.NetworkSessionMapper
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import dev.jordond.connectivity.Connectivity
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -33,6 +36,7 @@ class NetworkRemoteSessionsUpdater(
   private val api: AudioBookShelfApi,
   private val sessionDataSource: SessionDataSource,
   private val networkSessionMapper: NetworkSessionMapper,
+  private val serverSessionAttacher: ServerSessionAttacher,
   private val userSession: UserSession,
   private val connectivity: Connectivity,
   private val fatherTime: FatherTime,
@@ -48,6 +52,12 @@ class NetworkRemoteSessionsUpdater(
       wbark { "A sync job is already in progress, skipping" }
       return@withContext
     }
+
+    // Cheap throttle first: this is called from the 500ms playback tick, so bail on the
+    // unmetered interval before touching platform connectivity. The final (possibly
+    // stricter metered) interval is re-checked against the actual connection below.
+    val elapsedSinceSync = fatherTime.nowInEpochMillis() - lastSyncTimeMs
+    if (elapsedSinceSync < SYNC_INTERVAL_NOT_METERED && !skipInterval) return@withContext
 
     // Check for connectivity
     val status = connectivity.status()
@@ -79,12 +89,82 @@ class NetworkRemoteSessionsUpdater(
     // Read local sessions from db
     val currentUserId = userSession.userId ?: return
 
-    // Filter out any with insufficient listening time
-    val localSessions = sessionDataSource.getSessions(currentUserId).filter { session ->
-      // Omit sessions that have < 5s of listening time. These could likely be errant, or restoration sessions
-      // and we should hold off on uploading them until they have a significant amount of listening time
-      session.timeListening > 5.seconds
+    // Sessions with an attach in flight are pending: exactly one sync path may ever report
+    // a listening interval, so they wait for the attach to resolve to SERVER or LOCAL.
+    val sessions = sessionDataSource.getSessions(currentUserId)
+      .filterNot { serverSessionAttacher.isAttachPending(it.libraryItem.id) }
+
+    val (serverOwned, localOwned) = sessions.partition { it.serverSessionId != null }
+
+    serverOwned.forEach { session -> syncServerSession(session) }
+    syncLocalSessions(localOwned)
+  }
+
+  /**
+   * Reports the unreported listening delta into the row's server session, advancing the
+   * watermark on success. A 404 means the server lost the session (restart, idle reaper,
+   * same-device supersession): the row detaches and falls back to the local path — where
+   * the watermark ensures only the still-unreported remainder is ever uploaded.
+   */
+  private suspend fun syncServerSession(session: Session) {
+    val serverSessionId = session.serverSessionId ?: return
+    val delta = session.timeListening - session.reportedTimeListening
+    val isEnded = session.isFinished || session.isDeleted
+
+    if (delta <= Duration.ZERO && !isEnded) return
+
+    val result = if (isEnded) {
+      // Close carries the final delta inline (or an empty body when there is none — a
+      // zero-delta sync payload would plant a stray media progress write server-side)
+      api.closePlaybackSession(
+        sessionId = serverSessionId,
+        currentTime = session.currentTime.asSecondsDouble(),
+        timeListened = delta.asSecondsDouble(),
+        duration = session.duration.asSecondsDouble(),
+      )
+    } else {
+      api.syncPlaybackSession(
+        sessionId = serverSessionId,
+        currentTime = session.currentTime.asSecondsDouble(),
+        timeListened = delta.asSecondsDouble(),
+        duration = session.duration.asSecondsDouble(),
+      )
     }
+
+    result
+      .onSuccess {
+        if (isEnded) {
+          sessionDataSource.deleteSession(session.libraryItem.id)
+          ibark { "Closed server session $serverSessionId and deleted its row" }
+        } else {
+          sessionDataSource.updateReportedTimeListening(
+            libraryItemId = session.libraryItem.id,
+            reported = session.reportedTimeListening + delta,
+          )
+          dbark { "Synced ${delta.inWholeSeconds}s into server session $serverSessionId" }
+        }
+      }
+      .onFailure { error ->
+        if ((error as? ApiException)?.statusCode == 404) {
+          wbark { "Server session $serverSessionId is gone; row falls back to local sync" }
+          sessionDataSource.clearServerSession(session.libraryItem.id)
+        } else {
+          ebark(error) { "Failed to sync server session $serverSessionId" }
+        }
+      }
+  }
+
+  private suspend fun syncLocalSessions(sessions: List<Session>) {
+    // Filter out any with insufficient listening time, counting only what the local path
+    // still owes: time already reported through a (now dead) server session must never be
+    // re-uploaded — the server sums listening stats across session rows.
+    val localSessions = sessions
+      .map { session -> session.copy(timeListening = session.timeListening - session.reportedTimeListening) }
+      .filter { session ->
+        // Omit sessions that have < 5s of listening time. These could likely be errant, or restoration sessions
+        // and we should hold off on uploading them until they have a significant amount of listening time
+        session.timeListening > 5.seconds
+      }
 
     if (localSessions.isNotEmpty()) {
       val networkPlaybackSessions = localSessions.map { networkSessionMapper.map(it) }
@@ -94,6 +174,11 @@ class NetworkRemoteSessionsUpdater(
           ibark { "Local Session Sync Successful!" }
           r.results.forEach { result ->
             dbark { "--> Sync Result $result" }
+            if (!result.progressSynced) {
+              // Not an error: the server's recency guard skipped the MediaProgress write
+              // because another device wrote fresher progress (last-write-wins working)
+              dbark { "Server skipped progress write for ${result.id} (fresher progress exists)" }
+            }
             if (result.success) {
               // Check if session is a completed or deleted session
               val localSession = localSessions.find { it.id.toString() == result.id }
@@ -112,8 +197,11 @@ class NetworkRemoteSessionsUpdater(
     }
   }
 
+  private fun Duration.asSecondsDouble(): Double = inWholeMilliseconds / 1000.0
+
   companion object : Cork {
     override val tag: String = "NetworkRemoteSessionsUpdater"
+    override val enabled: Boolean = true
 
     private const val SYNC_INTERVAL_NOT_METERED = 15_000L // 15s
     private const val SYNC_INTERVAL_METERED = 60_000L // 1m

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/ServerSessionAttacher.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/ServerSessionAttacher.kt
@@ -1,0 +1,187 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.sessions.sync
+
+import app.campfire.core.Platform.ANDROID
+import app.campfire.core.Platform.DESKTOP
+import app.campfire.core.Platform.IOS
+import app.campfire.core.app.ApplicationInfo
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.currentPlatform
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import app.campfire.core.di.qualifier.ForScope
+import app.campfire.core.logging.Cork
+import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.PlayMethod
+import app.campfire.core.model.Session
+import app.campfire.network.AudioBookShelfApi
+import app.campfire.network.models.DeviceInfo
+import app.campfire.sessions.db.SessionDataSource
+import app.campfire.settings.api.CampfireSettings
+import app.campfire.settings.api.PlaybackSettings
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Opportunistically attaches a server playback session (`POST /api/items/{id}/play`) to a
+ * freshly created local session — the canonical ABS flow — without playback ever waiting on
+ * it. Local playback starts immediately; when the attach lands (a ~10ms metadata call under
+ * `forceDirectPlay` — no ffmpeg), the row's listening deltas route to
+ * `/api/session/{id}/sync` instead of the after-the-fact local-session batch.
+ *
+ * While an attach is in flight the row is *pending*: [isAttachPending] lets the local-session
+ * sweep skip it, so exactly one sync path ever reports a given listening interval. Pending
+ * state is deliberately in-memory only — a process death mid-attach reverts the row to plain
+ * local ownership, which is the designed fallback for every failure here (offline, old
+ * server, /play error, timeout).
+ */
+interface ServerSessionAttacher {
+
+  /** True while a /play attach is in flight for [libraryItemId]. */
+  fun isAttachPending(libraryItemId: LibraryItemId): Boolean
+
+  /** Fire-and-forget: attaches a server session to [session] when eligible. */
+  fun attachAsync(session: Session)
+}
+
+@SingleIn(UserScope::class)
+@ContributesBinding(UserScope::class, boundType = ServerSessionAttacher::class)
+@Inject
+class DefaultServerSessionAttacher(
+  private val api: AudioBookShelfApi,
+  private val sessionDataSource: SessionDataSource,
+  private val campfireSettings: CampfireSettings,
+  private val playbackSettings: PlaybackSettings,
+  private val applicationInfo: ApplicationInfo,
+  private val dispatcherProvider: DispatcherProvider,
+  @ForScope(AppScope::class) private val applicationScope: CoroutineScope,
+) : ServerSessionAttacher, Cork {
+
+  override val tag: String = "ServerSessionAttacher"
+  override val enabled: Boolean = true
+
+  private val pending = mutableSetOf<LibraryItemId>()
+
+  override fun isAttachPending(libraryItemId: LibraryItemId): Boolean {
+    return synchronized(pending) { libraryItemId in pending }
+  }
+
+  override fun attachAsync(session: Session) {
+    // Downloads play entirely locally and never open server sessions
+    if (session.playMethod == PlayMethod.Local) return
+    if (!playbackSettings.serverSessionsEnabled) return
+    if (session.serverSessionId != null) return
+
+    val itemId = session.libraryItem.id
+    val alreadyPending = synchronized(pending) { !pending.add(itemId) }
+    if (alreadyPending) return
+
+    applicationScope.launch(dispatcherProvider.io) {
+      try {
+        attach(session)
+      } finally {
+        synchronized(pending) { pending.remove(itemId) }
+      }
+    }
+  }
+
+  private suspend fun attach(session: Session) {
+    val playSession = withTimeoutOrNull(ATTACH_TIMEOUT_MS) {
+      api.startPlaybackSession(
+        libraryItemId = session.libraryItem.id,
+        episodeId = session.episodeId,
+        deviceInfo = deviceInfo(session),
+        mediaPlayer = platformMediaPlayer(),
+        supportedMimeTypes = platformSupportedMimeTypes(),
+        forceDirectPlay = true,
+      ).getOrElse { error ->
+        wbark(throwable = error) { "Server session attach failed; row stays locally owned" }
+        null
+      }
+    }
+
+    if (playSession == null) {
+      dbark { "No server session attached for ${session.libraryItem.id}" }
+      return
+    }
+
+    sessionDataSource.attachServerSession(
+      libraryItemId = session.libraryItem.id,
+      serverSessionId = playSession.id,
+      episodeId = session.episodeId,
+    )
+    ibark { "Attached server session ${playSession.id} to ${session.libraryItem.id}" }
+  }
+
+  /** Always the complete object: the server nulls stored device fields missing from a payload. */
+  private fun deviceInfo(session: Session): DeviceInfo {
+    val deviceId = campfireSettings.deviceId
+    return DeviceInfo(
+      id = deviceId,
+      userId = session.userId,
+      deviceId = deviceId,
+      osName = applicationInfo.osName,
+      osVersion = applicationInfo.osVersion,
+      clientName = "Campfire",
+      clientVersion = applicationInfo.versionName,
+      manufacturer = applicationInfo.manufacturer,
+      model = applicationInfo.model,
+      sdkVersion = applicationInfo.sdkVersion?.toString(),
+    )
+  }
+
+  private fun platformMediaPlayer(): String = when (currentPlatform) {
+    ANDROID -> "exo-player"
+    IOS -> "av-player"
+    DESKTOP -> "vlc"
+  }
+
+  /**
+   * The mime types this platform's player can direct-play. Only consulted server-side when
+   * force flags are absent, but sent truthfully anyway: it is what the server would use to
+   * negotiate once transcode support lands, and omitting it silently forces transcode.
+   */
+  private fun platformSupportedMimeTypes(): List<String> = when (currentPlatform) {
+    ANDROID, DESKTOP -> listOf(
+      "audio/flac",
+      "audio/mpeg",
+      "audio/mp3",
+      "audio/mp4",
+      "audio/aac",
+      "audio/mp4a-latm",
+      "audio/x-m4a",
+      "audio/x-m4b",
+      "audio/ogg",
+      "audio/vorbis",
+      "audio/opus",
+      "audio/webm",
+      "audio/wav",
+      "audio/x-wav",
+    )
+
+    IOS -> listOf(
+      "audio/flac",
+      "audio/mpeg",
+      "audio/mp3",
+      "audio/mp4",
+      "audio/aac",
+      "audio/mp4a-latm",
+      "audio/x-m4a",
+      "audio/x-m4b",
+      "audio/wav",
+      "audio/x-wav",
+      "audio/aiff",
+      "audio/x-aiff",
+    )
+  }
+
+  companion object {
+    private const val ATTACH_TIMEOUT_MS = 10_000L
+  }
+}

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/ServerSessionAttacher.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/ServerSessionAttacher.kt
@@ -23,6 +23,8 @@ import app.campfire.sessions.db.SessionDataSource
 import app.campfire.settings.api.CampfireSettings
 import app.campfire.settings.api.PlaybackSettings
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -50,6 +52,7 @@ interface ServerSessionAttacher {
   fun attachAsync(session: Session)
 }
 
+@OptIn(ExperimentalAtomicApi::class)
 @SingleIn(UserScope::class)
 @ContributesBinding(UserScope::class, boundType = ServerSessionAttacher::class)
 @Inject
@@ -66,10 +69,12 @@ class DefaultServerSessionAttacher(
   override val tag: String = "ServerSessionAttacher"
   override val enabled: Boolean = true
 
-  private val pending = mutableSetOf<LibraryItemId>()
+  // Copy-on-write set behind a multiplatform atomic: `synchronized` is JVM-only and this
+  // class is commonMain (compiled for iOS too)
+  private val pending = AtomicReference<Set<LibraryItemId>>(emptySet())
 
   override fun isAttachPending(libraryItemId: LibraryItemId): Boolean {
-    return synchronized(pending) { libraryItemId in pending }
+    return libraryItemId in pending.load()
   }
 
   override fun attachAsync(session: Session) {
@@ -79,15 +84,30 @@ class DefaultServerSessionAttacher(
     if (session.serverSessionId != null) return
 
     val itemId = session.libraryItem.id
-    val alreadyPending = synchronized(pending) { !pending.add(itemId) }
-    if (alreadyPending) return
+    if (!markPending(itemId)) return
 
     applicationScope.launch(dispatcherProvider.io) {
       try {
         attach(session)
       } finally {
-        synchronized(pending) { pending.remove(itemId) }
+        clearPending(itemId)
       }
+    }
+  }
+
+  /** Returns false when [itemId] was already pending. */
+  private fun markPending(itemId: LibraryItemId): Boolean {
+    while (true) {
+      val current = pending.load()
+      if (itemId in current) return false
+      if (pending.compareAndSet(current, current + itemId)) return true
+    }
+  }
+
+  private fun clearPending(itemId: LibraryItemId) {
+    while (true) {
+      val current = pending.load()
+      if (pending.compareAndSet(current, current - itemId)) return
     }
   }
 

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/PlaybackSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/PlaybackSettings.kt
@@ -52,6 +52,15 @@ interface PlaybackSettings {
   fun observePlaybackHistoryEnabled(): StateFlow<Boolean>
 
   /**
+   * When true (the default), streaming playback opportunistically opens a server playback
+   * session and reports listening in real time through it. When false, every session is
+   * locally owned and syncs after the fact — the pre-server-session behavior, and the
+   * escape hatch if server-session accounting misbehaves.
+   */
+  var serverSessionsEnabled: Boolean
+  fun observeServerSessionsEnabled(): StateFlow<Boolean>
+
+  /**
    * When true, resuming playback after a pause rewinds by an amount that scales with how long playback was
    * paused, per the sliding window derived from [resumeRewindConfig].
    */

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/PlaybackSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/PlaybackSettingsImpl.kt
@@ -79,6 +79,10 @@ class PlaybackSettingsImpl(
   override var playbackHistoryEnabled: Boolean by playbackHistoryEnabledProperty
   override fun observePlaybackHistoryEnabled(): StateFlow<Boolean> = playbackHistoryEnabledProperty.observe()
 
+  private val serverSessionsEnabledProperty = booleanSetting(PREF_SERVER_SESSIONS, DEFAULT_SERVER_SESSIONS)
+  override var serverSessionsEnabled: Boolean by serverSessionsEnabledProperty
+  override fun observeServerSessionsEnabled(): StateFlow<Boolean> = serverSessionsEnabledProperty.observe()
+
   private val autoRewindOnResumeEnabledProperty = booleanSetting(
     PREF_AUTO_REWIND_ON_RESUME,
     DEFAULT_AUTO_REWIND_ON_RESUME,
@@ -170,6 +174,7 @@ internal const val PREF_SYNC = "pref_synchronization"
 internal const val PREF_AUTO_SYNC = "pref_auto_sync"
 internal const val PREF_REMOTE_NEXT_PREV_SKIPS_CHAPTERS = "pref_playback_remote_next_prev_skips_chapters"
 internal const val PREF_PLAYBACK_HISTORY = "pref_playback_history_enabled"
+internal const val PREF_SERVER_SESSIONS = "pref_server_sessions_enabled"
 internal const val PREF_MIN_PAUSE_THRESHOLD = "pref_playback_resume_rewind_min_pause_threshold"
 internal const val PREF_MIN_RESUME_REWIND = "pref_playback_resume_rewind_min"
 internal const val PREF_MAX_RESUME_REWIND = "pref_playback_resume_rewind_max"
@@ -190,5 +195,6 @@ internal const val DEFAULT_PLAYBACK_SPEED = 1f
 internal const val DEFAULT_REMOTE_NEXT_PREV_SKIPS_CHAPTERS = false
 internal const val DEFAULT_AUTO_SYNC = true
 internal const val DEFAULT_PLAYBACK_HISTORY = true
+internal const val DEFAULT_SERVER_SESSIONS = true
 internal const val DEFAULT_AUTO_REWIND_ON_RESUME = false
 internal const val DEFAULT_AUTO_REWIND_STOP_AT_CHAPTER = true

--- a/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/FakePlaybackSettings.kt
+++ b/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/FakePlaybackSettings.kt
@@ -73,6 +73,12 @@ class FakePlaybackSettings : PlaybackSettings {
     set(value) { _playbackHistoryEnabled.value = value }
   override fun observePlaybackHistoryEnabled(): StateFlow<Boolean> = _playbackHistoryEnabled.asStateFlow()
 
+  private val _serverSessionsEnabled = MutableStateFlow(true)
+  override var serverSessionsEnabled: Boolean
+    get() = _serverSessionsEnabled.value
+    set(value) { _serverSessionsEnabled.value = value }
+  override fun observeServerSessionsEnabled(): StateFlow<Boolean> = _serverSessionsEnabled.asStateFlow()
+
   private val _autoRewindOnResumeEnabled = MutableStateFlow(false)
   override var autoRewindOnResumeEnabled: Boolean
     get() = _autoRewindOnResumeEnabled.value


### PR DESCRIPTION
## Summary

Phase 3a of the [/play adoption plan](https://claude.ai/code/artifact/ef6c4bdb-c6d7-45c2-a59d-b2b93a9dcbdb): the **sync-ownership backbone**. Streaming playback now follows ABS's canonical session flow — open `/play`, sync it in real time, close it — as an *opportunistic background attachment* that playback never waits on. Downloads, offline, old servers, the kill switch, and every failure path keep today's local-first behavior bit-for-bit.

### The ownership model
- **Attach** (`ServerSessionAttacher`): fire-and-forget `forceDirectPlay` `/play` (~10ms measured, no ffmpeg) from `createSession` for streaming items — phone device id, complete `DeviceInfo` (partial payloads erode the server's device record), honest per-platform `supportedMimeTypes`. PENDING is in-memory only: a crash mid-attach reverts to plain local ownership.
- **Schema** (additive migration 10): `serverSessionId` + `reportedTimeListening` on the session row. The watermark is the anti-double-count mechanism — the server *sums listening stats across session rows* (live-proven), so a row that lived partly on a dead server session may only upload the remainder through the local path.
- **Sweep** (`RemoteSessionsUpdater`): server-owned rows send positive deltas to `/api/session/{id}/sync` (never zero-delta — those plant stray MediaProgress writes) and advance the watermark; finished/deleted rows close with the final delta inline and delete on confirmation; 404 detaches back to local. Local-owned rows batch via local-all minus their watermark; PENDING rows are skipped. **Exactly one writer per listening interval, enforced structurally.**
- **Periodic sync re-enabled** (the #682 comment-out): archaeology + live verification showed the multi-device protection was never write-avoidance — the MediaProgress SoT freshness guard is what protects the sync banner, and the progress PATCH pushed on this same cadence all along. Both ownership modes now sync every 15s (60s metered) while playing, making the admin "listening now" data truthful.
- **Kill switch**: `PlaybackSettings.serverSessionsEnabled` (default on) forces everything local; its UI ships in the follow-up PR (3b) with the progress-PATCH retirement and the Streaming settings group.

### Verification
- `./gradlew test` + `verifyCommonMainCampfireDatabaseMigration` pass; `alphaDebug`, `fossDebug`, desktop compile; ktlint clean
- Device checklist: play a streamed book → logcat "Attached server session"; admin sessions view shows the session advancing during playback; pause/stop → session closes; kill switch off → no /play calls, behavior identical to today; downloaded book → no /play

Mostly plumbing + commonMain logic; `skip-coverage` for the network-adjacent classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)