### PR TITLE
Extract ChapterTimeline for coarse-queue chapter semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- End-of-chapter sleep timer now stops at actual chapter boundaries while casting, instead of at file boundaries or not at all
 - Cast playback stopping after about an hour — the receiver now streams through credential-free session links on servers running Audiobookshelf 2.22.0 or newer
 - App widgets breaking due to large image size
 - Cast devices not appearing reliably, including the cast button vanishing after rotating the screen

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -27,6 +27,7 @@ import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.OnFinishedListener
 import app.campfire.audioplayer.cast.CastController
 import app.campfire.audioplayer.history.PlaybackHistoryRecorder
+import app.campfire.audioplayer.impl.chapters.ChapterTimeline
 import app.campfire.audioplayer.impl.forwarding.PlaybackHistoryForwardingPlayer
 import app.campfire.audioplayer.impl.forwarding.RemoteControlForwardingPlayer
 import app.campfire.audioplayer.impl.mediaitem.MediaItemBuilder
@@ -41,7 +42,6 @@ import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.core.extensions.seconds
 import app.campfire.core.logging.Cork
 import app.campfire.core.logging.Corked
-import app.campfire.core.model.Chapter
 import app.campfire.core.model.Session
 import app.campfire.core.model.loggableId
 import app.campfire.core.toast.GlobalToaster
@@ -199,6 +199,8 @@ class ExoPlayerAudioPlayer(
   private var previousVolumeLevel: Float = 0f
   private var isRemotePlayback = false
   private var castWatchdogJob: Job? = null
+  private var chapterTimeline: ChapterTimeline? = null
+  private var lastBoundaryCheckTime: Duration? = null
 
   override var preparedSession: Session? = null
   private var finishedListener: OnFinishedListener? = null
@@ -223,6 +225,8 @@ class ExoPlayerAudioPlayer(
     onFinished: OnFinishedListener,
   ) = withContext(Dispatchers.Main) {
     preparedSession = session
+    chapterTimeline = ChapterTimeline(session)
+    lastBoundaryCheckTime = null
     finishedListener = onFinished
     _error.value = null
     state.value = AudioPlayer.State.Initializing
@@ -407,15 +411,17 @@ class ExoPlayerAudioPlayer(
 
   override fun stop() {
     preparedSession = null
+    chapterTimeline = null
+    lastBoundaryCheckTime = null
     finishedListener = null
     player.stop()
   }
 
   override fun seekTo(itemIndex: Int) {
     if (isRemotePlayback) {
-      val absolute = absoluteTimeOfLocalQueueIndex(itemIndex)
+      val absolute = chapterTimeline?.startOfLocalQueueIndex(itemIndex)
       if (absolute != null) {
-        remoteSeekTo(absolute, play = true)
+        coarseSeekTo(absolute, play = true)
         return
       }
     }
@@ -425,9 +431,9 @@ class ExoPlayerAudioPlayer(
 
   override fun seekTo(progress: Float) {
     if (isRemotePlayback) {
-      val chapter = chapterAt(overallTime.value)
+      val chapter = chapterTimeline?.chapterAt(overallTime.value)
       if (chapter != null) {
-        remoteSeekTo(chapter.start.seconds + chapter.duration * progress.toDouble(), play = false)
+        coarseSeekTo(chapter.start.seconds + chapter.duration * progress.toDouble(), play = false)
         currentTime.value = chapter.duration * progress.toDouble()
         return
       }
@@ -443,7 +449,7 @@ class ExoPlayerAudioPlayer(
 
   private fun seekTo(timestamp: Duration, play: Boolean) {
     if (isRemotePlayback) {
-      remoteSeekTo(timestamp, play)
+      coarseSeekTo(timestamp, play)
       return
     }
     val timestampInMillis = timestamp.inWholeMilliseconds
@@ -467,10 +473,10 @@ class ExoPlayerAudioPlayer(
 
   override fun skipToNext() {
     if (isRemotePlayback) {
-      // The remote queue is per-track; skip by chapter on the absolute timeline instead
-      val chapter = chapterAt(overallTime.value)
-      if (chapter != null) {
-        remoteSeekTo(chapter.end.seconds, play = false)
+      // The coarse queue is per-track; skip by chapter on the absolute timeline instead
+      val target = chapterTimeline?.nextChapterStart(overallTime.value)
+      if (target != null) {
+        coarseSeekTo(target, play = false)
         return
       }
     }
@@ -479,15 +485,9 @@ class ExoPlayerAudioPlayer(
 
   override fun skipToPrevious() {
     if (isRemotePlayback) {
-      val chapter = chapterAt(overallTime.value)
-      if (chapter != null) {
-        val progressInChapter = (overallTime.value - chapter.start.seconds).coerceAtLeast(Duration.ZERO)
-        val target = if (progressInChapter > settings.trackResetThreshold) {
-          chapter.start.seconds
-        } else {
-          chapterAt(chapter.start.seconds - 1.milliseconds)?.start?.seconds ?: chapter.start.seconds
-        }
-        remoteSeekTo(target, play = false)
+      val target = chapterTimeline?.previousChapterTarget(overallTime.value, settings.trackResetThreshold)
+      if (target != null) {
+        coarseSeekTo(target, play = false)
         return
       }
     }
@@ -701,9 +701,10 @@ class ExoPlayerAudioPlayer(
       }
     }
 
-    // If the media item transitions (i.e. chapter) and the timer is
-    // end of chapter, then stop the playback
-    if (events.containsAny(EVENT_MEDIA_ITEM_TRANSITION)) {
+    // If the media item transitions (i.e. chapter) and the timer is end of chapter, then
+    // stop the playback. Coarse queues (remote per-track) transition on tracks rather than
+    // chapters, so there the boundary detection in updateProgress owns this signal instead.
+    if (events.containsAny(EVENT_MEDIA_ITEM_TRANSITION) && !isRemotePlayback) {
       sleepTimerManager.endOfChapter()
     }
   }
@@ -723,11 +724,13 @@ class ExoPlayerAudioPlayer(
   }
 
   private fun updateProgress(player: Player) {
-    if (isRemotePlayback) {
-      val overallMs = remoteOverallPositionMs(player)
-      if (overallMs != null) {
-        overallTime.value = overallMs.milliseconds
-        updateRemoteChapterState(overallMs.milliseconds, player)
+    val timeline = chapterTimeline
+    if (isRemotePlayback && timeline != null) {
+      val overall = timeline.timeAtTrackPosition(player.currentMediaItemIndex, player.currentPosition.milliseconds)
+      if (overall != null) {
+        detectChapterBoundary(timeline, overall)
+        overallTime.value = overall
+        updateCoarseChapterState(timeline, overall, player)
         return
       }
     }
@@ -737,29 +740,29 @@ class ExoPlayerAudioPlayer(
   }
 
   /**
-   * Absolute position while remote, derived from the session's track table rather than item
-   * metadata: the remote queue is one item per audio track, and items in the cast timeline
-   * may not carry our duration metadata.
+   * Coarse queues have no media-item transition at chapter boundaries, so the end-of-chapter
+   * sleep timer is driven by detecting the crossing between progress ticks instead.
    */
-  private fun remoteOverallPositionMs(player: Player): Long? {
-    val session = preparedSession ?: return null
-    if (session.episode != null) return player.currentPosition
-    val track = session.libraryItem.media.tracks.getOrNull(player.currentMediaItemIndex) ?: return null
-    return track.startOffset.seconds.inWholeMilliseconds + player.currentPosition
+  private fun detectChapterBoundary(timeline: ChapterTimeline, overall: Duration) {
+    val previous = lastBoundaryCheckTime
+    lastBoundaryCheckTime = overall
+    if (previous != null && timeline.crossedChapterBoundary(previous, overall)) {
+      sleepTimerManager.endOfChapter()
+    }
   }
 
   /**
-   * While remote the queue is per-track but the UI speaks chapters: re-derive chapter-relative
-   * time, duration, and title from the absolute position so the playback UI matches local
-   * playback exactly.
+   * Coarse queues (per-track remote, single-item HLS) don't match the UI's chapter language:
+   * re-derive chapter-relative time, duration, and title from the absolute position so the
+   * playback UI matches chapter-granular queues exactly.
    */
-  private fun updateRemoteChapterState(overall: Duration, player: Player) {
-    val chapter = chapterAt(overall)
-    if (chapter != null) {
-      currentTime.value = (overall - chapter.start.seconds).coerceAtLeast(Duration.ZERO)
-      currentDuration.value = chapter.duration
-      if (currentMetadata.value.title != chapter.title) {
-        currentMetadata.value = currentMetadata.value.copy(title = chapter.title)
+  private fun updateCoarseChapterState(timeline: ChapterTimeline, overall: Duration, player: Player) {
+    val progress = timeline.progressAt(overall)
+    if (progress != null) {
+      currentTime.value = progress.position
+      currentDuration.value = progress.duration
+      if (currentMetadata.value.title != progress.chapter.title) {
+        currentMetadata.value = currentMetadata.value.copy(title = progress.chapter.title)
       }
     } else {
       currentTime.value = player.currentPosition.milliseconds
@@ -767,49 +770,19 @@ class ExoPlayerAudioPlayer(
     }
   }
 
-  /** The chapter containing [time] on the absolute book/episode timeline, if any. */
-  private fun chapterAt(time: Duration): Chapter? {
-    val session = preparedSession ?: return null
-    val timeMs = time.inWholeMilliseconds
-    return session.episode?.chapters?.find { chapter ->
-      timeMs >= chapter.start.seconds.inWholeMilliseconds && timeMs < chapter.end.seconds.inWholeMilliseconds
-    } ?: session.libraryItem.getChapterForDuration(timeMs)
-  }
-
   /**
-   * Seeks while remote using the session's track table (the remote queue is per-track and its
-   * timeline metadata may not survive the cast round-trip).
+   * Seeks on a coarse queue by translating the absolute timestamp through the session's
+   * track table (queue items may not carry our duration metadata across the cast boundary).
    */
-  private fun remoteSeekTo(timestamp: Duration, play: Boolean) {
-    val session = preparedSession ?: return
-    if (session.episode != null) {
-      player.seekTo(timestamp.inWholeMilliseconds)
-    } else {
-      val track = session.libraryItem.getAudioTrackForDuration(timestamp.inWholeMilliseconds) ?: return
-      val trackIndex = session.libraryItem.media.tracks.indexOf(track)
-      if (trackIndex < 0) return
-      val offsetMs = timestamp.inWholeMilliseconds - track.startOffset.seconds.inWholeMilliseconds
-      player.seekTo(trackIndex, offsetMs.coerceAtLeast(0L))
-    }
+  private fun coarseSeekTo(timestamp: Duration, play: Boolean) {
+    val timeline = chapterTimeline ?: return
+    val position = timeline.trackPositionAt(timestamp) ?: return
+    player.seekTo(position.queueIndex, position.offset.inWholeMilliseconds)
     overallTime.value = timestamp
+    // A deliberate seek is not a chapter boundary crossing
+    lastBoundaryCheckTime = timestamp
     if (play) {
       player.play()
-    }
-  }
-
-  /**
-   * The UI addresses seeks by local-queue index (chapter id when the item has chapters, track
-   * ordinal otherwise). While remote the player's queue is per-track, so translate the local
-   * index to absolute time first. Null when no translation applies (podcasts, unknown index).
-   */
-  private fun absoluteTimeOfLocalQueueIndex(itemIndex: Int): Duration? {
-    val session = preparedSession ?: return null
-    if (session.episode != null) return null
-    val chapters = session.libraryItem.media.chapters
-    return if (chapters.isNotEmpty()) {
-      chapters.find { it.id == itemIndex }?.start?.seconds
-    } else {
-      session.libraryItem.media.tracks.getOrNull(itemIndex)?.startOffset?.seconds
     }
   }
 }

--- a/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/chapters/ChapterTimeline.kt
+++ b/infra/audioplayer/impl/src/commonMain/kotlin/app/campfire/audioplayer/impl/chapters/ChapterTimeline.kt
@@ -1,0 +1,148 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.chapters
+
+import app.campfire.core.extensions.seconds
+import app.campfire.core.model.Chapter
+import app.campfire.core.model.Session
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Chapter semantics derived from a session's absolute timeline.
+ *
+ * The player's queue is not always chapter-granular: remote (Cast) playback uses one item per
+ * audio track, and HLS playback uses a single playlist item. In those *coarse-queue* modes the
+ * player can't lean on media-item boundaries for chapter behavior, so everything the UI and
+ * sleep timer need — the current chapter, chapter-relative position, next/previous seek
+ * targets, and boundary crossings — is derived here from the absolute position against the
+ * session's chapter and track tables. One mechanism, every consumer, so per-chapter rendering
+ * stays consistent regardless of queue shape.
+ */
+class ChapterTimeline(session: Session) {
+
+  /** Chapters on the absolute timeline; empty when the item has none. */
+  private val chapters: List<Chapter> =
+    session.episode?.chapters ?: session.libraryItem.media.chapters
+
+  /** Audio tracks on the absolute timeline (a podcast episode is a single implicit track). */
+  private val tracks: List<TrackSpan> = session.episode
+    ?.audioTrack
+    ?.let { track ->
+      listOf(TrackSpan(index = 0, startMs = 0L, durationMs = track.duration.seconds.inWholeMilliseconds))
+    }
+    ?: session.libraryItem.media.tracks.mapIndexed { index, track ->
+      TrackSpan(
+        index = index,
+        startMs = track.startOffset.seconds.inWholeMilliseconds,
+        durationMs = track.duration.seconds.inWholeMilliseconds,
+      )
+    }
+
+  val hasChapters: Boolean get() = chapters.isNotEmpty()
+
+  /** The chapter containing [time], or null when the item has no chapters or [time] is past the end. */
+  fun chapterAt(time: Duration): Chapter? {
+    val timeMs = time.inWholeMilliseconds
+    return chapters.find { chapter ->
+      timeMs >= chapter.startMs && timeMs < chapter.endMs
+    }
+  }
+
+  /** Chapter-relative progress at [time], for rendering identical to chapter-granular queues. */
+  fun progressAt(time: Duration): ChapterProgress? {
+    val chapter = chapterAt(time) ?: return null
+    return ChapterProgress(
+      chapter = chapter,
+      position = (time - chapter.start.seconds).coerceAtLeast(Duration.ZERO),
+      duration = chapter.duration,
+    )
+  }
+
+  /** The absolute start of the chapter after the one containing [time], or null at the last chapter. */
+  fun nextChapterStart(time: Duration): Duration? {
+    val chapter = chapterAt(time) ?: return null
+    val nextStart = chapter.end.seconds
+    // The final chapter's end is the end of the item — there is nothing to skip to
+    return nextStart.takeIf { chapterAt(it) != null }
+  }
+
+  /**
+   * The skip-previous target at [time]: restart the current chapter when more than
+   * [resetThreshold] into it, otherwise the start of the previous chapter (clamped to the
+   * current chapter's start at the beginning of the item).
+   */
+  fun previousChapterTarget(time: Duration, resetThreshold: Duration): Duration? {
+    val chapter = chapterAt(time) ?: return null
+    val progressInChapter = (time - chapter.start.seconds).coerceAtLeast(Duration.ZERO)
+    return if (progressInChapter > resetThreshold) {
+      chapter.start.seconds
+    } else {
+      chapters.lastOrNull { it.endMs <= chapter.startMs }?.start?.seconds ?: chapter.start.seconds
+    }
+  }
+
+  /**
+   * The absolute start time addressed by a *local-queue* index — chapter ordinal when the
+   * item has chapters, track ordinal otherwise. This is how the UI addresses seeks; coarse
+   * queues translate it to absolute time first.
+   */
+  fun startOfLocalQueueIndex(itemIndex: Int): Duration? {
+    return if (hasChapters) {
+      chapters.find { it.id == itemIndex }?.start?.seconds
+    } else {
+      tracks.getOrNull(itemIndex)?.startMs?.milliseconds
+    }
+  }
+
+  /** The (queue index, offset) of [time] on a per-track queue, or null when out of range. */
+  fun trackPositionAt(time: Duration): TrackPosition? {
+    val timeMs = time.inWholeMilliseconds
+    val track = tracks.find { timeMs >= it.startMs && timeMs < it.startMs + it.durationMs }
+      ?: tracks.lastOrNull()?.takeIf { timeMs >= it.startMs }
+      ?: return null
+    return TrackPosition(
+      queueIndex = track.index,
+      offset = (timeMs - track.startMs).coerceAtLeast(0L).milliseconds,
+    )
+  }
+
+  /** The absolute position represented by (per-track queue index, in-item position). */
+  fun timeAtTrackPosition(queueIndex: Int, positionInTrack: Duration): Duration? {
+    val track = tracks.getOrNull(queueIndex) ?: return null
+    return track.startMs.milliseconds + positionInTrack
+  }
+
+  /**
+   * True when moving from [previous] to [current] crossed a chapter boundary going forward —
+   * the coarse-queue substitute for the media-item-transition event the end-of-chapter sleep
+   * timer listens to. Backward jumps (seeks) are not boundary crossings.
+   */
+  fun crossedChapterBoundary(previous: Duration, current: Duration): Boolean {
+    if (!hasChapters || current <= previous) return false
+    val previousChapter = chapterAt(previous) ?: return false
+    val currentChapter = chapterAt(current)
+    return currentChapter?.id != previousChapter.id
+  }
+
+  data class ChapterProgress(
+    val chapter: Chapter,
+    val position: Duration,
+    val duration: Duration,
+  )
+
+  data class TrackPosition(
+    val queueIndex: Int,
+    val offset: Duration,
+  )
+
+  private data class TrackSpan(
+    val index: Int,
+    val startMs: Long,
+    val durationMs: Long,
+  )
+
+  private val Chapter.startMs: Long get() = start.seconds.inWholeMilliseconds
+  private val Chapter.endMs: Long get() = end.seconds.inWholeMilliseconds
+}

--- a/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/chapters/ChapterTimelineTest.kt
+++ b/infra/audioplayer/impl/src/commonTest/kotlin/app/campfire/audioplayer/impl/chapters/ChapterTimelineTest.kt
@@ -1,0 +1,232 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.chapters
+
+import app.campfire.core.model.AudioTrack
+import app.campfire.core.model.Chapter
+import app.campfire.core.model.FileMetadata
+import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.Media
+import app.campfire.core.model.MediaType
+import app.campfire.core.model.PlayMethod
+import app.campfire.core.model.Session
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
+import kotlinx.datetime.LocalDateTime
+
+class ChapterTimelineTest {
+
+  // region Fixtures
+
+  private fun track(index: Int, startOffset: Float, duration: Float) = AudioTrack(
+    index = index,
+    startOffset = startOffset,
+    duration = duration,
+    title = "Track $index",
+    contentUrl = "/track$index.m4b",
+    mimeType = "audio/mp4",
+    codec = "aac",
+    metadata = FileMetadata("track$index.m4b", ".m4b", "/track$index.m4b", "track$index.m4b", 0, 0, 0, 0),
+    metaTags = null,
+  )
+
+  private fun chapter(id: Int, start: Float, end: Float) = Chapter(
+    id = id,
+    start = start,
+    end = end,
+    title = "Chapter ${id + 1}",
+  )
+
+  private fun session(
+    chapters: List<Chapter> = emptyList(),
+    tracks: List<AudioTrack> = emptyList(),
+  ): Session {
+    val media = Media.Book(
+      id = "media-1",
+      metadata = Media.Metadata.Book(
+        title = "A Book",
+        titleIgnorePrefix = "A Book",
+        subtitle = null,
+        authorName = "An Author",
+        authorNameLastFirst = "Author, An",
+        narratorName = null,
+        seriesName = null,
+        series = emptyList(),
+        genres = emptyList(),
+        publishedYear = null,
+        publishedDate = null,
+        publisher = null,
+        description = null,
+        ISBN = null,
+        ASIN = null,
+        language = null,
+        isExplicit = false,
+        isAbridged = false,
+      ),
+      coverImageUrl = "/cover.jpg",
+      coverPath = null,
+      tags = emptyList(),
+      numTracks = tracks.size,
+      numAudioFiles = tracks.size,
+      numChapters = chapters.size,
+      numMissingParts = 0,
+      numInvalidAudioFiles = 0,
+      durationInMillis = (tracks.sumOf { it.duration.toDouble() } * 1000).toLong(),
+      sizeInBytes = 0L,
+      chapters = chapters,
+      tracks = tracks,
+    )
+    val item = LibraryItem(
+      id = "item-1",
+      ino = "ino-1",
+      libraryId = "lib-1",
+      folderId = "folder-1",
+      path = "/audiobooks/test",
+      relPath = "test",
+      isFile = false,
+      mtimeMs = 0L,
+      ctimeMs = 0L,
+      birthtimeMs = 0L,
+      isMissing = false,
+      isInvalid = false,
+      mediaType = MediaType.Book,
+      numFiles = 1,
+      sizeInBytes = 0L,
+      addedAtMillis = 0L,
+      updatedAtMillis = 0L,
+      media = media,
+    )
+    val now = LocalDateTime(2026, 1, 1, 0, 0)
+    return Session(
+      id = Uuid.random(),
+      libraryItem = item,
+      userId = "user-1",
+      isDeleted = false,
+      playMethod = PlayMethod.DirectPlay,
+      mediaPlayer = "campfire",
+      timeListening = 0.seconds,
+      startTime = 0.seconds,
+      currentTime = 0.seconds,
+      lastPlayedAt = null,
+      startedAt = now,
+      updatedAt = now,
+    )
+  }
+
+  // Two tracks of 30min; three chapters at 0-10, 10-30, 30-60 minutes
+  private fun timeline() = ChapterTimeline(
+    session(
+      chapters = listOf(
+        chapter(0, 0f, 600f),
+        chapter(1, 600f, 1800f),
+        chapter(2, 1800f, 3600f),
+      ),
+      tracks = listOf(
+        track(1, 0f, 1800f),
+        track(2, 1800f, 1800f),
+      ),
+    ),
+  )
+
+  // endregion
+
+  @Test
+  fun `chapterAt start is inclusive and end is exclusive`() {
+    val timeline = timeline()
+    assertThat(timeline.chapterAt(0.seconds)?.id).isEqualTo(0)
+    assertThat(timeline.chapterAt(10.minutes)?.id).isEqualTo(1)
+    assertThat(timeline.chapterAt(10.minutes - 1.seconds)?.id).isEqualTo(0)
+    assertThat(timeline.chapterAt(60.minutes)).isNull()
+  }
+
+  @Test
+  fun `progressAt is chapter-relative`() {
+    val progress = timeline().progressAt(15.minutes)
+    assertThat(progress).isNotNull()
+    assertThat(progress!!.chapter.id).isEqualTo(1)
+    assertThat(progress.position).isEqualTo(5.minutes)
+    assertThat(progress.duration).isEqualTo(20.minutes)
+  }
+
+  @Test
+  fun `nextChapterStart returns following chapter and null at the last`() {
+    val timeline = timeline()
+    assertThat(timeline.nextChapterStart(5.minutes)).isEqualTo(10.minutes)
+    assertThat(timeline.nextChapterStart(45.minutes)).isNull()
+  }
+
+  @Test
+  fun `previousChapterTarget restarts deep into a chapter and steps back near its start`() {
+    val timeline = timeline()
+    // 15min = 5min into chapter 1, beyond a 5s threshold -> restart chapter 1
+    assertThat(timeline.previousChapterTarget(15.minutes, resetThreshold = 5.seconds)).isEqualTo(10.minutes)
+    // 2s into chapter 1 -> previous chapter's start
+    assertThat(timeline.previousChapterTarget(10.minutes + 2.seconds, resetThreshold = 5.seconds))
+      .isEqualTo(0.seconds)
+    // 2s into the first chapter clamps to its own start
+    assertThat(timeline.previousChapterTarget(2.seconds, resetThreshold = 5.seconds)).isEqualTo(0.seconds)
+  }
+
+  @Test
+  fun `startOfLocalQueueIndex uses chapter ids when chapters exist`() {
+    assertThat(timeline().startOfLocalQueueIndex(2)).isEqualTo(30.minutes)
+  }
+
+  @Test
+  fun `startOfLocalQueueIndex uses track ordinals when chapterless`() {
+    val timeline = ChapterTimeline(
+      session(tracks = listOf(track(1, 0f, 1800f), track(2, 1800f, 1800f))),
+    )
+    assertThat(timeline.startOfLocalQueueIndex(1)).isEqualTo(30.minutes)
+    assertThat(timeline.startOfLocalQueueIndex(5)).isNull()
+  }
+
+  @Test
+  fun `trackPositionAt maps absolute time onto the per-track queue`() {
+    val position = timeline().trackPositionAt(45.minutes)
+    assertThat(position).isNotNull()
+    assertThat(position!!.queueIndex).isEqualTo(1)
+    assertThat(position.offset).isEqualTo(15.minutes)
+  }
+
+  @Test
+  fun `trackPositionAt clamps past-the-end times into the last track`() {
+    val position = timeline().trackPositionAt(61.minutes)
+    assertThat(position).isNotNull()
+    assertThat(position!!.queueIndex).isEqualTo(1)
+  }
+
+  @Test
+  fun `timeAtTrackPosition is the inverse mapping`() {
+    assertThat(timeline().timeAtTrackPosition(1, 15.minutes)).isEqualTo(45.minutes)
+    assertThat(timeline().timeAtTrackPosition(7, 0.seconds)).isNull()
+  }
+
+  @Test
+  fun `crossedChapterBoundary detects forward crossings only`() {
+    val timeline = timeline()
+    assertThat(timeline.crossedChapterBoundary(previous = 9.minutes + 59.seconds, current = 10.minutes)).isTrue()
+    assertThat(timeline.crossedChapterBoundary(previous = 5.minutes, current = 6.minutes)).isFalse()
+    // Backward jump (a seek) is not a boundary crossing
+    assertThat(timeline.crossedChapterBoundary(previous = 15.minutes, current = 5.minutes)).isFalse()
+    // Crossing past the final chapter's end counts (chapterAt returns null there)
+    assertThat(timeline.crossedChapterBoundary(previous = 59.minutes, current = 60.minutes)).isTrue()
+  }
+
+  @Test
+  fun `chapterless items never report boundaries or chapters`() {
+    val timeline = ChapterTimeline(session(tracks = listOf(track(1, 0f, 1800f))))
+    assertThat(timeline.hasChapters).isFalse()
+    assertThat(timeline.chapterAt(5.minutes)).isNull()
+    assertThat(timeline.crossedChapterBoundary(1.minutes, 2.minutes)).isFalse()
+  }
+}


### PR DESCRIPTION
## Summary

Phase 4a of the [/play adoption plan](https://claude.ai/code/artifact/ef6c4bdb-c6d7-45c2-a59d-b2b93a9dcbdb): the architecture pass keeping per-chapter rendering consistent app-wide. One component — **`ChapterTimeline`** — now owns every chapter derivation the player needs when its queue is coarser than chapters: today's remote (Cast) per-track queue, and the single-item HLS queue arriving in Phase 4b.

### What it provides (commonMain, fully unit-tested)
`chapterAt`, chapter-relative progress, next/previous skip targets (with the reset-threshold rule), local-queue-index → absolute-time translation, per-track position mapping in both directions, and forward chapter-boundary-crossing detection.

### What it replaces
The five inline helpers Phase 2B added to `ExoPlayerAudioPlayer` for remote playback collapse into timeline calls, built once per prepared session. Behavior parity everywhere, plus one incidental fix: chapter-addressed seeks while casting a *podcast episode with chapters* now translate correctly.

### The real bug it fixes
The **end-of-chapter sleep timer** listened only to media-item transitions — which fire per *track* on the remote queue, so while casting it either never fired mid-track or fired at file boundaries instead of chapters. Boundary crossings detected between progress ticks now drive it on coarse queues (deliberate seeks excluded from detection), and the item-transition path is gated to chapter-granular queues so it can't double-fire.

## Testing
- New `ChapterTimelineTest` covering boundaries (inclusive start / exclusive end), progress derivation, skip targets, index translation, track mapping + clamping, and crossing detection (forward-only, seek-immune, chapterless)
- `./gradlew test` passes; `alphaDebug`, `fossDebug`, desktop, **and `compileKotlinIosSimulatorArm64`** verified locally
- No changelog entry beyond behavior parity — except the sleep-timer fix, which is user-visible; entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)