### PR TITLE
Make the quick playback speed options customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Playback settings for how often listening progress syncs to the server, separately for Wi-Fi and mobile data
 - Optional HLS streaming on Android with a new Streaming method setting (Auto, Direct play, or Prefer HLS) for smoother seeking in large single-file audiobooks
 - Per-book playback speed — a toggle in the playback speed sheet saves a speed for just that book instead of changing the global speed
+- The five quick playback speed options can now be customized in Settings → Playback, with sliders from 0.5x to 3x and tap-to-type exact values
 
 ### Changed
 

--- a/common/compose/src/commonMain/composeResources/values/common_compose_strings.xml
+++ b/common/compose/src/commonMain/composeResources/values/common_compose_strings.xml
@@ -50,4 +50,10 @@
     <item>On a journey to find the edges of the world and the depths of a good book.</item>
     <item>Every book is a new beginning.</item>
   </string-array>
+
+  <string name="playback_speed_dialog_title">Custom speed</string>
+  <string name="playback_speed_dialog_label">Speed</string>
+  <string name="playback_speed_dialog_error">Enter a value between %1$s and %2$s</string>
+  <string name="playback_speed_dialog_apply">Apply</string>
+  <string name="playback_speed_dialog_cancel">Cancel</string>
 </resources>

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/PlaybackSpeedDialog.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/PlaybackSpeedDialog.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import app.campfire.core.extensions.readable
 import app.campfire.core.extensions.readableHundredths
 import app.campfire.core.extensions.roundToHundredths
 import campfire.common.compose.generated.resources.Res
@@ -45,8 +44,8 @@ fun PlaybackSpeedDialog(
   val isError = input.isNotBlank() && parsed == null
   val rangeError = stringResource(
     Res.string.playback_speed_dialog_error,
-    range.start.readable,
-    range.endInclusive.readable,
+    range.start.readableHundredths,
+    range.endInclusive.readableHundredths,
   )
 
   AlertDialog(

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/PlaybackSpeedDialog.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/PlaybackSpeedDialog.kt
@@ -1,0 +1,101 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.widgets
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import app.campfire.core.extensions.readable
+import app.campfire.core.extensions.readableHundredths
+import app.campfire.core.extensions.roundToHundredths
+import campfire.common.compose.generated.resources.Res
+import campfire.common.compose.generated.resources.playback_speed_dialog_apply
+import campfire.common.compose.generated.resources.playback_speed_dialog_cancel
+import campfire.common.compose.generated.resources.playback_speed_dialog_error
+import campfire.common.compose.generated.resources.playback_speed_dialog_label
+import campfire.common.compose.generated.resources.playback_speed_dialog_title
+import org.jetbrains.compose.resources.stringResource
+
+/** The supported range for user-adjusted playback speeds. */
+val PlaybackSpeedRange: ClosedFloatingPointRange<Float> = 0.5f.rangeTo(3f)
+
+/**
+ * A dialog for typing an exact playback speed, validated against [range].
+ */
+@Composable
+fun PlaybackSpeedDialog(
+  initialSpeed: Float,
+  onDismiss: () -> Unit,
+  onConfirm: (Float) -> Unit,
+  modifier: Modifier = Modifier,
+  range: ClosedFloatingPointRange<Float> = PlaybackSpeedRange,
+) {
+  var input by remember { mutableStateOf(initialSpeed.readableHundredths) }
+  val parsed = parsePlaybackSpeed(input, range)
+  val isError = input.isNotBlank() && parsed == null
+  val rangeError = stringResource(
+    Res.string.playback_speed_dialog_error,
+    range.start.readable,
+    range.endInclusive.readable,
+  )
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    modifier = modifier,
+    title = { Text(stringResource(Res.string.playback_speed_dialog_title)) },
+    text = {
+      OutlinedTextField(
+        value = input,
+        onValueChange = { input = it },
+        singleLine = true,
+        isError = isError,
+        label = { Text(stringResource(Res.string.playback_speed_dialog_label)) },
+        suffix = { Text("x") },
+        supportingText = { Text(rangeError) },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+      )
+    },
+    confirmButton = {
+      TextButton(
+        enabled = parsed != null,
+        onClick = { parsed?.let(onConfirm) },
+      ) {
+        Text(stringResource(Res.string.playback_speed_dialog_apply))
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss) {
+        Text(stringResource(Res.string.playback_speed_dialog_cancel))
+      }
+    },
+  )
+}
+
+/**
+ * Parse a user-entered playback speed such as "1.2", "1,2" or "1.2x", rounded to hundredths.
+ * Returns null if the text isn't a number or falls outside [range].
+ */
+fun parsePlaybackSpeed(
+  text: String,
+  range: ClosedFloatingPointRange<Float> = PlaybackSpeedRange,
+): Float? {
+  val value = text.trim()
+    .removeSuffix("x")
+    .removeSuffix("X")
+    .trim()
+    .replace(',', '.')
+    .toFloatOrNull()
+    ?.roundToHundredths()
+    ?: return null
+  return value.takeIf { it in range }
+}

--- a/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
+++ b/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
@@ -14,11 +14,6 @@
 
   <string name="speed_bottomsheet_title">Playback speed</string>
   <string name="speed_custom_open">Enter custom speed</string>
-  <string name="speed_custom_dialog_title">Custom speed</string>
-  <string name="speed_custom_dialog_label">Speed</string>
-  <string name="speed_custom_dialog_error">Enter a value between %1$s and %2$s</string>
-  <string name="speed_custom_action_apply">Apply</string>
-  <string name="speed_custom_action_cancel">Cancel</string>
   <string name="speed_per_book_toggle">Use a separate playback speed for this book</string>
   <string name="timer_bottomsheet_title">Sleep Timer</string>
   <string name="timer_end_of_chapter">End of Chapter</string>

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
@@ -13,20 +13,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -38,7 +34,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -55,6 +50,8 @@ import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Book
 import app.campfire.common.compose.icons.rounded.Globe
 import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.PlaybackSpeedDialog
+import app.campfire.common.compose.widgets.PlaybackSpeedRange
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.ComponentHolder
 import app.campfire.core.extensions.readable
@@ -65,11 +62,6 @@ import app.campfire.sessions.ui.sheets.SessionSheetLayout
 import app.campfire.settings.api.PlaybackSettings
 import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.speed_bottomsheet_title
-import campfire.features.sessions.ui.generated.resources.speed_custom_action_apply
-import campfire.features.sessions.ui.generated.resources.speed_custom_action_cancel
-import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_error
-import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_label
-import campfire.features.sessions.ui.generated.resources.speed_custom_dialog_title
 import campfire.features.sessions.ui.generated.resources.speed_custom_open
 import campfire.features.sessions.ui.generated.resources.speed_per_book_toggle
 import com.r0adkll.kimchi.annotations.ContributesTo
@@ -144,7 +136,7 @@ private fun PlaybackSpeedBottomSheet(
       }
   }.collectAsState(input.speed)
 
-  val speedOptions = remember { component.playbackSettings.playbackRates.sorted() }
+  val speedOptions = remember { component.playbackSettings.playbackRates.distinct().sorted() }
 
   val itemPlaybackSpeeds by remember {
     component.playbackSettings.observeItemPlaybackSpeeds()
@@ -240,14 +232,14 @@ internal fun PlaybackSpeedSheet(
         }
       }
 
-      val sliderProgressNormalized = sliderValue / (DefaultSpeedRange.start + DefaultSpeedRange.length)
+      val sliderProgressNormalized = sliderValue / (PlaybackSpeedRange.start + PlaybackSpeedRange.length)
       val waveLength = lerp(WavelengthRange.endInclusive, WavelengthRange.start, sliderProgressNormalized)
       val waveHeight = lerp(WaveHeightRange.start, WaveHeightRange.endInclusive, sliderProgressNormalized)
       val waveVelocity = lerp(WaveVelocityRange.start, WaveVelocityRange.endInclusive, sliderProgressNormalized)
       val waveThickness = lerp(WaveThicknessRange.start, WaveThicknessRange.endInclusive, sliderProgressNormalized)
 
       val setSpeed: (Float) -> Unit = { raw ->
-        val speed = raw.roundToHundredths().coerceIn(DefaultSpeedRange)
+        val speed = raw.roundToHundredths().coerceIn(PlaybackSpeedRange)
         // Rounding to hundredths means nearby drag frames resolve to the same value; only push real changes
         if (speed != sliderValue) {
           sliderValue = speed
@@ -257,7 +249,7 @@ internal fun PlaybackSpeedSheet(
 
       WavySlider(
         value = sliderValue,
-        valueRange = DefaultSpeedRange,
+        valueRange = PlaybackSpeedRange,
         onValueChange = setSpeed,
         waveLength = waveLength,
         waveHeight = waveHeight,
@@ -284,7 +276,7 @@ internal fun PlaybackSpeedSheet(
       )
 
       if (showCustomSpeedDialog) {
-        CustomSpeedDialog(
+        PlaybackSpeedDialog(
           initialSpeed = sliderValue,
           onDismiss = { showCustomSpeedDialog = false },
           onConfirm = { speed ->
@@ -297,70 +289,6 @@ internal fun PlaybackSpeedSheet(
 
     Spacer(Modifier.height(24.dp))
   }
-}
-
-@Composable
-private fun CustomSpeedDialog(
-  initialSpeed: Float,
-  onDismiss: () -> Unit,
-  onConfirm: (Float) -> Unit,
-  modifier: Modifier = Modifier,
-) {
-  var input by remember { mutableStateOf(initialSpeed.readableHundredths) }
-  val parsed = parsePlaybackSpeed(input)
-  val isError = input.isNotBlank() && parsed == null
-  val rangeError = stringResource(
-    Res.string.speed_custom_dialog_error,
-    DefaultSpeedRange.start.readable,
-    DefaultSpeedRange.endInclusive.readable,
-  )
-
-  AlertDialog(
-    onDismissRequest = onDismiss,
-    modifier = modifier,
-    title = { Text(stringResource(Res.string.speed_custom_dialog_title)) },
-    text = {
-      OutlinedTextField(
-        value = input,
-        onValueChange = { input = it },
-        singleLine = true,
-        isError = isError,
-        label = { Text(stringResource(Res.string.speed_custom_dialog_label)) },
-        suffix = { Text("x") },
-        supportingText = { Text(rangeError) },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-      )
-    },
-    confirmButton = {
-      TextButton(
-        enabled = parsed != null,
-        onClick = { parsed?.let(onConfirm) },
-      ) {
-        Text(stringResource(Res.string.speed_custom_action_apply))
-      }
-    },
-    dismissButton = {
-      TextButton(onClick = onDismiss) {
-        Text(stringResource(Res.string.speed_custom_action_cancel))
-      }
-    },
-  )
-}
-
-/**
- * Parse a user-entered playback speed such as "1.2", "1,2" or "1.2x", rounded to hundredths.
- * Returns null if the text isn't a number or falls outside [DefaultSpeedRange].
- */
-internal fun parsePlaybackSpeed(text: String): Float? {
-  val value = text.trim()
-    .removeSuffix("x")
-    .removeSuffix("X")
-    .trim()
-    .replace(',', '.')
-    .toFloatOrNull()
-    ?.roundToHundredths()
-    ?: return null
-  return value.takeIf { it in DefaultSpeedRange }
 }
 
 @Preview
@@ -391,5 +319,4 @@ private val WaveHeightRange = 0.dp.rangeTo(40.dp)
 private val WaveVelocityRange = 50.dp.rangeTo(120.dp)
 private val WaveThicknessRange = 16.dp.rangeTo(6.dp)
 
-internal val DefaultSpeedRange = 0.5f.rangeTo(2f)
 private val ClosedFloatingPointRange<Float>.length: Float get() = endInclusive - start

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/speed/PlaybackSpeedBottomSheet.kt
@@ -54,7 +54,6 @@ import app.campfire.common.compose.widgets.PlaybackSpeedDialog
 import app.campfire.common.compose.widgets.PlaybackSpeedRange
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.ComponentHolder
-import app.campfire.core.extensions.readable
 import app.campfire.core.extensions.readableHundredths
 import app.campfire.core.extensions.roundToHundredths
 import app.campfire.core.model.LibraryItemId
@@ -209,7 +208,7 @@ internal fun PlaybackSpeedSheet(
         SegmentedButton(
           shape = SegmentedButtonDefaults.itemShape(index, speedOptions.size, RoundedCornerShape(16.dp)),
           selected = isCurrentSpeed,
-          label = { Text("${defaultSpeed.readable}x") },
+          label = { Text("${defaultSpeed.readableHundredths}x") },
           onClick = { onSpeedChange(defaultSpeed) },
         )
       }

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -67,6 +67,9 @@
   <string name="setting_playback_track_reset_subtitle">How far into a track that skip previous will just restart it</string>
   <string name="setting_playback_remote_skip_title">Bluetooth next/prev skips chapters</string>
   <string name="setting_playback_remote_skip_subtitle">When enabled, Bluetooth next/previous buttons skip to next/previous chapter. When disabled, they seek forward/backward by the configured time.</string>
+  <string name="header_playback_speed_options">Playback speed</string>
+  <string name="setting_playback_speed_options_description">Customize the quick speed options offered in the playback speed selector.</string>
+  <string name="setting_playback_speed_option_edit">Enter custom speed</string>
   <string name="header_player_interface">Player interface</string>
   <string name="setting_playback_book_time_title">Show book progress</string>
   <string name="setting_playback_book_time_subtitle">Display the overall book progress and time remaining above the seek bar in the player</string>

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -65,6 +65,7 @@ import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ForwardTime
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.MinPauseThreshold
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.Mp3IndexSeeking
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.PlaybackHistoryEnabled
+import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.PlaybackRateChanged
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.PlaybackWavyScrubber
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.RemoteNextPrevSkipsChapters
 import app.campfire.ui.settings.SettingsUiEvent.PlaybackSettingEvent.ResumeRewindRange
@@ -148,6 +149,7 @@ class SettingsPresenter(
     }.collectAsState()
 
     // Playback Settings
+    val playbackRates by remember { playbackSettings.observePlaybackRates() }.collectAsState()
     val forwardTime by remember { playbackSettings.observeForwardTimeMs() }.collectAsState()
     val backwardTime by remember { playbackSettings.observeBackwardTimeMs() }.collectAsState()
     val trackResetThreshold by remember { playbackSettings.observeTrackResetThreshold() }.collectAsState()
@@ -262,6 +264,7 @@ class SettingsPresenter(
         downloads = downloadEntries,
       ),
       playbackSettings = PlaybackSettingsInfo(
+        playbackRates = playbackRates,
         forwardTime = forwardTime.milliseconds,
         backwardTime = backwardTime.milliseconds,
         trackResetThreshold = trackResetThreshold,
@@ -362,6 +365,13 @@ class SettingsPresenter(
         }
 
         is SettingsUiEvent.PlaybackSettingEvent -> when (event) {
+          is PlaybackRateChanged -> {
+            val rates = playbackSettings.playbackRates.toMutableList()
+            if (event.index in rates.indices) {
+              rates[event.index] = event.rate
+              playbackSettings.playbackRates = rates
+            }
+          }
           is ForwardTime -> playbackSettings.forwardTimeMs = event.forwardTime.inWholeMilliseconds
           is BackwardTime -> playbackSettings.backwardTimeMs = event.backwardTime.inWholeMilliseconds
           is TrackResetThreshold -> playbackSettings.trackResetThreshold = event.trackResetThreshold

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -79,6 +79,7 @@ sealed interface DownloadEntry {
 
 @Immutable
 data class PlaybackSettingsInfo(
+  val playbackRates: List<Float>,
   val forwardTime: Duration,
   val backwardTime: Duration,
   val trackResetThreshold: Duration,
@@ -193,6 +194,7 @@ sealed interface SettingsUiEvent : CircuitUiEvent {
 
   // Playback Setting Events
   sealed interface PlaybackSettingEvent : SettingsUiEvent {
+    data class PlaybackRateChanged(val index: Int, val rate: Float) : PlaybackSettingEvent
     data class ForwardTime(val forwardTime: Duration) : PlaybackSettingEvent
     data class BackwardTime(val backwardTime: Duration) : PlaybackSettingEvent
     data class TrackResetThreshold(val trackResetThreshold: Duration) : PlaybackSettingEvent

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
@@ -82,6 +82,8 @@ class SettingsAnalyticUiEventHandler(
     }
 
     is SettingsUiEvent.PlaybackSettingEvent -> when (event) {
+      is SettingsUiEvent.PlaybackSettingEvent.PlaybackRateChanged ->
+        send("playback_rate_${event.index}", Updated, event.rate)
       is ForwardTime -> send("forward_time", Updated, event.forwardTime.inWholeMilliseconds)
       is BackwardTime -> send("backward_time", Updated, event.backwardTime.inWholeMilliseconds)
       is TrackResetThreshold -> send("track_reset_threshold", Updated, event.trackResetThreshold.inWholeMilliseconds)

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/composables/PlaybackSpeedOptionsSetting.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/composables/PlaybackSpeedOptionsSetting.kt
@@ -1,0 +1,158 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.ui.settings.composables
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.PlaybackSpeedDialog
+import app.campfire.common.compose.widgets.PlaybackSpeedRange
+import app.campfire.core.extensions.readableHundredths
+import app.campfire.core.extensions.roundToHundredths
+import campfire.features.settings.ui.generated.resources.Res
+import campfire.features.settings.ui.generated.resources.setting_playback_speed_option_edit
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Editors for the quick playback speed options offered in the playback speed sheet — one
+ * slider row per option, with the value label clickable to type an exact speed.
+ */
+@Composable
+internal fun PlaybackSpeedOptionsSetting(
+  rates: List<Float>,
+  onRateChange: (index: Int, rate: Float) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+    modifier = modifier.padding(horizontal = 16.dp),
+  ) {
+    rates.forEachIndexed { index, rate ->
+      SpeedOptionRow(
+        rate = rate,
+        shape = rowShape(index = index, total = rates.size),
+        onRateChange = { onRateChange(index, it) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun SpeedOptionRow(
+  rate: Float,
+  shape: Shape,
+  onRateChange: (Float) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  ElevatedCard(
+    shape = shape,
+    modifier = modifier,
+  ) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+      var sliderValue by remember { mutableStateOf(rate) }
+
+      LaunchedEffect(rate) {
+        if (sliderValue != rate) {
+          sliderValue = rate
+        }
+      }
+
+      val setRate: (Float) -> Unit = { raw ->
+        val speed = raw.roundToHundredths().coerceIn(PlaybackSpeedRange)
+        // Rounding to hundredths means nearby drag frames resolve to the same value; only push real changes
+        if (speed != sliderValue) {
+          sliderValue = speed
+          onRateChange(speed)
+        }
+      }
+
+      Slider(
+        value = sliderValue,
+        onValueChange = setRate,
+        valueRange = PlaybackSpeedRange,
+        modifier = Modifier.weight(1f),
+      )
+
+      var showSpeedDialog by remember { mutableStateOf(false) }
+      val editLabel = stringResource(Res.string.setting_playback_speed_option_edit)
+
+      Text(
+        text = "${sliderValue.readableHundredths}x",
+        textAlign = TextAlign.Center,
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.ExtraBold,
+        modifier = Modifier
+          .padding(start = 12.dp)
+          .clip(RoundedCornerShape(12.dp))
+          .clickable(onClickLabel = editLabel) { showSpeedDialog = true }
+          .padding(horizontal = 8.dp, vertical = 12.dp)
+          .width(44.dp),
+      )
+
+      if (showSpeedDialog) {
+        PlaybackSpeedDialog(
+          initialSpeed = sliderValue,
+          onDismiss = { showSpeedDialog = false },
+          onConfirm = { speed ->
+            showSpeedDialog = false
+            setRate(speed)
+          },
+        )
+      }
+    }
+  }
+}
+
+private fun rowShape(index: Int, total: Int): Shape {
+  val large = 16.dp
+  val small = 4.dp
+  return when {
+    total == 1 -> RoundedCornerShape(large)
+    index == 0 -> RoundedCornerShape(topStart = large, topEnd = large, bottomStart = small, bottomEnd = small)
+    index == total - 1 ->
+      RoundedCornerShape(topStart = small, topEnd = small, bottomStart = large, bottomEnd = large)
+    else -> RoundedCornerShape(small)
+  }
+}
+
+@Preview
+@Composable
+private fun PlaybackSpeedOptionsSettingPreview() {
+  CampfireTheme {
+    var rates by remember { mutableStateOf(listOf(1f, 1.1f, 1.25f, 1.5f, 2f)) }
+
+    PlaybackSpeedOptionsSetting(
+      rates = rates,
+      onRateChange = { index, rate ->
+        rates = rates.toMutableList().apply { this[index] = rate }
+      },
+    )
+  }
+}

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/PlaybackPane.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/PlaybackPane.kt
@@ -5,9 +5,14 @@ package app.campfire.ui.settings.panes
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import app.campfire.core.Platform
 import app.campfire.core.currentPlatform
 import app.campfire.settings.api.MinPauseThresholdRange
@@ -18,6 +23,7 @@ import app.campfire.ui.settings.SettingsUiState
 import app.campfire.ui.settings.composables.DurationRangeSliderSetting
 import app.campfire.ui.settings.composables.DurationSliderSetting
 import app.campfire.ui.settings.composables.Header
+import app.campfire.ui.settings.composables.PlaybackSpeedOptionsSetting
 import app.campfire.ui.settings.composables.ResumeRewindPreviewRow
 import app.campfire.ui.settings.composables.StreamingMethodSetting
 import app.campfire.ui.settings.composables.SwitchSetting
@@ -26,6 +32,7 @@ import app.campfire.ui.settings.composables.TimeJumps
 import campfire.features.settings.ui.generated.resources.Res
 import campfire.features.settings.ui.generated.resources.header_auto_rewind_on_resume
 import campfire.features.settings.ui.generated.resources.header_playback_history
+import campfire.features.settings.ui.generated.resources.header_playback_speed_options
 import campfire.features.settings.ui.generated.resources.header_player_interface
 import campfire.features.settings.ui.generated.resources.header_streaming
 import campfire.features.settings.ui.generated.resources.header_synchronization
@@ -52,6 +59,7 @@ import campfire.features.settings.ui.generated.resources.setting_playback_rewind
 import campfire.features.settings.ui.generated.resources.setting_playback_rewind_range_title
 import campfire.features.settings.ui.generated.resources.setting_playback_rewind_stop_chapter_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_rewind_stop_chapter_title
+import campfire.features.settings.ui.generated.resources.setting_playback_speed_options_description
 import campfire.features.settings.ui.generated.resources.setting_playback_sync_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_sync_title
 import campfire.features.settings.ui.generated.resources.setting_playback_title
@@ -125,6 +133,28 @@ internal fun PlaybackPane(
       headlineContent = { Text(stringResource(Res.string.setting_playback_remote_skip_title)) },
       supportingContent = { Text(stringResource(Res.string.setting_playback_remote_skip_subtitle)) },
     )
+
+    Header(
+      title = { Text(stringResource(Res.string.header_playback_speed_options)) },
+    )
+
+    Text(
+      text = stringResource(Res.string.setting_playback_speed_options_description),
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      modifier = Modifier.padding(horizontal = 16.dp),
+    )
+
+    Spacer(Modifier.height(8.dp))
+
+    PlaybackSpeedOptionsSetting(
+      rates = state.playbackSettings.playbackRates,
+      onRateChange = { index, rate ->
+        state.eventSink(PlaybackSettingEvent.PlaybackRateChanged(index, rate))
+      },
+    )
+
+    Spacer(Modifier.height(8.dp))
 
     Header(
       title = { Text(stringResource(Res.string.header_player_interface)) },


### PR DESCRIPTION
Closes #1012

Builds on the per-book playback speed work from #1011.

## What

Settings → Playback gains a **Playback speed** section that lets users customize the five quick speed options shown in the playback speed sheet. Each option is a card row (visually matching the Android Auto categories settings — same surfaces and first/last rounded corners, no reordering) with:

- a slider from **0.5x to 3x** (hundredths precision), and
- a tap-to-type value label that opens the same custom speed dialog as the playback sheet.

## How

- The existing `PlaybackSettings.playbackRates` setting is now user-editable: `PlaybackSettingsInfo.playbackRates` + a `PlaybackRateChanged(index, rate)` event flow through `SettingsPresenter`, with an analytics branch (`playback_rate_{index}`).
- The custom speed dialog and `parsePlaybackSpeed` move out of the sessions sheet into `common/compose` as a shared `PlaybackSpeedDialog`, so settings and the sheet use one implementation.
- A shared `PlaybackSpeedRange` (0.5x–3x) replaces the sheet's private 0.5x–2x range — the sheet's wavy slider and dialog now also accept up to 3x, keeping the two surfaces consistent when a quick option above 2x is configured.
- The sheet's quick options are de-duplicated (`distinct()`) in case two slots are set to the same speed.
- New `PlaybackSpeedOptionsSetting` is a pure composable with a compose preview; slot order is preserved while editing and the sheet sorts for display.

## Testing

- `:common:compose`, `:features:sessions:ui`, `:features:settings:ui`, and `:features:settings:impl` JVM tests pass; JVM + Android compilations verified; ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)