### PR TITLE
Consolidate progress writers and surface the server-sessions setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Playback setting to turn off real-time server listening sessions, reverting to sync-after-pause
+
 ### Changed
 
 - Listening activity now reports to the server in real time while playing, using Audiobookshelf's native session flow, instead of only syncing after pausing

--- a/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/MediaProgressPlaybackSynchronizer.kt
+++ b/features/sessions/impl/src/commonMain/kotlin/app/campfire/sessions/sync/MediaProgressPlaybackSynchronizer.kt
@@ -108,6 +108,12 @@ class MediaProgressPlaybackSynchronizer : PlaybackSynchronizer {
       source = MediaProgress.Source.Local,
     )
 
-    component.mediaProgressRepository.updateProgress(updatedProgress, force)
+    // Local mirror only: this keeps the row that drives the sync banner and resume logic
+    // fresh, but never uploads. The server learns playback progress exclusively through
+    // session syncs now (/api/session/{id}/sync while attached, the local-session batch
+    // otherwise — both write server-side MediaProgress), so a parallel PATCH here would be
+    // a redundant second writer of the same position. Explicit finish/unfinish actions
+    // still upload through markFinished/markNotFinished, which this path never handled.
+    component.mediaProgressRepository.updateProgress(updatedProgress, force, skipUpload = true)
   }
 }

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -85,6 +85,9 @@
   <string name="setting_playback_resume_rewind_tier_title">Paused ≥ %1$s</string>
   <string name="setting_playback_resume_rewind_none">None</string>
   <string name="header_synchronization">Synchronization</string>
+  <string name="header_streaming">Streaming</string>
+  <string name="setting_server_sessions_title">Server listening sessions</string>
+  <string name="setting_server_sessions_subtitle">Report your listening to the server in real time while streaming. When off, listening syncs after you pause instead</string>
   <string name="header_playback_history">History</string>
   <string name="setting_playback_history_title">Enable playback history</string>
   <string name="setting_playback_history_subtitle">Record playback actions like play, pause, and seek. Disabling this will clear all existing history.</string>

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -68,6 +68,7 @@ import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.PlaybackHis
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.PlaybackWavyScrubber
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.RemoteNextPrevSkipsChapters
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ResumeRewindRange
+import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ServerSessionsEnabled
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.SyncEnabled
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.TrackResetThreshold
 import app.campfire.ui.settings.SettingsUiEvent.SleepSettingEvent.AutoSleepRewindAmount
@@ -154,6 +155,7 @@ class SettingsPresenter(
     }.collectAsState()
     val syncEnabled by remember { playbackSettings.observeSyncEnabled() }.collectAsState()
     val autoSyncEnabled by remember { playbackSettings.observeAutoSyncEnabled() }.collectAsState()
+    val serverSessionsEnabled by remember { playbackSettings.observeServerSessionsEnabled() }.collectAsState()
     val playbackHistoryEnabled by remember { playbackSettings.observePlaybackHistoryEnabled() }.collectAsState()
     val autoRewindOnResumeEnabled by remember { playbackSettings.observeAutoRewindOnResumeEnabled() }.collectAsState()
     val resumeRewindConfig by remember { playbackSettings.observeResumeRewindConfig() }.collectAsState()
@@ -261,6 +263,7 @@ class SettingsPresenter(
         mp3IndexSeeking = mp3IndexSeeking,
         remoteNextPrevSkipsChapters = remoteNextPrevSkipsChapters,
         syncEnabled = syncEnabled,
+        serverSessionsEnabled = serverSessionsEnabled,
         autoSyncEnabled = syncEnabled && autoSyncEnabled,
         playbackHistoryEnabled = playbackHistoryEnabled,
         autoRewindOnResumeEnabled = autoRewindOnResumeEnabled,
@@ -359,6 +362,7 @@ class SettingsPresenter(
             playbackSettings.remoteNextPrevSkipsChapters = event.remoteNextPrevSkipsChapters
           is SyncEnabled -> playbackSettings.syncEnabled = event.enabled
           is AutoSyncEnabled -> playbackSettings.autoSyncEnabled = event.enabled
+          is ServerSessionsEnabled -> playbackSettings.serverSessionsEnabled = event.enabled
           is PlaybackHistoryEnabled -> {
             playbackSettings.playbackHistoryEnabled = event.enabled
             if (!event.enabled) {

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -85,6 +85,7 @@ data class PlaybackSettingsInfo(
   val remoteNextPrevSkipsChapters: Boolean,
   val syncEnabled: Boolean,
   val autoSyncEnabled: Boolean,
+  val serverSessionsEnabled: Boolean,
   val playbackHistoryEnabled: Boolean,
   val autoRewindOnResumeEnabled: Boolean,
   val resumeRewindConfig: ResumeRewindConfig,
@@ -195,6 +196,7 @@ sealed interface SettingsUiEvent : CircuitUiEvent {
     data class RemoteNextPrevSkipsChapters(val remoteNextPrevSkipsChapters: Boolean) : PlaybackSettingEvent
     data class SyncEnabled(val enabled: Boolean) : PlaybackSettingEvent
     data class AutoSyncEnabled(val enabled: Boolean) : PlaybackSettingEvent
+    data class ServerSessionsEnabled(val enabled: Boolean) : PlaybackSettingEvent
     data class PlaybackHistoryEnabled(val enabled: Boolean) : PlaybackSettingEvent
     data class AutoRewindOnResumeEnabled(val enabled: Boolean) : PlaybackSettingEvent
     data class MinPauseThreshold(val threshold: Duration) : PlaybackSettingEvent

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
@@ -31,6 +31,7 @@ import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ForwardTime
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.Mp3IndexSeeking
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.PlaybackHistoryEnabled
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.RemoteNextPrevSkipsChapters
+import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ServerSessionsEnabled
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.SyncEnabled
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.TrackResetThreshold
 import app.campfire.ui.settings.SettingsUiEvent.SleepSettingEvent.AutoSleepRewindAmount
@@ -90,6 +91,7 @@ class SettingsAnalyticUiEventHandler(
       )
       is SyncEnabled -> send("sync", Updated, event.enabled)
       is AutoSyncEnabled -> send("auto_sync", Updated, event.enabled)
+      is ServerSessionsEnabled -> send("server_sessions", Updated, event.enabled)
       is PlaybackHistoryEnabled -> send("playback_history", Updated, event.enabled)
       is SettingsUiEvent.PlaybackSettingEvent.AutoRewindOnResumeEnabled ->
         send("auto_rewind_on_resume", Updated, event.enabled)

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/PlaybackPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/PlaybackPane.kt
@@ -23,6 +23,7 @@ import campfire.features.settings.ui.generated.resources.Res
 import campfire.features.settings.ui.generated.resources.header_auto_rewind_on_resume
 import campfire.features.settings.ui.generated.resources.header_playback_history
 import campfire.features.settings.ui.generated.resources.header_player_interface
+import campfire.features.settings.ui.generated.resources.header_streaming
 import campfire.features.settings.ui.generated.resources.header_synchronization
 import campfire.features.settings.ui.generated.resources.setting_playback_auto_rewind_on_resume_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_auto_rewind_on_resume_title
@@ -54,6 +55,8 @@ import campfire.features.settings.ui.generated.resources.setting_playback_track_
 import campfire.features.settings.ui.generated.resources.setting_playback_track_reset_title
 import campfire.features.settings.ui.generated.resources.setting_playback_wavy_scrubber_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_wavy_scrubber_title
+import campfire.features.settings.ui.generated.resources.setting_server_sessions_subtitle
+import campfire.features.settings.ui.generated.resources.setting_server_sessions_title
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import org.jetbrains.compose.resources.stringResource
@@ -223,6 +226,19 @@ internal fun PlaybackPane(
         supportingContent = { Text(stringResource(Res.string.setting_playback_auto_sync_subtitle)) },
       )
     }
+
+    Header(
+      title = { Text(stringResource(Res.string.header_streaming)) },
+    )
+
+    SwitchSetting(
+      value = state.playbackSettings.serverSessionsEnabled,
+      onValueChange = {
+        state.eventSink(PlaybackSettingEvent.ServerSessionsEnabled(it))
+      },
+      headlineContent = { Text(stringResource(Res.string.setting_server_sessions_title)) },
+      supportingContent = { Text(stringResource(Res.string.setting_server_sessions_subtitle)) },
+    )
 
     Header(
       title = { Text(stringResource(Res.string.header_playback_history)) },

--- a/features/user/api/src/commonMain/kotlin/app/campfire/user/api/MediaProgressRepository.kt
+++ b/features/user/api/src/commonMain/kotlin/app/campfire/user/api/MediaProgressRepository.kt
@@ -37,11 +37,16 @@ interface MediaProgressRepository {
    * @param skipUpload When `true`, the local write happens but the synchronizer's upload back
    *   to the server is suppressed. Use this when the progress originated remotely (e.g. came
    *   in over the socket from another client) so we don't echo it back to the server.
+   * @param onlyIfFresher When `true`, the write is skipped entirely if the stored row has a
+   *   newer [MediaProgress.lastUpdate] than [newProgress]. Use this for remotely-originated
+   *   writes so a device's own (throttled, therefore stale) server echo can never clobber
+   *   the fresher local row it is continuously writing during playback.
    */
   suspend fun updateProgress(
     newProgress: MediaProgress,
     force: Boolean = false,
     skipUpload: Boolean = false,
+    onlyIfFresher: Boolean = false,
   )
 
   suspend fun deleteProgress(

--- a/features/user/impl/src/commonMain/kotlin/app/campfire/user/StoreMediaProgressRepository.kt
+++ b/features/user/impl/src/commonMain/kotlin/app/campfire/user/StoreMediaProgressRepository.kt
@@ -107,9 +107,10 @@ class StoreMediaProgressRepository(
     newProgress: MediaProgress,
     force: Boolean,
     skipUpload: Boolean,
+    onlyIfFresher: Boolean,
   ) {
     // Update local storage
-    val progressId = db.mediaProgressQueries.transactionWithResult {
+    val progressId = db.mediaProgressQueries.transactionWithResult<String?> {
       val existing = db.mediaProgressQueries.selectForEpisode(
         userId = newProgress.userId,
         libraryItemId = newProgress.libraryItemId,
@@ -117,12 +118,19 @@ class StoreMediaProgressRepository(
         episodeId = newProgress.episodeId.orEmpty(),
       ).awaitAsOneOrNull()
 
+      if (onlyIfFresher && existing != null && existing.lastUpdate > newProgress.lastUpdate) {
+        // The stored row is fresher (e.g. this device's own live playback writes) —
+        // dropping the incoming stale echo is the same last-write-wins rule the fetch
+        // path's insertIfFresher applies.
+        return@transactionWithResult null
+      }
+
       db.mediaProgressQueries.insert(
         newProgress.asDbModel(existing?.id),
       )
 
       existing?.id?.takeIf { it != MediaProgress.UNKNOWN_ID } ?: newProgress.id
-    }
+    } ?: return
 
     val updatedProgress = newProgress.copy(id = progressId)
 

--- a/features/user/impl/src/commonMain/kotlin/app/campfire/user/mediaprogress/MediaProgressSocketListener.kt
+++ b/features/user/impl/src/commonMain/kotlin/app/campfire/user/mediaprogress/MediaProgressSocketListener.kt
@@ -19,9 +19,13 @@ class MediaProgressSocketListener(
 ) : SocketEventListener {
   override suspend fun handle(event: SocketEvent) {
     if (event !is UserItemProgressUpdated) return
+    // skipUpload: never echo a remote write back to the server. onlyIfFresher: server
+    // session syncs make this device's own echoes arrive here frequently while playing;
+    // last-write-wins keeps them from clobbering the fresher local row.
     mediaProgressRepository.updateProgress(
       newProgress = event.payload.data.asDomainModel(),
       skipUpload = true,
+      onlyIfFresher = true,
     )
   }
 }

--- a/features/user/test/src/commonMain/kotlin/app/campfire/user/test/FakeMediaProgressRepository.kt
+++ b/features/user/test/src/commonMain/kotlin/app/campfire/user/test/FakeMediaProgressRepository.kt
@@ -44,6 +44,7 @@ class FakeMediaProgressRepository : MediaProgressRepository {
     newProgress: MediaProgress,
     force: Boolean,
     skipUpload: Boolean,
+    onlyIfFresher: Boolean,
   ) {
     invocations += Invocation.UpdateProgress(newProgress, force, skipUpload)
   }

--- a/infra/audioplayer/cast/build.gradle.kts
+++ b/infra/audioplayer/cast/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         implementation(projects.core)
         implementation(projects.data.account.api)
         implementation(projects.data.network.api)
+        implementation(projects.features.sessions.api)
         implementation(projects.features.settings.api)
 
         // `api` because MediaRouterCastController's supertypes (CastStateListener,

--- a/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastPlaySessionHolder.kt
+++ b/infra/audioplayer/cast/src/androidMain/kotlin/app/campfire/audioplayer/impl/cast/CastPlaySessionHolder.kt
@@ -20,6 +20,7 @@ import app.campfire.core.model.Session
 import app.campfire.core.session.serverUrl
 import app.campfire.network.AudioBookShelfApi
 import app.campfire.network.models.DeviceInfo
+import app.campfire.sessions.api.SessionsRepository
 import app.campfire.settings.api.CampfireSettings
 import com.r0adkll.kimchi.annotations.ContributesTo
 import kotlinx.coroutines.CoroutineScope
@@ -31,6 +32,7 @@ import me.tatarka.inject.annotations.Inject
 @ContributesTo(UserScope::class)
 interface CastPlaySessionUserComponent {
   val audioBookShelfApi: AudioBookShelfApi
+  val sessionsRepository: SessionsRepository
 }
 
 /**
@@ -69,6 +71,10 @@ class CastPlaySessionHolder(
   @Volatile
   private var sessionItemKey: String? = null
 
+  /** False when the staged id is the phone's own attached session — never ours to close. */
+  @Volatile
+  private var ownsSession: Boolean = false
+
   private val mutex = Mutex()
 
   /** The credential-free receiver URL for [trackContentUrl], if a session is staged for it. */
@@ -104,10 +110,23 @@ class CastPlaySessionHolder(
         return
       }
 
-      val api = ComponentHolder.maybeComponent<CastPlaySessionUserComponent>()?.audioBookShelfApi ?: return
+      val userComponent = ComponentHolder.maybeComponent<CastPlaySessionUserComponent>() ?: return
+      val api = userComponent.audioBookShelfApi
       val serverUrl = userSessionManager.current.serverUrl ?: return
 
       closeCurrent()
+
+      // Prefer the phone's own attached session (opened by ServerSessionAttacher): the
+      // public track endpoint's only check is that the session exists, so the receiver can
+      // share it — and admins then see exactly one advancing session while casting. The
+      // preparedSession snapshot predates the attach, so read the live row.
+      val phoneSessionId = userComponent.sessionsRepository
+        .getSession(session.libraryItem.id)
+        ?.serverSessionId
+      if (phoneSessionId != null) {
+        stage(session, key, phoneSessionId, serverUrl, owned = false)
+        return
+      }
 
       val deviceId = "${campfireSettings.deviceId}$CAST_DEVICE_ID_SUFFIX"
       val playSession = api.startPlaybackSession(
@@ -134,31 +153,43 @@ class CastPlaySessionHolder(
         return
       }
 
-      val episode = session.episode
-      val urls = if (episode != null) {
-        // Podcast sessions always expose exactly one server-side track, at index 1
-        val track = episode.audioTrack ?: return
-        mapOf(track.contentUrl to publicTrackUrl(serverUrl, playSession.id, 1))
-      } else {
-        session.libraryItem.media.tracks.associate { track ->
-          track.contentUrl to publicTrackUrl(serverUrl, playSession.id, track.index)
-        }
-      }
-
-      sessionId = playSession.id
-      sessionItemKey = key
-      publicTrackUrls = urls
-      bark { "Staged cast credential session ${playSession.id} (${urls.size} tracks)" }
+      stage(session, key, playSession.id, serverUrl, owned = true)
     } catch (e: Throwable) {
       bark(LogPriority.WARN, throwable = e) { "Failed to stage cast credential session" }
     }
   }
 
+  private fun stage(session: Session, key: String, stagedSessionId: String, serverUrl: String, owned: Boolean) {
+    val episode = session.episode
+    val urls = if (episode != null) {
+      // Podcast sessions always expose exactly one server-side track, at index 1
+      val track = episode.audioTrack ?: return
+      mapOf(track.contentUrl to publicTrackUrl(serverUrl, stagedSessionId, 1))
+    } else {
+      session.libraryItem.media.tracks.associate { track ->
+        track.contentUrl to publicTrackUrl(serverUrl, stagedSessionId, track.index)
+      }
+    }
+
+    sessionId = stagedSessionId
+    sessionItemKey = key
+    ownsSession = owned
+    publicTrackUrls = urls
+    bark { "Staged cast credential session $stagedSessionId (${urls.size} tracks, owned=$owned)" }
+  }
+
   private suspend fun closeCurrent() {
     val id = sessionId ?: return
+    val shouldClose = ownsSession
     sessionId = null
     sessionItemKey = null
+    ownsSession = false
     publicTrackUrls = emptyMap()
+
+    // The phone's own attached session is never ours to close — it belongs to the
+    // playback sync lifecycle and keeps reporting after casting ends.
+    if (!shouldClose) return
+
     try {
       val api = ComponentHolder.maybeComponent<CastPlaySessionUserComponent>()?.audioBookShelfApi ?: return
       api.closePlaybackSession(id)


### PR DESCRIPTION
## Summary

Phase 3b of the [/play adoption plan](https://claude.ai/code/artifact/ef6c4bdb-c6d7-45c2-a59d-b2b93a9dcbdb), stacked on #998. Completes the one-writer rule and ships the user-facing control.

### Progress PATCH retired
`MediaProgressPlaybackSynchronizer` now mirrors progress **locally only** (`skipUpload = true`) — the row driving the sync banner and resume stays fresh, but the server learns playback position exclusively through session syncs (live `/sync` while attached, local-all batch otherwise; both write server-side MediaProgress, source-verified). Deletes a redundant second writer and ~halves steady-state playback traffic. `markFinished`/`markNotFinished` (the only routes for explicit finish state) are untouched; ebook fields were never written by any path.

### Socket echo stomp fixed
`updateProgress` gains `onlyIfFresher`, applying the same last-write-wins rule as the fetch path's `insertIfFresher`; the socket listener opts in. Previously a device's own throttled (stale) server echo could clobber the fresher local row mid-playback — a pre-existing bypass that real-time session syncs would have amplified.

### Settings
New **Streaming** group in Playback settings with the **Server listening sessions** toggle (default on), wired through state/presenter/analytics/strings. The streaming-method chooser joins this group when HLS lands.

### Cast borrows the phone's session
When the playing item has an attached server session, the cast holder stages *its* id for the receiver's public track URLs instead of opening a `-cast` session (verified: the endpoint's only check is session existence) — admins see exactly one advancing session while casting. `ownsSession` guards close so the borrowed session is never torn down by the cast lifecycle; `-cast` remains the fallback for unattached playback.

### Device checklist
- Play streamed book → cast → admin sessions view shows ONE session advancing; logcat "owned=false"
- Toggle Server listening sessions off → attach skipped, behavior reverts to today's
- Another device updates progress mid-playback → sync banner still appears; own echoes no longer flip the local row

## Testing
`./gradlew test` passes; `alphaDebug`, `fossDebug`, desktop compile; ktlint clean; changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)