### PR TITLE
Add per-book playback speed overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Playback settings for how often listening progress syncs to the server, separately for Wi-Fi and mobile data
 - Optional HLS streaming on Android with a new Streaming method setting (Auto, Direct play, or Prefer HLS) for smoother seeking in large single-file audiobooks
+- Per-book playback speed — a toggle in the playback speed sheet saves a speed for just that book instead of changing the global speed
 
 ### Changed
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/rounded/Globe.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/rounded/Globe.kt
@@ -1,0 +1,70 @@
+package app.campfire.common.compose.icons.rounded
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Rounded.Globe: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
+  ImageVector.Builder(
+    name = "Globe",
+    defaultWidth = 24.dp,
+    defaultHeight = 24.dp,
+    viewportWidth = 960f,
+    viewportHeight = 960f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFE3E3E3))) {
+      moveTo(480f, 880f)
+      quadToRelative(-83f, 0f, -156f, -31.5f)
+      reflectiveQuadTo(197f, 763f)
+      quadToRelative(-54f, -54f, -85.5f, -127f)
+      reflectiveQuadTo(80f, 480f)
+      quadToRelative(0f, -83f, 31.5f, -156f)
+      reflectiveQuadTo(197f, 197f)
+      quadToRelative(54f, -54f, 127f, -85.5f)
+      reflectiveQuadTo(480f, 80f)
+      quadToRelative(83f, 0f, 156f, 31.5f)
+      reflectiveQuadTo(763f, 197f)
+      quadToRelative(54f, 54f, 85.5f, 127f)
+      reflectiveQuadTo(880f, 480f)
+      quadToRelative(0f, 83f, -31.5f, 156f)
+      reflectiveQuadTo(763f, 763f)
+      quadToRelative(-54f, 54f, -127f, 85.5f)
+      reflectiveQuadTo(480f, 880f)
+      close()
+      moveTo(480f, 800f)
+      quadToRelative(134f, 0f, 227f, -93f)
+      reflectiveQuadToRelative(93f, -227f)
+      quadToRelative(0f, -7f, -0.5f, -14.5f)
+      reflectiveQuadTo(799f, 453f)
+      quadToRelative(-5f, 29f, -27f, 48f)
+      reflectiveQuadToRelative(-52f, 19f)
+      horizontalLineToRelative(-80f)
+      quadToRelative(-33f, 0f, -56.5f, -23.5f)
+      reflectiveQuadTo(560f, 440f)
+      verticalLineToRelative(-40f)
+      lineTo(400f, 400f)
+      verticalLineToRelative(-80f)
+      quadToRelative(0f, -33f, 23.5f, -56.5f)
+      reflectiveQuadTo(480f, 240f)
+      horizontalLineToRelative(40f)
+      quadToRelative(0f, -23f, 12.5f, -40.5f)
+      reflectiveQuadTo(563f, 171f)
+      quadToRelative(-20f, -5f, -40.5f, -8f)
+      reflectiveQuadToRelative(-42.5f, -3f)
+      quadToRelative(-134f, 0f, -227f, 93f)
+      reflectiveQuadToRelative(-93f, 227f)
+      horizontalLineToRelative(200f)
+      quadToRelative(66f, 0f, 113f, 47f)
+      reflectiveQuadToRelative(47f, 113f)
+      verticalLineToRelative(40f)
+      lineTo(400f, 680f)
+      verticalLineToRelative(110f)
+      quadToRelative(20f, 5f, 39.5f, 7.5f)
+      reflectiveQuadTo(480f, 800f)
+      close()
+    }
+  }.build()
+}

--- a/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
+++ b/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
@@ -19,6 +19,7 @@
   <string name="speed_custom_dialog_error">Enter a value between %1$s and %2$s</string>
   <string name="speed_custom_action_apply">Apply</string>
   <string name="speed_custom_action_cancel">Cancel</string>
+  <string name="speed_per_book_toggle">Use a separate playback speed for this book</string>
   <string name="timer_bottomsheet_title">Sleep Timer</string>
   <string name="timer_end_of_chapter">End of Chapter</string>
   <string name="timer_custom">Custom</string>

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
@@ -310,8 +310,9 @@ private fun PlaybackBottomBar(
           PlaybackSpeedAction(
             playbackSpeed = playbackSpeed,
             onClick = {
+              if (session == null) return@PlaybackSpeedAction
               scope.launch {
-                overlayHost.showPlaybackSpeedBottomSheet(playbackSpeed)
+                overlayHost.showPlaybackSpeedBottomSheet(session.libraryItem.id, playbackSpeed)
               }
             },
           )

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
@@ -576,7 +576,7 @@ private fun SharedTransitionScope.ExpandedPlaybackContent(
           playbackSpeed = playerState.speed,
           onClick = {
             scope.launch {
-              overlayHost.showPlaybackSpeedBottomSheet(playerState.speed)
+              overlayHost.showPlaybackSpeedBottomSheet(session!!.libraryItem.id, playerState.speed)
             }
           },
         )

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/SmallExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/SmallExpandedPlaybackBar.kt
@@ -618,7 +618,7 @@ private fun PlaybackOptionsColumn(
         playbackSpeed = playerState.speed,
         onClick = {
           scope.launch {
-            overlayHost.showPlaybackSpeedBottomSheet(playerState.speed)
+            overlayHost.showPlaybackSpeedBottomSheet(session!!.libraryItem.id, playerState.speed)
           }
         },
       )

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
@@ -10,15 +10,21 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -34,6 +40,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import app.campfire.analytics.Analytics
@@ -44,11 +51,16 @@ import app.campfire.analytics.events.ScreenViewEvent
 import app.campfire.analytics.events.Speed
 import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.common.compose.analytics.Impression
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.rounded.Book
+import app.campfire.common.compose.icons.rounded.Globe
+import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.ComponentHolder
 import app.campfire.core.extensions.readable
 import app.campfire.core.extensions.readableHundredths
 import app.campfire.core.extensions.roundToHundredths
+import app.campfire.core.model.LibraryItemId
 import app.campfire.sessions.ui.sheets.SessionSheetLayout
 import app.campfire.settings.api.PlaybackSettings
 import campfire.features.sessions.ui.generated.resources.Res
@@ -59,6 +71,7 @@ import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_err
 import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_label
 import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_title
 import campfire.features.sessions.ui.generated.resources.speed_custom_open
+import campfire.features.sessions.ui.generated.resources.speed_per_book_toggle
 import com.r0adkll.kimchi.annotations.ContributesTo
 import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuitx.overlays.BottomSheetOverlay
@@ -69,23 +82,31 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import org.jetbrains.compose.resources.stringResource
 
-suspend fun OverlayHost.showPlaybackSpeedBottomSheet(speed: Float) {
+data class PlaybackSpeedInput(
+  val itemId: LibraryItemId,
+  val speed: Float,
+)
+
+suspend fun OverlayHost.showPlaybackSpeedBottomSheet(
+  itemId: LibraryItemId,
+  speed: Float,
+) {
   show(
     BottomSheetOverlay(
-      model = speed,
+      model = PlaybackSpeedInput(itemId, speed),
       onDismiss = { },
       sheetShape = RoundedCornerShape(
         topStart = 32.dp,
         topEnd = 32.dp,
       ),
       skipPartiallyExpandedState = true,
-    ) { s, _ ->
+    ) { input, _ ->
       Impression {
         ScreenViewEvent("PlaybackSpeed", ScreenType.Overlay)
       }
 
       PlaybackSpeedBottomSheet(
-        speed = s,
+        input = input,
         modifier = Modifier.navigationBarsPadding(),
       )
     },
@@ -105,10 +126,14 @@ private fun rememberPlaybackSpeedComponent(): PlaybackSpeedBottomSheetComponent 
   }
 }
 
+/**
+ * State/DI layer for the playback speed sheet: resolves the component, collects the player and
+ * settings flows, and handles events so [PlaybackSpeedSheet] stays pure and previewable.
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 private fun PlaybackSpeedBottomSheet(
-  speed: Float,
+  input: PlaybackSpeedInput,
   modifier: Modifier = Modifier,
   component: PlaybackSpeedBottomSheetComponent = rememberPlaybackSpeedComponent(),
 ) {
@@ -117,13 +142,68 @@ private fun PlaybackSpeedBottomSheet(
       .flatMapLatest {
         it?.playbackSpeed ?: emptyFlow()
       }
-  }.collectAsState(speed)
+  }.collectAsState(input.speed)
 
   val speedOptions = remember { component.playbackSettings.playbackRates.sorted() }
 
+  val itemPlaybackSpeeds by remember {
+    component.playbackSettings.observeItemPlaybackSpeeds()
+  }.collectAsState()
+
+  PlaybackSpeedSheet(
+    currentSpeed = currentSpeed,
+    speedOptions = speedOptions,
+    perBookSpeedEnabled = input.itemId in itemPlaybackSpeeds,
+    onSpeedChange = { speed ->
+      Analytics.send(PlaybackActionEvent(Speed, Changed, extras = mapOf("speed" to speed)))
+      component.audioPlayerHolder.currentPlayer.value
+        ?.setPlaybackSpeed(speed)
+    },
+    onPerBookSpeedChange = { enabled ->
+      Analytics.send(PlaybackActionEvent(Speed, Changed, extras = mapOf("perBook" to enabled)))
+      if (enabled) {
+        component.playbackSettings.itemPlaybackSpeeds += (input.itemId to currentSpeed)
+      } else {
+        component.playbackSettings.itemPlaybackSpeeds -= input.itemId
+        // Snap active playback back to the global speed the item now falls back to
+        component.audioPlayerHolder.currentPlayer.value
+          ?.setPlaybackSpeed(component.playbackSettings.playbackSpeed)
+      }
+    },
+    modifier = modifier,
+  )
+}
+
+@Composable
+internal fun PlaybackSpeedSheet(
+  currentSpeed: Float,
+  speedOptions: List<Float>,
+  perBookSpeedEnabled: Boolean,
+  onSpeedChange: (Float) -> Unit,
+  onPerBookSpeedChange: (Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+) {
   SessionSheetLayout(
     modifier = modifier,
     title = { Text(stringResource(Res.string.speed_bottomsheet_title)) },
+    trailingContent = {
+      Switch(
+        checked = perBookSpeedEnabled,
+        onCheckedChange = onPerBookSpeedChange,
+        thumbContent = {
+          Icon(
+            imageVector = if (perBookSpeedEnabled) {
+              CampfireIcons.Rounded.Book
+            } else {
+              CampfireIcons.Rounded.Globe
+            },
+            modifier = Modifier.size(16.dp),
+            contentDescription = stringResource(Res.string.speed_per_book_toggle),
+          )
+        },
+        modifier = Modifier.align(Alignment.CenterEnd),
+      )
+    },
   ) {
     Spacer(Modifier.height(16.dp))
 
@@ -138,11 +218,7 @@ private fun PlaybackSpeedBottomSheet(
           shape = SegmentedButtonDefaults.itemShape(index, speedOptions.size, RoundedCornerShape(16.dp)),
           selected = isCurrentSpeed,
           label = { Text("${defaultSpeed.readable}x") },
-          onClick = {
-            Analytics.send(PlaybackActionEvent(Speed, Changed, extras = mapOf("speed" to defaultSpeed)))
-            component.audioPlayerHolder.currentPlayer.value
-              ?.setPlaybackSpeed(defaultSpeed)
-          },
+          onClick = { onSpeedChange(defaultSpeed) },
         )
       }
     }
@@ -156,7 +232,7 @@ private fun PlaybackSpeedBottomSheet(
         .padding(horizontal = 20.dp),
       verticalAlignment = Alignment.CenterVertically,
     ) {
-      var sliderValue by remember { mutableStateOf(speed) }
+      var sliderValue by remember { mutableStateOf(currentSpeed) }
 
       LaunchedEffect(currentSpeed) {
         if (sliderValue != currentSpeed) {
@@ -175,8 +251,7 @@ private fun PlaybackSpeedBottomSheet(
         // Rounding to hundredths means nearby drag frames resolve to the same value; only push real changes
         if (speed != sliderValue) {
           sliderValue = speed
-          Analytics.send(PlaybackActionEvent(Speed, Changed, extras = mapOf("speed" to speed)))
-          component.audioPlayerHolder.currentPlayer.value?.setPlaybackSpeed(speed)
+          onSpeedChange(speed)
         }
       }
 
@@ -286,6 +361,29 @@ internal fun parsePlaybackSpeed(text: String): Float? {
     ?.roundToHundredths()
     ?: return null
   return value.takeIf { it in DefaultSpeedRange }
+}
+
+@Preview
+@Composable
+private fun PlaybackSpeedSheetPreview() {
+  CampfireTheme {
+    var speed by remember { mutableStateOf(1.25f) }
+    var perBook by remember { mutableStateOf(false) }
+
+    ModalBottomSheetLayout(
+      sheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Expanded),
+      sheetContent = {
+        PlaybackSpeedSheet(
+          currentSpeed = speed,
+          speedOptions = listOf(1f, 1.1f, 1.25f, 1.5f, 2f),
+          perBookSpeedEnabled = perBook,
+          onSpeedChange = { speed = it },
+          onPerBookSpeedChange = { perBook = it },
+        )
+      },
+    ) {
+    }
+  }
 }
 
 private val WavelengthRange = 40.dp.rangeTo(135.dp)

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/PlaybackSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/PlaybackSettings.kt
@@ -3,6 +3,7 @@
 
 package app.campfire.settings.api
 
+import app.campfire.core.model.LibraryItemId
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -25,6 +26,34 @@ interface PlaybackSettings {
   fun observePlaybackRates(): StateFlow<List<Float>>
 
   var playbackSpeed: Float
+
+  /**
+   * Per-item playback speed overrides, keyed by library item id. The presence of an entry means the
+   * item has a per-item speed enabled, and its value is that item's saved speed. Items without an
+   * entry use the global [playbackSpeed].
+   */
+  var itemPlaybackSpeeds: Map<LibraryItemId, Float>
+  fun observeItemPlaybackSpeeds(): StateFlow<Map<LibraryItemId, Float>>
+
+  /**
+   * The effective playback speed for [itemId] — its per-item override if one is enabled,
+   * otherwise the global [playbackSpeed].
+   */
+  fun playbackSpeedFor(itemId: LibraryItemId?): Float {
+    return itemId?.let { itemPlaybackSpeeds[it] } ?: playbackSpeed
+  }
+
+  /**
+   * Persist [speed] to [itemId]'s per-item override when one is enabled, otherwise to the
+   * global [playbackSpeed].
+   */
+  fun setPlaybackSpeedFor(itemId: LibraryItemId?, speed: Float) {
+    if (itemId != null && itemId in itemPlaybackSpeeds) {
+      itemPlaybackSpeeds = itemPlaybackSpeeds + (itemId to speed)
+    } else {
+      playbackSpeed = speed
+    }
+  }
 
   /**
    * When true, remote control next/previous buttons skip to next/previous chapter.

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/PlaybackSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/PlaybackSettingsImpl.kt
@@ -6,6 +6,7 @@ package app.campfire.settings
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.qualifier.ForScope
+import app.campfire.core.model.LibraryItemId
 import app.campfire.settings.api.PendingResumeRewind
 import app.campfire.settings.api.PlaybackSettings
 import app.campfire.settings.api.ResumeRewindConfig
@@ -60,6 +61,20 @@ class PlaybackSettingsImpl(
   override fun observePlaybackRates(): StateFlow<List<Float>> = playbackRatesProperty.observe()
 
   override var playbackSpeed: Float by floatSetting(PREF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED)
+
+  private val itemPlaybackSpeedsProperty = customSetting(
+    key = PREF_ITEM_PLAYBACK_SPEEDS,
+    defaultValue = emptyMap<LibraryItemId, Float>(),
+    getter = { it.asItemSpeedMap() },
+    setter = { speeds ->
+      speeds.entries.joinToString(ITEM_SPEED_ENTRY_SEPARATOR) {
+        "${it.key}$ITEM_SPEED_VALUE_SEPARATOR${it.value}"
+      }
+    },
+  )
+  override var itemPlaybackSpeeds: Map<LibraryItemId, Float> by itemPlaybackSpeedsProperty
+  override fun observeItemPlaybackSpeeds(): StateFlow<Map<LibraryItemId, Float>> =
+    itemPlaybackSpeedsProperty.observe()
 
   private val remoteNextPrevSkipsChaptersProperty = booleanSetting(
     PREF_REMOTE_NEXT_PREV_SKIPS_CHAPTERS,
@@ -164,6 +179,16 @@ class PlaybackSettingsImpl(
 
   private fun String.asFloatList(): List<Float> = split(PLAYBACK_RATES_SEPARATOR).mapNotNull { it.toFloatOrNull() }
 
+  private fun String.asItemSpeedMap(): Map<LibraryItemId, Float> {
+    return split(ITEM_SPEED_ENTRY_SEPARATOR)
+      .mapNotNull { entry ->
+        val itemId = entry.substringBefore(ITEM_SPEED_VALUE_SEPARATOR)
+        val speed = entry.substringAfter(ITEM_SPEED_VALUE_SEPARATOR, "").toFloatOrNull()
+        if (itemId.isEmpty() || speed == null) null else itemId to speed
+      }
+      .toMap()
+  }
+
   private fun PendingResumeRewind.serialize(): String =
     "$pausedAtEpochMillis$PENDING_RESUME_REWIND_SEPARATOR$libraryItemId"
 
@@ -180,6 +205,9 @@ internal const val PREF_BACKWARD_TIME_MS = "pref_playback_backward_time_ms"
 internal const val PREF_TRACK_RESET_THRESHOLD = "pref_playback_track_reset_threshold"
 internal const val PREF_PLAYBACK_RATES = "pref_playback_rates"
 internal const val PREF_PLAYBACK_SPEED = "pref_playback_speed"
+internal const val PREF_ITEM_PLAYBACK_SPEEDS = "pref_item_playback_speeds"
+internal const val ITEM_SPEED_ENTRY_SEPARATOR = "::"
+internal const val ITEM_SPEED_VALUE_SEPARATOR = "|"
 internal const val PREF_SYNC = "pref_synchronization"
 internal const val PREF_AUTO_SYNC = "pref_auto_sync"
 internal const val PREF_REMOTE_NEXT_PREV_SKIPS_CHAPTERS = "pref_playback_remote_next_prev_skips_chapters"

--- a/features/settings/impl/src/commonTest/kotlin/app/campfire/settings/ItemPlaybackSpeedsTest.kt
+++ b/features/settings/impl/src/commonTest/kotlin/app/campfire/settings/ItemPlaybackSpeedsTest.kt
@@ -1,0 +1,66 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.settings
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import com.russhwolf.settings.MapSettings
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+
+class ItemPlaybackSpeedsTest {
+
+  private val settingsScope = CoroutineScope(Dispatchers.Unconfined + Job())
+
+  @Test
+  fun `itemPlaybackSpeeds defaults to empty and round-trips through storage`() {
+    val settings = playbackSettings()
+    assertThat(settings.itemPlaybackSpeeds).isEmpty()
+
+    val speeds = mapOf("li_abc123" to 1.5f, "li_def456" to 0.75f)
+    settings.itemPlaybackSpeeds = speeds
+    assertThat(settings.itemPlaybackSpeeds).isEqualTo(speeds)
+
+    settings.itemPlaybackSpeeds = emptyMap()
+    assertThat(settings.itemPlaybackSpeeds).isEmpty()
+  }
+
+  @Test
+  fun `playbackSpeedFor falls back to the global speed without an override`() {
+    val settings = playbackSettings()
+    settings.playbackSpeed = 1.25f
+    settings.itemPlaybackSpeeds = mapOf("li_abc123" to 2f)
+
+    assertThat(settings.playbackSpeedFor("li_abc123")).isEqualTo(2f)
+    assertThat(settings.playbackSpeedFor("li_other")).isEqualTo(1.25f)
+    assertThat(settings.playbackSpeedFor(null)).isEqualTo(1.25f)
+  }
+
+  @Test
+  fun `setPlaybackSpeedFor writes the override when enabled and the global otherwise`() {
+    val settings = playbackSettings()
+    settings.playbackSpeed = 1f
+    settings.itemPlaybackSpeeds = mapOf("li_abc123" to 1.5f)
+
+    // Item with an override enabled: only its entry changes
+    settings.setPlaybackSpeedFor("li_abc123", 1.75f)
+    assertThat(settings.itemPlaybackSpeeds).isEqualTo(mapOf("li_abc123" to 1.75f))
+    assertThat(settings.playbackSpeed).isEqualTo(1f)
+
+    // Item without an override: the global changes, no entry is created
+    settings.setPlaybackSpeedFor("li_other", 1.2f)
+    assertThat(settings.playbackSpeed).isEqualTo(1.2f)
+    assertThat(settings.itemPlaybackSpeeds).isEqualTo(mapOf("li_abc123" to 1.75f))
+
+    // No item at all: the global changes
+    settings.setPlaybackSpeedFor(null, 0.9f)
+    assertThat(settings.playbackSpeed).isEqualTo(0.9f)
+  }
+
+  private fun playbackSettings(): PlaybackSettingsImpl =
+    PlaybackSettingsImpl(MapSettings(), settingsScope)
+}

--- a/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/FakePlaybackSettings.kt
+++ b/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/FakePlaybackSettings.kt
@@ -3,6 +3,7 @@
 
 package app.campfire.settings.test
 
+import app.campfire.core.model.LibraryItemId
 import app.campfire.settings.api.PendingResumeRewind
 import app.campfire.settings.api.PlaybackSettings
 import app.campfire.settings.api.ResumeRewindConfig
@@ -49,6 +50,13 @@ class FakePlaybackSettings : PlaybackSettings {
   override fun observePlaybackRates(): StateFlow<List<Float>> = _playbackRates.asStateFlow()
 
   override var playbackSpeed: Float = 1f
+
+  private val _itemPlaybackSpeeds = MutableStateFlow(emptyMap<LibraryItemId, Float>())
+  override var itemPlaybackSpeeds: Map<LibraryItemId, Float>
+    get() = _itemPlaybackSpeeds.value
+    set(value) { _itemPlaybackSpeeds.value = value }
+  override fun observeItemPlaybackSpeeds(): StateFlow<Map<LibraryItemId, Float>> =
+    _itemPlaybackSpeeds.asStateFlow()
 
   private val _remoteNextPrevSkipsChapters = MutableStateFlow(true)
   override var remoteNextPrevSkipsChapters: Boolean

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -278,6 +278,7 @@ class ExoPlayerAudioPlayer(
     hlsQueueActive = session.episode == null && session.hlsStreamUrl != null
     hlsFallbackAttempted = false
     finishedListener = onFinished
+    playbackSpeed.value = settings.playbackSpeedFor(session.libraryItem.id)
     _error.value = null
     state.value = AudioPlayer.State.Initializing
 
@@ -605,7 +606,7 @@ class ExoPlayerAudioPlayer(
 
   override fun setPlaybackSpeed(speed: Float) {
     playbackSpeed.value = speed
-    settings.playbackSpeed = speed
+    settings.setPlaybackSpeedFor(preparedSession?.libraryItem?.id, speed)
     player.setPlaybackSpeed(speed)
   }
 
@@ -735,7 +736,7 @@ class ExoPlayerAudioPlayer(
     ) {
       // Ensure that our remote cast player has up-to-date playback speed set
       // See: https://github.com/androidx/media/issues/889
-      player.setPlaybackSpeed(settings.playbackSpeed)
+      player.setPlaybackSpeed(playbackSpeed.value)
     }
   }
 

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaSessionCallback.kt
@@ -99,7 +99,7 @@ internal class MediaSessionCallback(
     when (customCommand.customAction) {
       WidgetSessionCommand.CYCLE_SPEED -> {
         val rates = component.playbackSettings.playbackRates
-        val currentSpeed = component.playbackSettings.playbackSpeed
+        val currentSpeed = player.playbackSpeed.value
         val currentIndex = rates.indexOfFirst { it == currentSpeed }
         val nextIndex = if (currentIndex < 0) 0 else (currentIndex + 1) % rates.size
         player.setPlaybackSpeed(rates[nextIndex])

--- a/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/IosAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/IosAudioPlayer.kt
@@ -112,6 +112,7 @@ class IosAudioPlayer(
   ) {
     preparedSession = session
     finishedListener = onFinished
+    playbackSpeed.value = settings.playbackSpeedFor(session.libraryItem.id)
     player.prePrepare()
 
     setupRemoteTransportControls()
@@ -337,7 +338,7 @@ class IosAudioPlayer(
 
   override fun setPlaybackSpeed(speed: Float) {
     playbackSpeed.value = speed
-    settings.playbackSpeed = speed
+    settings.setPlaybackSpeedFor(preparedSession?.libraryItem?.id, speed)
     player.setPlaybackSpeed(speed)
   }
 

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/VlcAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/VlcAudioPlayer.kt
@@ -70,6 +70,7 @@ class VlcAudioPlayer(
   ) {
     preparedSession = session
     finishedListener = onFinished
+    playbackSpeed.value = settings.playbackSpeedFor(session.libraryItem.id)
     state.value = AudioPlayer.State.Initializing
 
     // Build and set media items for the current session
@@ -257,7 +258,7 @@ class VlcAudioPlayer(
 
   override fun setPlaybackSpeed(speed: Float) {
     playbackSpeed.value = speed
-    settings.playbackSpeed = speed
+    settings.setPlaybackSpeedFor(preparedSession?.libraryItem?.id, speed)
     mediaPlayer.setPlaybackSpeed(speed)
   }
 


### PR DESCRIPTION
Closes #971

## What

Adds the ability to set a playback speed per book/item. The playback speed sheet gains a toggle (globe ↔ book icon) that switches the current item between the global speed and its own saved speed.

## How

- **Setting**: `PlaybackSettings.itemPlaybackSpeeds: Map<LibraryItemId, Float>` — an entry's presence means per-book speed is enabled for that item, and its value is the saved speed. Interface-default helpers `playbackSpeedFor(itemId)` and `setPlaybackSpeedFor(itemId, speed)` centralize the override-else-global routing.
- **Players**: `ExoPlayerAudioPlayer`, `IosAudioPlayer`, and `VlcAudioPlayer` resolve the effective speed at `prepare()` from the session's library item, and route `setPlaybackSpeed` persistence through `setPlaybackSpeedFor`, so every speed entry point (sheet, widget cycle-speed, Cast re-apply) respects the override automatically.
- **Sheet**: `showPlaybackSpeedBottomSheet` now takes the item id via a `PlaybackSpeedInput` overlay model instead of pulling it from DI. Component access is hoisted into a state layer above a pure `PlaybackSpeedSheet` composable with a compose preview.
- Toggling on seeds the override with the current speed; toggling off removes it and snaps active playback back to the global speed.

Podcasts get per-podcast granularity (overrides are keyed by library item id, shared across episodes).

## Testing

- New `ItemPlaybackSpeedsTest` covers storage round-trip and the fallback/routing behavior of the helpers.
- `:features:settings:impl`, `:features:sessions:ui`, and `:infra:audioplayer:impl` JVM tests pass; JVM + Android compilations verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)