### PR TITLE
Add a sound equalizer with presets, loudness, and bass boost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional HLS streaming on Android with a new Streaming method setting (Auto, Direct play, or Prefer HLS) for smoother seeking in large single-file audiobooks
 - Per-book playback speed — a toggle in the playback speed sheet saves a speed for just that book instead of changing the global speed
 - The five quick playback speed options can now be customized in Settings → Playback, with sliders from 0.5x to 3x and tap-to-type exact values
+- Sound equalizer on the playing screen (Android and desktop) with presets, 10-band adjustment, loudness and bass boost, and per-book profiles
 
 ### Changed
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/VerticalSlider.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/VerticalSlider.kt
@@ -1,0 +1,70 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.widgets
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+
+/**
+ * A vertically oriented Material 3 [Slider], drag up to increase. The caller's [modifier]
+ * sizes the vertical footprint (e.g. `Modifier.height(160.dp)`); the underlying slider is
+ * rotated into it so Material semantics, keyboard, and accessibility behavior are preserved.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VerticalSlider(
+  value: Float,
+  onValueChange: (Float) -> Unit,
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+  onValueChangeFinished: (() -> Unit)? = null,
+) {
+  val interactionSource = remember { MutableInteractionSource() }
+  Slider(
+    value = value,
+    onValueChange = onValueChange,
+    onValueChangeFinished = onValueChangeFinished,
+    valueRange = valueRange,
+    enabled = enabled,
+    interactionSource = interactionSource,
+    thumb = {
+      SliderDefaults.Thumb(
+        interactionSource = interactionSource,
+        enabled = enabled,
+        thumbSize = DpSize(4.dp, 32.dp),
+      )
+    },
+    modifier = modifier
+      .graphicsLayer { rotationZ = 270f }
+      .layout { measurable, constraints ->
+        // Swap the incoming constraints so the rotated slider measures its length against
+        // the caller's height, then report the swapped size back
+        val placeable = measurable.measure(
+          Constraints(
+            minWidth = constraints.minHeight,
+            maxWidth = constraints.maxHeight,
+            minHeight = constraints.minWidth,
+            maxHeight = constraints.maxWidth,
+          ),
+        )
+        layout(placeable.height, placeable.width) {
+          placeable.place(
+            x = -(placeable.width - placeable.height) / 2,
+            y = (placeable.width - placeable.height) / 2,
+          )
+        }
+      },
+  )
+}

--- a/core/src/commonMain/kotlin/app/campfire/core/audio/Equalizer.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/audio/Equalizer.kt
@@ -1,0 +1,114 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.core.audio
+
+/**
+ * The fixed band layout shared by every equalizer engine. The center frequencies match
+ * VLC's 10 ISO bands so the desktop (libvlc) equalizer maps index-for-index and the
+ * Android engine builds its bands from the same list.
+ */
+object EqualizerBands {
+  val centerFrequenciesHz: List<Int> = listOf(60, 170, 310, 600, 1_000, 3_000, 6_000, 12_000, 14_000, 16_000)
+
+  const val BAND_COUNT = 10
+
+  val BandGainRangeDb = -12f..12f
+  val LoudnessGainRangeDb = 0f..15f
+  val BassBoostRange = 0f..1f
+}
+
+/**
+ * A complete, user-adjustable equalizer configuration.
+ *
+ * @param enabled Master switch; when false no audio processing is applied.
+ * @param presetId One of [EqualizerPresets] ids, or [EqualizerPresets.CUSTOM_ID].
+ * @param bandGainsDb Gain in dB for each of the [EqualizerBands.BAND_COUNT] bands.
+ * @param loudnessGainDb Extra loudness gain in dB, within [EqualizerBands.LoudnessGainRangeDb].
+ * @param bassBoost Normalized bass boost strength, within [EqualizerBands.BassBoostRange].
+ */
+data class EqualizerProfile(
+  val enabled: Boolean = false,
+  val presetId: String = EqualizerPresets.FLAT_ID,
+  val bandGainsDb: List<Float> = List(EqualizerBands.BAND_COUNT) { 0f },
+  val loudnessGainDb: Float = 0f,
+  val bassBoost: Float = 0f,
+)
+
+data class EqualizerPreset(
+  val id: String,
+  val bandGainsDb: List<Float>,
+)
+
+/**
+ * The built-in presets. Display names are localized in the UI layer keyed off the stable
+ * preset id; no user-facing text lives here.
+ */
+object EqualizerPresets {
+  const val FLAT_ID = "flat"
+  const val VOICE_BOOST_ID = "voice_boost"
+  const val PODCAST_ID = "podcast"
+  const val BASS_BOOST_ID = "bass_boost"
+  const val TREBLE_BOOST_ID = "treble_boost"
+  const val WARM_ID = "warm"
+  const val REDUCE_NOISE_ID = "reduce_noise"
+  const val CUSTOM_ID = "custom"
+
+  val Flat = EqualizerPreset(
+    id = FLAT_ID,
+    bandGainsDb = listOf(0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f),
+  )
+
+  val VoiceBoost = EqualizerPreset(
+    id = VOICE_BOOST_ID,
+    bandGainsDb = listOf(-4f, -3f, -1f, 0f, 2f, 4f, 4f, 2f, 0f, -1f),
+  )
+
+  /**
+   * A fuller voice curve: where [VoiceBoost] cuts the lows for crispness, this keeps the
+   * low-mid body that gives podcast-style speech its warmth.
+   */
+  val Podcast = EqualizerPreset(
+    id = PODCAST_ID,
+    bandGainsDb = listOf(3f, 4f, 5f, 5f, 4f, 3f, 2f, 1f, 0f, 0f),
+  )
+
+  val BassBoost = EqualizerPreset(
+    id = BASS_BOOST_ID,
+    bandGainsDb = listOf(6f, 5f, 4f, 2f, 0f, 0f, 0f, 0f, 0f, 0f),
+  )
+
+  val TrebleBoost = EqualizerPreset(
+    id = TREBLE_BOOST_ID,
+    bandGainsDb = listOf(0f, 0f, 0f, 0f, 0f, 2f, 4f, 5f, 5f, 5f),
+  )
+
+  val Warm = EqualizerPreset(
+    id = WARM_ID,
+    bandGainsDb = listOf(3f, 2f, 1f, 0f, 0f, -1f, -2f, -2f, -3f, -3f),
+  )
+
+  /**
+   * Tames both extremes — rumble at the bottom, hiss at the top — for older or
+   * poorly-mastered recordings.
+   */
+  val ReduceNoise = EqualizerPreset(
+    id = REDUCE_NOISE_ID,
+    bandGainsDb = listOf(-3f, -2f, -1f, 0f, 0f, 0f, -1f, -2f, -3f, -3f),
+  )
+
+  /**
+   * All built-in presets in the order they should appear in the preset selector.
+   */
+  val all: List<EqualizerPreset> = listOf(Flat, VoiceBoost, Podcast, BassBoost, TrebleBoost, Warm, ReduceNoise)
+
+  fun forId(id: String): EqualizerPreset? = all.find { it.id == id }
+
+  /**
+   * Returns the id of the built-in preset whose gains match [gains],
+   * or [CUSTOM_ID] when none do.
+   */
+  fun presetIdMatching(gains: List<Float>): String {
+    return all.find { it.bandGainsDb == gains }?.id ?: CUSTOM_ID
+  }
+}

--- a/core/src/commonTest/kotlin/app/campfire/core/audio/EqualizerPresetsTest.kt
+++ b/core/src/commonTest/kotlin/app/campfire/core/audio/EqualizerPresetsTest.kt
@@ -1,0 +1,39 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.core.audio
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class EqualizerPresetsTest {
+
+  @Test
+  fun `every preset has the shared band count`() {
+    EqualizerPresets.all.forEach { preset ->
+      assertThat(preset.bandGainsDb).hasSize(EqualizerBands.BAND_COUNT)
+    }
+    assertThat(EqualizerBands.centerFrequenciesHz).hasSize(EqualizerBands.BAND_COUNT)
+  }
+
+  @Test
+  fun `presetIdMatching round-trips every built-in preset`() {
+    EqualizerPresets.all.forEach { preset ->
+      assertThat(EqualizerPresets.presetIdMatching(preset.bandGainsDb)).isEqualTo(preset.id)
+    }
+  }
+
+  @Test
+  fun `presetIdMatching returns custom for unrecognized gains`() {
+    val custom = listOf(1f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f)
+    assertThat(EqualizerPresets.presetIdMatching(custom)).isEqualTo(EqualizerPresets.CUSTOM_ID)
+  }
+
+  @Test
+  fun `forId resolves built-ins and misses custom`() {
+    assertThat(EqualizerPresets.forId(EqualizerPresets.WARM_ID)).isEqualTo(EqualizerPresets.Warm)
+    assertThat(EqualizerPresets.forId(EqualizerPresets.CUSTOM_ID)).isEqualTo(null)
+  }
+}

--- a/data/analytics/api/src/commonMain/kotlin/app/campfire/analytics/events/PlaybackActionEvent.kt
+++ b/data/analytics/api/src/commonMain/kotlin/app/campfire/analytics/events/PlaybackActionEvent.kt
@@ -33,6 +33,7 @@ val Chapter get() = PlaybackObj("chapter")
 val AudioTrack get() = PlaybackObj("track")
 val Bookmark get() = PlaybackObj("bookmark")
 val Speed get() = PlaybackObj("playback_speed")
+val Equalizer get() = PlaybackObj("equalizer")
 val Sync get() = PlaybackObj("sync_progress")
 
 // Verbs

--- a/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
+++ b/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
@@ -15,6 +15,23 @@
   <string name="speed_bottomsheet_title">Playback speed</string>
   <string name="speed_custom_open">Enter custom speed</string>
   <string name="speed_per_book_toggle">Use a separate playback speed for this book</string>
+
+  <string name="equalizer_bottomsheet_title">Equalizer</string>
+  <string name="action_equalizer">Equalizer</string>
+  <string name="equalizer_per_book_toggle">Use a separate equalizer for this book</string>
+  <string name="equalizer_enabled_toggle">Enable equalizer</string>
+  <string name="equalizer_preset_flat">Flat</string>
+  <string name="equalizer_preset_voice_boost">Voice Boost</string>
+  <string name="equalizer_preset_podcast">Podcast</string>
+  <string name="equalizer_preset_bass_boost">Bass Boost</string>
+  <string name="equalizer_preset_treble_boost">Treble Boost</string>
+  <string name="equalizer_preset_warm">Warm</string>
+  <string name="equalizer_preset_reduce_noise">Reduce Noise</string>
+  <string name="equalizer_preset_custom">Custom</string>
+  <string name="equalizer_loudness_label">Loudness</string>
+  <string name="equalizer_bass_label">Bass</string>
+  <string name="equalizer_unavailable_casting">The equalizer isn\'t available while casting</string>
+  <string name="equalizer_band_gain_cd">%1$s equalizer band gain</string>
   <string name="timer_bottomsheet_title">Sleep Timer</string>
   <string name="timer_end_of_chapter">End of Chapter</string>
   <string name="timer_custom">Custom</string>

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
@@ -68,12 +68,15 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.campfire.audioplayer.AudioPlayer
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.common.compose.extensions.readoutFormat
+import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Bookmarks
 import app.campfire.common.compose.icons.rounded.EditAudio
+import app.campfire.common.compose.icons.rounded.Equalizer
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.widgets.CoverImage
 import app.campfire.common.compose.widgets.IconButtonTooltip
@@ -90,6 +93,7 @@ import app.campfire.sessions.ui.sheets.bookmarks.BookmarkResult
 import app.campfire.sessions.ui.sheets.bookmarks.showBookmarksBottomSheet
 import app.campfire.sessions.ui.sheets.chapters.ChapterResult
 import app.campfire.sessions.ui.sheets.chapters.showChapterBottomSheet
+import app.campfire.sessions.ui.sheets.equalizer.showEqualizerBottomSheet
 import app.campfire.sessions.ui.sheets.sleeptimer.TimerResult
 import app.campfire.sessions.ui.sheets.sleeptimer.showSleepTimerBottomSheet
 import app.campfire.sessions.ui.sheets.speed.showPlaybackSpeedBottomSheet
@@ -98,6 +102,7 @@ import app.campfire.sessions.ui.sheets.tracks.showAudioTrackBottomSheet
 import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.action_add_bookmark
 import campfire.features.sessions.ui.generated.resources.action_chapters
+import campfire.features.sessions.ui.generated.resources.action_equalizer
 import campfire.features.sessions.ui.generated.resources.action_forward
 import campfire.features.sessions.ui.generated.resources.action_rewind
 import campfire.features.sessions.ui.generated.resources.action_skip_next
@@ -142,6 +147,10 @@ fun PlaybackBottomBar(
       audioPlayer?.runningTimer ?: emptyFlow()
     }.collectAsState(null)
 
+    val equalizer = remember(audioPlayer) {
+      audioPlayer?.equalizer ?: emptyFlow()
+    }.collectAsState(EqualizerState.Unsupported)
+
     // Until an audio player is prepared for this session (service cold start, resume
     // priming), derive the same display values from the session row the player would seed
     // from — the handoff to live player state is value-identical
@@ -161,6 +170,7 @@ fun PlaybackBottomBar(
       currentDuration = placeholder?.duration ?: currentDuration.value,
       currentMetadata = placeholder?.metadata ?: currentMetadata.value,
       runningTimer = runningTimer.value,
+      equalizer = equalizer.value,
       onPlayPauseClick = {
         if (playerState.value == AudioPlayer.State.Disabled) {
           startSession()
@@ -203,6 +213,7 @@ private fun PlaybackBottomBar(
   currentDuration: Duration,
   currentMetadata: Metadata,
   runningTimer: RunningTimer?,
+  equalizer: EqualizerState,
 
   session: Session?,
   onPlayPauseClick: () -> Unit,
@@ -325,6 +336,13 @@ private fun PlaybackBottomBar(
               TimerResult.Cleared -> onTimerCleared()
               else -> Unit
             }
+          }
+        },
+        showEqualizer = equalizer !is EqualizerState.Unsupported,
+        onEqualizerClick = {
+          if (session == null) return@ActionRow
+          scope.launch {
+            overlayHost.showEqualizerBottomSheet(session.libraryItem.id)
           }
         },
         onChapterListClick = {
@@ -608,6 +626,8 @@ private fun ActionRow(
   onBookmarkAddClick: () -> Unit,
   speedContent: @Composable () -> Unit,
   onTimerClick: () -> Unit,
+  showEqualizer: Boolean,
+  onEqualizerClick: () -> Unit,
   onChapterListClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -687,6 +707,17 @@ private fun ActionRow(
             )
             Spacer(Modifier.width(16.dp))
           }
+        }
+      }
+    }
+
+    if (showEqualizer) {
+      val equalizerLabel = stringResource(Res.string.action_equalizer)
+      IconButtonTooltip(text = equalizerLabel) {
+        IconButton(
+          onClick = onEqualizerClick,
+        ) {
+          Icon(CampfireIcons.Rounded.Equalizer, contentDescription = equalizerLabel)
         }
       }
     }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackPresenter.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackPresenter.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.toMutableStateList
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.audioplayer.PlaybackController
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.core.coroutines.flatMapIfNotNull
 import app.campfire.core.extensions.asDateTime
@@ -240,6 +241,14 @@ class PlaybackPresenter(
         }
     }.collectAsState(1f)
 
+    val equalizer by remember {
+      snapshotFlow { player }
+        .filterNotNull()
+        .flatMapLatest {
+          it.equalizer
+        }
+    }.collectAsState(EqualizerState.Unsupported)
+
     val timer by remember {
       snapshotFlow { player }
         .filterNotNull()
@@ -284,6 +293,7 @@ class PlaybackPresenter(
       metadata = placeholder?.metadata ?: metadata,
       state = state,
       speed = speed,
+      equalizer = equalizer,
       timer = timer,
       error = error,
     ) { event ->

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackUiState.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/PlaybackUiState.kt
@@ -6,6 +6,7 @@ package app.campfire.sessions.ui.playback
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import app.campfire.audioplayer.AudioPlayer
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.audioplayer.model.RunningTimer
@@ -42,6 +43,7 @@ data class PlayerUiState(
   val metadata: Metadata,
   val state: AudioPlayer.State,
   val speed: Float,
+  val equalizer: EqualizerState,
   val timer: RunningTimer?,
   val error: Throwable?,
   val eventSink: (PlayerUiEvent) -> Unit,

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/ExpandedPlaybackBar.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.ui.cast.CastButton
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.extensions.readoutFormat
@@ -112,6 +113,7 @@ import app.campfire.sessions.ui.sheets.bookmarks.showBookmarksBottomSheet
 import app.campfire.sessions.ui.sheets.chapters.ChapterResult
 import app.campfire.sessions.ui.sheets.chapters.showChapterBottomSheet
 import app.campfire.sessions.ui.sheets.description.showEpisodeDescriptionBottomSheet
+import app.campfire.sessions.ui.sheets.equalizer.showEqualizerBottomSheet
 import app.campfire.sessions.ui.sheets.history.PlaybackHistoryResult
 import app.campfire.sessions.ui.sheets.history.showPlaybackHistoryBottomSheet
 import app.campfire.sessions.ui.sheets.sleeptimer.TimerResult
@@ -604,6 +606,12 @@ private fun SharedTransitionScope.ExpandedPlaybackContent(
           },
         )
       },
+      onEqualizerClick = {
+        scope.launch {
+          overlayHost.showEqualizerBottomSheet(session!!.libraryItem.id)
+        }
+      },
+      showEqualizer = playerState.equalizer !is EqualizerState.Unsupported,
       onChapterListClick = {
         if (session!!.libraryItem.media.chapters.isNotEmpty()) {
           scope.launch {

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/SmallExpandedPlaybackBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/SmallExpandedPlaybackBar.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.ui.cast.CastButton
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.layout.isLandscapePhone
@@ -102,6 +103,7 @@ import app.campfire.sessions.ui.sheets.bookmarks.showBookmarksBottomSheet
 import app.campfire.sessions.ui.sheets.chapters.ChapterResult
 import app.campfire.sessions.ui.sheets.chapters.showChapterBottomSheet
 import app.campfire.sessions.ui.sheets.description.showEpisodeDescriptionBottomSheet
+import app.campfire.sessions.ui.sheets.equalizer.showEqualizerBottomSheet
 import app.campfire.sessions.ui.sheets.history.PlaybackHistoryResult
 import app.campfire.sessions.ui.sheets.history.showPlaybackHistoryBottomSheet
 import app.campfire.sessions.ui.sheets.sleeptimer.TimerResult
@@ -646,6 +648,12 @@ private fun PlaybackOptionsColumn(
         },
       )
     },
+    onEqualizerClick = {
+      scope.launch {
+        overlayHost.showEqualizerBottomSheet(session!!.libraryItem.id)
+      }
+    },
+    showEqualizer = playerState.equalizer !is EqualizerState.Unsupported,
     onChapterListClick = {
       if (session!!.libraryItem.media.chapters.isNotEmpty()) {
         scope.launch {

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ActionRow.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ActionRow.kt
@@ -24,11 +24,13 @@ import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Bookmarks
 import app.campfire.common.compose.icons.rounded.Description
+import app.campfire.common.compose.icons.rounded.Equalizer
 import app.campfire.common.compose.widgets.IconButtonTooltip
 import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.action_bookmarks
 import campfire.features.sessions.ui.generated.resources.action_chapters
 import campfire.features.sessions.ui.generated.resources.action_description
+import campfire.features.sessions.ui.generated.resources.action_equalizer
 import campfire.features.sessions.ui.generated.resources.action_history
 import org.jetbrains.compose.resources.stringResource
 
@@ -37,6 +39,8 @@ internal fun ActionRow(
   onBookmarksClick: () -> Unit,
   speedContent: @Composable () -> Unit,
   timerContent: @Composable () -> Unit,
+  onEqualizerClick: () -> Unit,
+  showEqualizer: Boolean,
   onChapterListClick: () -> Unit,
   showChapters: Boolean,
   onDescriptionClick: () -> Unit,
@@ -57,6 +61,8 @@ internal fun ActionRow(
       onBookmarksClick = onBookmarksClick,
       speedContent = speedContent,
       timerContent = timerContent,
+      onEqualizerClick = onEqualizerClick,
+      showEqualizer = showEqualizer,
       onChapterListClick = onChapterListClick,
       showChapters = showChapters,
       onDescriptionClick = onDescriptionClick,
@@ -73,6 +79,8 @@ internal fun ActionColumn(
   onBookmarksClick: () -> Unit,
   speedContent: @Composable () -> Unit,
   timerContent: @Composable () -> Unit,
+  onEqualizerClick: () -> Unit,
+  showEqualizer: Boolean,
   onChapterListClick: () -> Unit,
   showChapters: Boolean,
   onDescriptionClick: () -> Unit,
@@ -92,6 +100,8 @@ internal fun ActionColumn(
       onBookmarksClick = onBookmarksClick,
       speedContent = speedContent,
       timerContent = timerContent,
+      onEqualizerClick = onEqualizerClick,
+      showEqualizer = showEqualizer,
       onChapterListClick = onChapterListClick,
       showChapters = showChapters,
       onDescriptionClick = onDescriptionClick,
@@ -108,6 +118,8 @@ private fun ActionContent(
   onBookmarksClick: () -> Unit,
   speedContent: @Composable () -> Unit,
   timerContent: @Composable () -> Unit,
+  onEqualizerClick: () -> Unit,
+  showEqualizer: Boolean,
   onChapterListClick: () -> Unit,
   showChapters: Boolean,
   onDescriptionClick: () -> Unit,
@@ -142,6 +154,22 @@ private fun ActionContent(
     contentAlignment = Alignment.Center,
   ) {
     timerContent()
+  }
+
+  if (showEqualizer) {
+    Box(
+      modifier = actionModifier,
+      contentAlignment = Alignment.Center,
+    ) {
+      val equalizerLabel = stringResource(Res.string.action_equalizer)
+      IconButtonTooltip(text = equalizerLabel) {
+        IconButton(
+          onClick = onEqualizerClick,
+        ) {
+          Icon(CampfireIcons.Rounded.Equalizer, contentDescription = equalizerLabel)
+        }
+      }
+    }
   }
 
   if (showChapters) {

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/equalizer/EqualizerBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/equalizer/EqualizerBottomSheet.kt
@@ -1,0 +1,522 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.sessions.ui.sheets.equalizer
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import app.campfire.analytics.Analytics
+import app.campfire.analytics.events.Changed
+import app.campfire.analytics.events.Equalizer
+import app.campfire.analytics.events.PlaybackActionEvent
+import app.campfire.analytics.events.ScreenType
+import app.campfire.analytics.events.ScreenViewEvent
+import app.campfire.audioplayer.AudioPlayerHolder
+import app.campfire.audioplayer.model.EqualizerState
+import app.campfire.audioplayer.model.profileOrNull
+import app.campfire.common.compose.analytics.Impression
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.rounded.Book
+import app.campfire.common.compose.icons.rounded.Globe
+import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.compose.widgets.VerticalSlider
+import app.campfire.common.compose.widgets.bottomSheetShape
+import app.campfire.core.audio.EqualizerBands
+import app.campfire.core.audio.EqualizerPresets
+import app.campfire.core.audio.EqualizerProfile
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.ComponentHolder
+import app.campfire.core.model.LibraryItemId
+import app.campfire.sessions.ui.sheets.SessionSheetLayout
+import app.campfire.settings.api.EqualizerSettings
+import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.equalizer_band_gain_cd
+import campfire.features.sessions.ui.generated.resources.equalizer_bass_label
+import campfire.features.sessions.ui.generated.resources.equalizer_bottomsheet_title
+import campfire.features.sessions.ui.generated.resources.equalizer_enabled_toggle
+import campfire.features.sessions.ui.generated.resources.equalizer_loudness_label
+import campfire.features.sessions.ui.generated.resources.equalizer_per_book_toggle
+import campfire.features.sessions.ui.generated.resources.equalizer_preset_bass_boost
+import campfire.features.sessions.ui.generated.resources.equalizer_preset_custom
+import campfire.features.sessions.ui.generated.resources.equalizer_preset_flat
+import campfire.features.sessions.ui.generated.resources.equalizer_preset_podcast
+import campfire.features.sessions.ui.generated.resources.equalizer_preset_reduce_noise
+import campfire.features.sessions.ui.generated.resources.equalizer_preset_treble_boost
+import campfire.features.sessions.ui.generated.resources.equalizer_preset_voice_boost
+import campfire.features.sessions.ui.generated.resources.equalizer_preset_warm
+import campfire.features.sessions.ui.generated.resources.equalizer_unavailable_casting
+import com.r0adkll.kimchi.annotations.ContributesTo
+import com.slack.circuit.overlay.OverlayHost
+import com.slack.circuitx.overlays.BottomSheetOverlay
+import kotlin.math.roundToInt
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import org.jetbrains.compose.resources.stringResource
+
+data class EqualizerInput(
+  val itemId: LibraryItemId,
+)
+
+suspend fun OverlayHost.showEqualizerBottomSheet(
+  itemId: LibraryItemId,
+) {
+  show(
+    BottomSheetOverlay(
+      model = EqualizerInput(itemId),
+      onDismiss = { },
+      sheetShape = bottomSheetShape,
+      skipPartiallyExpandedState = true,
+    ) { input, _ ->
+      Impression {
+        ScreenViewEvent("Equalizer", ScreenType.Overlay)
+      }
+
+      EqualizerBottomSheet(
+        input = input,
+        modifier = Modifier.navigationBarsPadding(),
+      )
+    },
+  )
+}
+
+@ContributesTo(AppScope::class)
+interface EqualizerBottomSheetComponent {
+  val equalizerSettings: EqualizerSettings
+  val audioPlayerHolder: AudioPlayerHolder
+}
+
+@Composable
+private fun rememberEqualizerComponent(): EqualizerBottomSheetComponent {
+  return remember {
+    ComponentHolder.component<EqualizerBottomSheetComponent>()
+  }
+}
+
+/**
+ * State/DI layer for the equalizer sheet: resolves the component, collects the player and
+ * settings flows, and handles events so [EqualizerSheet] stays pure and previewable.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@Composable
+private fun EqualizerBottomSheet(
+  input: EqualizerInput,
+  modifier: Modifier = Modifier,
+  component: EqualizerBottomSheetComponent = rememberEqualizerComponent(),
+) {
+  val equalizerState by remember {
+    component.audioPlayerHolder.currentPlayer
+      .flatMapLatest {
+        it?.equalizer ?: emptyFlow()
+      }
+  }.collectAsState(EqualizerState.Available(component.equalizerSettings.equalizerProfileFor(input.itemId)))
+
+  val itemEqualizerProfiles by remember {
+    component.equalizerSettings.observeItemEqualizerProfiles()
+  }.collectAsState()
+
+  val profile = equalizerState.profileOrNull ?: EqualizerProfile()
+
+  val pushProfile: (EqualizerProfile) -> Unit = { updated ->
+    component.audioPlayerHolder.currentPlayer.value
+      ?.setEqualizer(updated)
+      ?: component.equalizerSettings.setEqualizerProfileFor(input.itemId, updated)
+  }
+
+  EqualizerSheet(
+    profile = profile,
+    available = equalizerState is EqualizerState.Available,
+    perBookEnabled = input.itemId in itemEqualizerProfiles,
+    onEnabledChange = { enabled ->
+      Analytics.send(PlaybackActionEvent(Equalizer, Changed, extras = mapOf("enabled" to enabled)))
+      pushProfile(profile.copy(enabled = enabled))
+    },
+    onPresetSelected = { presetId ->
+      Analytics.send(PlaybackActionEvent(Equalizer, Changed, extras = mapOf("preset" to presetId)))
+      val gains = if (presetId == EqualizerPresets.CUSTOM_ID) {
+        component.equalizerSettings.customBandGains
+      } else {
+        EqualizerPresets.forId(presetId)?.bandGainsDb ?: profile.bandGainsDb
+      }
+      pushProfile(profile.copy(presetId = presetId, bandGainsDb = gains))
+    },
+    onBandGainChange = { index, gainDb ->
+      val gains = profile.bandGainsDb.toMutableList().also { it[index] = gainDb }
+      // Touching any fader turns the profile into the persisted "Custom" curve
+      component.equalizerSettings.customBandGains = gains
+      pushProfile(profile.copy(presetId = EqualizerPresets.CUSTOM_ID, bandGainsDb = gains))
+    },
+    onLoudnessChange = { loudnessGainDb ->
+      pushProfile(profile.copy(loudnessGainDb = loudnessGainDb))
+    },
+    onBassBoostChange = { bassBoost ->
+      pushProfile(profile.copy(bassBoost = bassBoost))
+    },
+    onPerBookChange = { enabled ->
+      Analytics.send(PlaybackActionEvent(Equalizer, Changed, extras = mapOf("perBook" to enabled)))
+      if (enabled) {
+        component.equalizerSettings.itemEqualizerProfiles += (input.itemId to profile)
+      } else {
+        component.equalizerSettings.itemEqualizerProfiles -= input.itemId
+        // Snap active playback back to the global profile the item now falls back to
+        component.audioPlayerHolder.currentPlayer.value
+          ?.setEqualizer(component.equalizerSettings.equalizerProfile)
+      }
+    },
+    modifier = modifier,
+  )
+}
+
+@Composable
+internal fun EqualizerSheet(
+  profile: EqualizerProfile,
+  available: Boolean,
+  perBookEnabled: Boolean,
+  onEnabledChange: (Boolean) -> Unit,
+  onPresetSelected: (String) -> Unit,
+  onBandGainChange: (Int, Float) -> Unit,
+  onLoudnessChange: (Float) -> Unit,
+  onBassBoostChange: (Float) -> Unit,
+  onPerBookChange: (Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val controlsEnabled = available && profile.enabled
+
+  SessionSheetLayout(
+    modifier = modifier,
+    title = { Text(stringResource(Res.string.equalizer_bottomsheet_title)) },
+    trailingContent = {
+      Switch(
+        checked = perBookEnabled,
+        onCheckedChange = onPerBookChange,
+        enabled = available,
+        thumbContent = {
+          Icon(
+            imageVector = if (perBookEnabled) {
+              CampfireIcons.Rounded.Book
+            } else {
+              CampfireIcons.Rounded.Globe
+            },
+            modifier = Modifier.size(16.dp),
+            contentDescription = stringResource(Res.string.equalizer_per_book_toggle),
+          )
+        },
+        modifier = Modifier.align(Alignment.CenterEnd),
+      )
+    },
+  ) {
+    if (!available) {
+      Text(
+        text = stringResource(Res.string.equalizer_unavailable_casting),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 16.dp),
+      )
+      Spacer(Modifier.height(8.dp))
+    }
+
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp),
+    ) {
+      Text(
+        text = stringResource(Res.string.equalizer_enabled_toggle),
+        style = MaterialTheme.typography.bodyLarge,
+        modifier = Modifier.weight(1f),
+      )
+      Switch(
+        checked = profile.enabled,
+        onCheckedChange = onEnabledChange,
+        enabled = available,
+      )
+    }
+
+    Spacer(Modifier.height(8.dp))
+
+    PresetChipRow(
+      selectedPresetId = profile.presetId,
+      enabled = controlsEnabled,
+      onPresetSelected = onPresetSelected,
+    )
+
+    Spacer(Modifier.height(16.dp))
+
+    BandFaderRow(
+      bandGainsDb = profile.bandGainsDb,
+      enabled = controlsEnabled,
+      onBandGainChange = onBandGainChange,
+    )
+
+    Spacer(Modifier.height(16.dp))
+
+    LabeledSlider(
+      label = stringResource(Res.string.equalizer_loudness_label),
+      value = profile.loudnessGainDb,
+      valueRange = EqualizerBands.LoudnessGainRangeDb,
+      valueText = "+${profile.loudnessGainDb.roundToInt()} dB",
+      enabled = controlsEnabled,
+      onValueChange = { onLoudnessChange(it.roundToInt().toFloat()) },
+    )
+
+    LabeledSlider(
+      label = stringResource(Res.string.equalizer_bass_label),
+      value = profile.bassBoost,
+      valueRange = EqualizerBands.BassBoostRange,
+      valueText = "${(profile.bassBoost * 100).roundToInt()}%",
+      enabled = controlsEnabled,
+      onValueChange = { onBassBoostChange((it * 20).roundToInt() / 20f) },
+    )
+
+    Spacer(Modifier.height(24.dp))
+  }
+}
+
+@Composable
+private fun PresetChipRow(
+  selectedPresetId: String,
+  enabled: Boolean,
+  onPresetSelected: (String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val presetIds = remember { EqualizerPresets.all.map { it.id } + EqualizerPresets.CUSTOM_ID }
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    modifier = modifier
+      .fillMaxWidth()
+      .horizontalScroll(rememberScrollState())
+      .padding(horizontal = 16.dp),
+  ) {
+    presetIds.forEach { presetId ->
+      FilterChip(
+        selected = presetId == selectedPresetId,
+        enabled = enabled,
+        onClick = { onPresetSelected(presetId) },
+        label = { Text(presetLabel(presetId)) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun BandFaderRow(
+  bandGainsDb: List<Float>,
+  enabled: Boolean,
+  onBandGainChange: (Int, Float) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    horizontalArrangement = Arrangement.SpaceEvenly,
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 8.dp),
+  ) {
+    EqualizerBands.centerFrequenciesHz.forEachIndexed { index, frequencyHz ->
+      BandFader(
+        frequencyHz = frequencyHz,
+        gainDb = bandGainsDb.getOrElse(index) { 0f },
+        enabled = enabled,
+        onGainChange = { onBandGainChange(index, it) },
+        modifier = Modifier.weight(1f),
+      )
+    }
+  }
+}
+
+@Composable
+private fun BandFader(
+  frequencyHz: Int,
+  gainDb: Float,
+  enabled: Boolean,
+  onGainChange: (Float) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    horizontalAlignment = Alignment.CenterHorizontally,
+    modifier = modifier,
+  ) {
+    // Local state keeps the drag smooth; rounding to whole dB means nearby drag frames
+    // resolve to the same value, and only real changes are pushed
+    var draggedGain by remember(gainDb) { mutableStateOf(gainDb) }
+
+    Text(
+      text = draggedGain.asGainLabel(),
+      style = MaterialTheme.typography.labelSmall,
+      fontWeight = FontWeight.SemiBold,
+      textAlign = TextAlign.Center,
+    )
+    VerticalSlider(
+      value = draggedGain,
+      valueRange = EqualizerBands.BandGainRangeDb,
+      enabled = enabled,
+      onValueChange = { raw ->
+        val gain = raw.roundToInt().toFloat()
+        if (gain != draggedGain) {
+          draggedGain = gain
+          onGainChange(gain)
+        }
+      },
+      modifier = Modifier
+        .height(BandFaderHeight)
+        .width(32.dp)
+        .bandSemantics(frequencyHz),
+    )
+    Text(
+      text = frequencyHz.asFrequencyLabel(),
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+    )
+  }
+}
+
+@Composable
+private fun LabeledSlider(
+  label: String,
+  value: Float,
+  valueRange: ClosedFloatingPointRange<Float>,
+  valueText: String,
+  enabled: Boolean,
+  onValueChange: (Float) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 20.dp),
+  ) {
+    Text(
+      text = label,
+      style = MaterialTheme.typography.bodyMedium,
+      modifier = Modifier.width(72.dp),
+    )
+    Slider(
+      value = value,
+      valueRange = valueRange,
+      enabled = enabled,
+      onValueChange = onValueChange,
+      modifier = Modifier.weight(1f),
+    )
+    Text(
+      text = valueText,
+      style = MaterialTheme.typography.labelLarge,
+      fontWeight = FontWeight.SemiBold,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.width(56.dp),
+    )
+  }
+}
+
+@Composable
+private fun presetLabel(presetId: String): String = when (presetId) {
+  EqualizerPresets.FLAT_ID -> stringResource(Res.string.equalizer_preset_flat)
+  EqualizerPresets.VOICE_BOOST_ID -> stringResource(Res.string.equalizer_preset_voice_boost)
+  EqualizerPresets.PODCAST_ID -> stringResource(Res.string.equalizer_preset_podcast)
+  EqualizerPresets.BASS_BOOST_ID -> stringResource(Res.string.equalizer_preset_bass_boost)
+  EqualizerPresets.TREBLE_BOOST_ID -> stringResource(Res.string.equalizer_preset_treble_boost)
+  EqualizerPresets.WARM_ID -> stringResource(Res.string.equalizer_preset_warm)
+  EqualizerPresets.REDUCE_NOISE_ID -> stringResource(Res.string.equalizer_preset_reduce_noise)
+  else -> stringResource(Res.string.equalizer_preset_custom)
+}
+
+@Composable
+private fun Modifier.bandSemantics(frequencyHz: Int): Modifier {
+  // The rotated slider keeps Material slider semantics; label it with its band so
+  // screen readers can distinguish the ten faders
+  val label = stringResource(Res.string.equalizer_band_gain_cd, frequencyHz.asFrequencyLabel())
+  return semantics { contentDescription = label }
+}
+
+private fun Float.asGainLabel(): String {
+  val rounded = roundToInt()
+  return if (rounded > 0) "+$rounded" else "$rounded"
+}
+
+private fun Int.asFrequencyLabel(): String {
+  return if (this >= 1000) "${this / 1000}k" else toString()
+}
+
+private val BandFaderHeight = 160.dp
+
+@Preview
+@Composable
+private fun EqualizerSheetPreview() {
+  CampfireTheme {
+    var profile by remember {
+      mutableStateOf(
+        EqualizerProfile(
+          enabled = true,
+          presetId = EqualizerPresets.VOICE_BOOST_ID,
+          bandGainsDb = EqualizerPresets.VoiceBoost.bandGainsDb,
+          loudnessGainDb = 6f,
+          bassBoost = 0.25f,
+        ),
+      )
+    }
+    var perBook by remember { mutableStateOf(false) }
+
+    ModalBottomSheetLayout(
+      sheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Expanded),
+      sheetContent = {
+        EqualizerSheet(
+          profile = profile,
+          available = true,
+          perBookEnabled = perBook,
+          onEnabledChange = { profile = profile.copy(enabled = it) },
+          onPresetSelected = { presetId ->
+            val gains = EqualizerPresets.forId(presetId)?.bandGainsDb ?: profile.bandGainsDb
+            profile = profile.copy(presetId = presetId, bandGainsDb = gains)
+          },
+          onBandGainChange = { index, gain ->
+            profile = profile.copy(
+              presetId = EqualizerPresets.CUSTOM_ID,
+              bandGainsDb = profile.bandGainsDb.toMutableList().also { it[index] = gain },
+            )
+          },
+          onLoudnessChange = { profile = profile.copy(loudnessGainDb = it) },
+          onBassBoostChange = { profile = profile.copy(bassBoost = it) },
+          onPerBookChange = { perBook = it },
+        )
+      },
+    ) {
+    }
+  }
+}

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/EqualizerSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/EqualizerSettings.kt
@@ -1,0 +1,51 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.settings.api
+
+import app.campfire.core.audio.EqualizerProfile
+import app.campfire.core.model.LibraryItemId
+import kotlinx.coroutines.flow.StateFlow
+
+interface EqualizerSettings {
+
+  /**
+   * The global equalizer profile applied to items without a per-item override.
+   */
+  var equalizerProfile: EqualizerProfile
+  fun observeEqualizerProfile(): StateFlow<EqualizerProfile>
+
+  /**
+   * The band gains last used for the "Custom" preset, persisted so that switching to a
+   * built-in preset and back restores the user's custom curve.
+   */
+  var customBandGains: List<Float>
+
+  /**
+   * Per-item equalizer overrides, keyed by library item id. The presence of an entry means the
+   * item has a per-item equalizer enabled, and its value is that item's saved profile. Items
+   * without an entry use the global [equalizerProfile].
+   */
+  var itemEqualizerProfiles: Map<LibraryItemId, EqualizerProfile>
+  fun observeItemEqualizerProfiles(): StateFlow<Map<LibraryItemId, EqualizerProfile>>
+
+  /**
+   * The effective equalizer profile for [itemId] — its per-item override if one is enabled,
+   * otherwise the global [equalizerProfile].
+   */
+  fun equalizerProfileFor(itemId: LibraryItemId?): EqualizerProfile {
+    return itemId?.let { itemEqualizerProfiles[it] } ?: equalizerProfile
+  }
+
+  /**
+   * Persist [profile] to [itemId]'s per-item override when one is enabled, otherwise to the
+   * global [equalizerProfile].
+   */
+  fun setEqualizerProfileFor(itemId: LibraryItemId?, profile: EqualizerProfile) {
+    if (itemId != null && itemId in itemEqualizerProfiles) {
+      itemEqualizerProfiles = itemEqualizerProfiles + (itemId to profile)
+    } else {
+      equalizerProfile = profile
+    }
+  }
+}

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/EqualizerSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/EqualizerSettingsImpl.kt
@@ -1,0 +1,101 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.settings
+
+import app.campfire.core.audio.EqualizerBands
+import app.campfire.core.audio.EqualizerProfile
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.qualifier.ForScope
+import app.campfire.core.model.LibraryItemId
+import app.campfire.settings.api.EqualizerSettings
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.ObservableSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import me.tatarka.inject.annotations.Inject
+
+@OptIn(ExperimentalSettingsApi::class)
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = EqualizerSettings::class)
+@Inject
+class EqualizerSettingsImpl(
+  override val settings: ObservableSettings,
+  @ForScope(AppScope::class) override val scope: CoroutineScope,
+) : EqualizerSettings, AppSettings() {
+
+  private val equalizerProfileProperty = customSetting(
+    key = PREF_EQUALIZER_PROFILE,
+    defaultValue = EqualizerProfile(),
+    getter = { it.asEqualizerProfile() ?: EqualizerProfile() },
+    setter = { profile -> profile.serialize() },
+  )
+  override var equalizerProfile: EqualizerProfile by equalizerProfileProperty
+  override fun observeEqualizerProfile(): StateFlow<EqualizerProfile> = equalizerProfileProperty.observe()
+
+  override var customBandGains: List<Float> by customSetting(
+    key = PREF_EQUALIZER_CUSTOM_GAINS,
+    defaultValue = List(EqualizerBands.BAND_COUNT) { 0f },
+    getter = { it.asBandGains() ?: List(EqualizerBands.BAND_COUNT) { 0f } },
+    setter = { gains -> gains.joinToString(EQUALIZER_GAINS_SEPARATOR) },
+  )
+
+  private val itemEqualizerProfilesProperty = customSetting(
+    key = PREF_ITEM_EQUALIZER_PROFILES,
+    defaultValue = emptyMap<LibraryItemId, EqualizerProfile>(),
+    getter = { it.asItemProfileMap() },
+    setter = { profiles ->
+      profiles.entries.joinToString(EQUALIZER_ENTRY_SEPARATOR) {
+        "${it.key}$EQUALIZER_FIELD_SEPARATOR${it.value.serialize()}"
+      }
+    },
+  )
+  override var itemEqualizerProfiles: Map<LibraryItemId, EqualizerProfile> by itemEqualizerProfilesProperty
+  override fun observeItemEqualizerProfiles(): StateFlow<Map<LibraryItemId, EqualizerProfile>> =
+    itemEqualizerProfilesProperty.observe()
+
+  private fun EqualizerProfile.serialize(): String = listOf(
+    if (enabled) "1" else "0",
+    presetId,
+    bandGainsDb.joinToString(EQUALIZER_GAINS_SEPARATOR),
+    loudnessGainDb.toString(),
+    bassBoost.toString(),
+  ).joinToString(EQUALIZER_FIELD_SEPARATOR)
+
+  private fun String.asEqualizerProfile(): EqualizerProfile? {
+    val fields = split(EQUALIZER_FIELD_SEPARATOR)
+    if (fields.size != 5) return null
+    val (enabled, presetId, gains, loudness, bass) = fields
+    return EqualizerProfile(
+      enabled = enabled == "1",
+      presetId = presetId.ifEmpty { return null },
+      bandGainsDb = gains.asBandGains() ?: return null,
+      loudnessGainDb = loudness.toFloatOrNull() ?: return null,
+      bassBoost = bass.toFloatOrNull() ?: return null,
+    )
+  }
+
+  private fun String.asBandGains(): List<Float>? {
+    val gains = split(EQUALIZER_GAINS_SEPARATOR).mapNotNull { it.toFloatOrNull() }
+    return gains.takeIf { it.size == EqualizerBands.BAND_COUNT }
+  }
+
+  private fun String.asItemProfileMap(): Map<LibraryItemId, EqualizerProfile> {
+    return split(EQUALIZER_ENTRY_SEPARATOR)
+      .mapNotNull { entry ->
+        val itemId = entry.substringBefore(EQUALIZER_FIELD_SEPARATOR)
+        val profile = entry.substringAfter(EQUALIZER_FIELD_SEPARATOR, "").asEqualizerProfile()
+        if (itemId.isEmpty() || profile == null) null else itemId to profile
+      }
+      .toMap()
+  }
+}
+
+internal const val PREF_EQUALIZER_PROFILE = "pref_equalizer_profile"
+internal const val PREF_EQUALIZER_CUSTOM_GAINS = "pref_equalizer_custom_gains"
+internal const val PREF_ITEM_EQUALIZER_PROFILES = "pref_item_equalizer_profiles"
+internal const val EQUALIZER_ENTRY_SEPARATOR = "::"
+internal const val EQUALIZER_FIELD_SEPARATOR = "|"
+internal const val EQUALIZER_GAINS_SEPARATOR = ","

--- a/features/settings/impl/src/commonTest/kotlin/app/campfire/settings/EqualizerSettingsTest.kt
+++ b/features/settings/impl/src/commonTest/kotlin/app/campfire/settings/EqualizerSettingsTest.kt
@@ -1,0 +1,103 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.settings
+
+import app.campfire.core.audio.EqualizerPresets
+import app.campfire.core.audio.EqualizerProfile
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import com.russhwolf.settings.MapSettings
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+
+class EqualizerSettingsTest {
+
+  private val settingsScope = CoroutineScope(Dispatchers.Unconfined + Job())
+
+  @Test
+  fun `equalizerProfile defaults and round-trips through storage`() {
+    val settings = equalizerSettings()
+    assertThat(settings.equalizerProfile).isEqualTo(EqualizerProfile())
+
+    val profile = EqualizerProfile(
+      enabled = true,
+      presetId = EqualizerPresets.CUSTOM_ID,
+      bandGainsDb = listOf(-4f, -3f, -1f, 0f, 2f, 4f, 4f, 2f, 0f, -1f),
+      loudnessGainDb = 6.5f,
+      bassBoost = 0.25f,
+    )
+    settings.equalizerProfile = profile
+    assertThat(settings.equalizerProfile).isEqualTo(profile)
+  }
+
+  @Test
+  fun `corrupt profile strings fall back to the default`() {
+    val backing = MapSettings()
+    val settings = EqualizerSettingsImpl(backing, settingsScope)
+
+    listOf(
+      "",
+      "garbage",
+      "1|voice_boost|1,2,3|6.0|0.25", // wrong band count
+      "1|voice_boost|a,b,c,d,e,f,g,h,i,j|6.0|0.25", // non-numeric gains
+      "1|voice_boost|0,0,0,0,0,0,0,0,0,0|nope|0.25", // non-numeric loudness
+      "1||0,0,0,0,0,0,0,0,0,0|0.0|0.0", // empty preset id
+      "1|flat|0,0,0,0,0,0,0,0,0,0|0.0", // missing field
+    ).forEach { corrupt ->
+      backing.putString(PREF_EQUALIZER_PROFILE, corrupt)
+      assertThat(settings.equalizerProfile).isEqualTo(EqualizerProfile())
+    }
+  }
+
+  @Test
+  fun `itemEqualizerProfiles round-trips and drops corrupt entries`() {
+    val settings = equalizerSettings()
+    assertThat(settings.itemEqualizerProfiles).isEmpty()
+
+    val profiles = mapOf(
+      "li_abc123" to EqualizerProfile(enabled = true, presetId = EqualizerPresets.BASS_BOOST_ID),
+      "li_def456" to EqualizerProfile(bandGainsDb = listOf(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f)),
+    )
+    settings.itemEqualizerProfiles = profiles
+    assertThat(settings.itemEqualizerProfiles).isEqualTo(profiles)
+
+    settings.itemEqualizerProfiles = emptyMap()
+    assertThat(settings.itemEqualizerProfiles).isEmpty()
+  }
+
+  @Test
+  fun `equalizerProfileFor falls back to the global profile without an override`() {
+    val settings = equalizerSettings()
+    val global = EqualizerProfile(enabled = true, presetId = EqualizerPresets.WARM_ID)
+    val override = EqualizerProfile(enabled = true, presetId = EqualizerPresets.VOICE_BOOST_ID)
+    settings.equalizerProfile = global
+    settings.itemEqualizerProfiles = mapOf("li_abc123" to override)
+
+    assertThat(settings.equalizerProfileFor("li_abc123")).isEqualTo(override)
+    assertThat(settings.equalizerProfileFor("li_other")).isEqualTo(global)
+    assertThat(settings.equalizerProfileFor(null)).isEqualTo(global)
+  }
+
+  @Test
+  fun `setEqualizerProfileFor writes the override when enabled and the global otherwise`() {
+    val settings = equalizerSettings()
+    val initial = EqualizerProfile(enabled = true)
+    settings.itemEqualizerProfiles = mapOf("li_abc123" to initial)
+
+    val updated = initial.copy(loudnessGainDb = 3f)
+    settings.setEqualizerProfileFor("li_abc123", updated)
+    assertThat(settings.itemEqualizerProfiles).isEqualTo(mapOf("li_abc123" to updated))
+    assertThat(settings.equalizerProfile).isEqualTo(EqualizerProfile())
+
+    settings.setEqualizerProfileFor("li_other", updated)
+    assertThat(settings.equalizerProfile).isEqualTo(updated)
+    assertThat(settings.itemEqualizerProfiles).isEqualTo(mapOf("li_abc123" to updated))
+  }
+
+  private fun equalizerSettings(): EqualizerSettingsImpl =
+    EqualizerSettingsImpl(MapSettings(), settingsScope)
+}

--- a/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/FakeEqualizerSettings.kt
+++ b/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/FakeEqualizerSettings.kt
@@ -1,0 +1,33 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.settings.test
+
+import app.campfire.core.audio.EqualizerBands
+import app.campfire.core.audio.EqualizerProfile
+import app.campfire.core.model.LibraryItemId
+import app.campfire.settings.api.EqualizerSettings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * A simple in-memory [EqualizerSettings] fake backed by [MutableStateFlow]s for use in tests.
+ */
+class FakeEqualizerSettings : EqualizerSettings {
+
+  private val _equalizerProfile = MutableStateFlow(EqualizerProfile())
+  override var equalizerProfile: EqualizerProfile
+    get() = _equalizerProfile.value
+    set(value) { _equalizerProfile.value = value }
+  override fun observeEqualizerProfile(): StateFlow<EqualizerProfile> = _equalizerProfile.asStateFlow()
+
+  override var customBandGains: List<Float> = List(EqualizerBands.BAND_COUNT) { 0f }
+
+  private val _itemEqualizerProfiles = MutableStateFlow(emptyMap<LibraryItemId, EqualizerProfile>())
+  override var itemEqualizerProfiles: Map<LibraryItemId, EqualizerProfile>
+    get() = _itemEqualizerProfiles.value
+    set(value) { _itemEqualizerProfiles.value = value }
+  override fun observeItemEqualizerProfiles(): StateFlow<Map<LibraryItemId, EqualizerProfile>> =
+    _itemEqualizerProfiles.asStateFlow()
+}

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/AudioPlayer.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/AudioPlayer.kt
@@ -3,9 +3,11 @@
 
 package app.campfire.audioplayer
 
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.audioplayer.model.RunningTimer
+import app.campfire.core.audio.EqualizerProfile
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.Session
 import kotlin.time.Duration
@@ -61,6 +63,11 @@ interface AudioPlayer {
   val playbackSpeed: StateFlow<Float>
 
   /**
+   * A flow of the equalizer capability and configuration of this player.
+   */
+  val equalizer: StateFlow<EqualizerState>
+
+  /**
    * A flow of the current playback timer
    */
   val runningTimer: StateFlow<RunningTimer?>
@@ -93,6 +100,7 @@ interface AudioPlayer {
   fun seekBackward()
 
   fun setPlaybackSpeed(speed: Float)
+  fun setEqualizer(profile: EqualizerProfile)
   fun setTimer(timer: PlaybackTimer)
   fun clearTimer()
 

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/model/EqualizerState.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/model/EqualizerState.kt
@@ -1,0 +1,41 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.model
+
+import app.campfire.core.audio.EqualizerProfile
+
+/**
+ * The equalizer capability and configuration of an
+ * [app.campfire.audioplayer.AudioPlayer].
+ */
+sealed interface EqualizerState {
+
+  /**
+   * The platform cannot apply an equalizer at all (e.g. iOS). The UI should hide
+   * its equalizer entry point entirely.
+   */
+  data object Unsupported : EqualizerState
+
+  /**
+   * The platform supports an equalizer, but effects cannot be applied right now
+   * (e.g. audio is rendered remotely on a Cast device). The UI should render
+   * disabled.
+   */
+  data class Unavailable(val profile: EqualizerProfile) : EqualizerState
+
+  /**
+   * The equalizer is active and adjustable.
+   */
+  data class Available(val profile: EqualizerProfile) : EqualizerState
+}
+
+/**
+ * The current profile carried by this state, or null when the platform has none.
+ */
+val EqualizerState.profileOrNull: EqualizerProfile?
+  get() = when (this) {
+    EqualizerState.Unsupported -> null
+    is EqualizerState.Unavailable -> profile
+    is EqualizerState.Available -> profile
+  }

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/ExoPlayerAudioPlayer.kt
@@ -28,6 +28,7 @@ import app.campfire.audioplayer.OnFinishedListener
 import app.campfire.audioplayer.cast.CastController
 import app.campfire.audioplayer.history.PlaybackHistoryRecorder
 import app.campfire.audioplayer.impl.chapters.ChapterTimeline
+import app.campfire.audioplayer.impl.equalizer.AudioEffectsController
 import app.campfire.audioplayer.impl.forwarding.ChapterWindowForwardingPlayer
 import app.campfire.audioplayer.impl.forwarding.PlaybackHistoryForwardingPlayer
 import app.campfire.audioplayer.impl.forwarding.RemoteControlForwardingPlayer
@@ -37,9 +38,12 @@ import app.campfire.audioplayer.impl.sleep.VolumeFadeController
 import app.campfire.audioplayer.impl.util.AUDIO_TAG
 import app.campfire.audioplayer.impl.util.eventAsDebugLog
 import app.campfire.audioplayer.impl.util.playbackStateAsDebugLog
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.audioplayer.model.RunningTimer
+import app.campfire.audioplayer.model.profileOrNull
+import app.campfire.core.audio.EqualizerProfile
 import app.campfire.core.extensions.seconds
 import app.campfire.core.logging.Cork
 import app.campfire.core.logging.Corked
@@ -50,6 +54,7 @@ import app.campfire.core.toast.GlobalToaster
 import app.campfire.core.toast.Toast
 import app.campfire.crashreporting.CrashReporter
 import app.campfire.infra.audioplayer.impl.R
+import app.campfire.settings.api.EqualizerSettings
 import app.campfire.settings.api.PlaybackSettings
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -78,6 +83,7 @@ private const val CAST_FALLBACK_SWAP_TIMEOUT_MS = 5_000L
 class ExoPlayerAudioPlayer(
   private val context: Context,
   private val settings: PlaybackSettings,
+  private val equalizerSettings: EqualizerSettings,
   private val sleepTimerManagerFactory: SleepTimerManager.Factory,
   private val playbackHistoryRecorder: PlaybackHistoryRecorder,
   private val castController: CastController,
@@ -95,6 +101,7 @@ class ExoPlayerAudioPlayer(
   @Inject
   class Factory(
     private val settings: PlaybackSettings,
+    private val equalizerSettings: EqualizerSettings,
     private val mediaSourceFactory: MediaSource.Factory,
     private val sleepTimerManagerFactory: SleepTimerManager.Factory,
     private val playbackHistoryRecorder: PlaybackHistoryRecorder,
@@ -107,6 +114,7 @@ class ExoPlayerAudioPlayer(
       return ExoPlayerAudioPlayer(
         context = context,
         settings = settings,
+        equalizerSettings = equalizerSettings,
         mediaSourceFactory = mediaSourceFactory,
         playbackHistoryRecorder = playbackHistoryRecorder,
         sleepTimerManagerFactory = sleepTimerManagerFactory,
@@ -263,6 +271,33 @@ class ExoPlayerAudioPlayer(
   override val currentMetadata = MutableStateFlow(Metadata())
   override val playbackSpeed = MutableStateFlow(settings.playbackSpeed)
 
+  private val audioEffects = AudioEffectsController()
+  override val equalizer = MutableStateFlow<EqualizerState>(
+    EqualizerState.Available(equalizerSettings.equalizerProfile),
+  )
+
+  private val currentEqualizerProfile: EqualizerProfile
+    get() = equalizer.value.profileOrNull ?: equalizerSettings.equalizerProfile
+
+  init {
+    // Audio effects bind to the local audio session id, which only the underlying ExoPlayer
+    // reports — the cast composite player doesn't forward audio-sink callbacks.
+    exoPlayer.addListener(
+      object : Player.Listener {
+        override fun onAudioSessionIdChanged(audioSessionId: Int) {
+          if (audioSessionId == C.AUDIO_SESSION_ID_UNSET) {
+            audioEffects.release()
+          } else {
+            audioEffects.attach(audioSessionId, currentEqualizerProfile)
+          }
+        }
+      },
+    )
+    if (exoPlayer.audioSessionId != C.AUDIO_SESSION_ID_UNSET) {
+      audioEffects.attach(exoPlayer.audioSessionId, currentEqualizerProfile)
+    }
+  }
+
   override val runningTimer: StateFlow<RunningTimer?>
     get() = sleepTimerManager.runningTimer
 
@@ -279,6 +314,7 @@ class ExoPlayerAudioPlayer(
     hlsFallbackAttempted = false
     finishedListener = onFinished
     playbackSpeed.value = settings.playbackSpeedFor(session.libraryItem.id)
+    updateEqualizer(equalizerSettings.equalizerProfileFor(session.libraryItem.id))
     _error.value = null
     state.value = AudioPlayer.State.Initializing
 
@@ -451,6 +487,7 @@ class ExoPlayerAudioPlayer(
   override fun release() {
     preparedSession = null
     finishedListener = null
+    audioEffects.release()
     scope.cancel()
   }
 
@@ -610,6 +647,25 @@ class ExoPlayerAudioPlayer(
     player.setPlaybackSpeed(speed)
   }
 
+  override fun setEqualizer(profile: EqualizerProfile) {
+    equalizerSettings.setEqualizerProfileFor(preparedSession?.libraryItem?.id, profile)
+    updateEqualizer(profile)
+  }
+
+  /**
+   * Publishes [profile] as the current equalizer state and pushes it to the audio effects
+   * when audio is rendered locally. While casting the receiver renders the audio, so effects
+   * cannot apply and the state is surfaced as [EqualizerState.Unavailable].
+   */
+  private fun updateEqualizer(profile: EqualizerProfile) {
+    if (isRemotePlayback) {
+      equalizer.value = EqualizerState.Unavailable(profile)
+    } else {
+      equalizer.value = EqualizerState.Available(profile)
+      audioEffects.apply(profile)
+    }
+  }
+
   override fun setTimer(timer: PlaybackTimer) {
     sleepTimerManager.setTimer(timer)
   }
@@ -626,12 +682,14 @@ class ExoPlayerAudioPlayer(
     if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_LOCAL) {
       dbark { "onDeviceInfoChanged: Local Player" }
       isRemotePlayback = false
+      updateEqualizer(currentEqualizerProfile)
       armCastWatchdog(null)
       updateProgress(player)
     } else if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
       dbark { "onDeviceInfoChanged: Remote Player" }
       if (!isRemotePlayback) {
         isRemotePlayback = true
+        updateEqualizer(currentEqualizerProfile)
         // The remote player surfaces no PlaybackException for receiver-side failures
         // (unreachable/unauthorized media, dead receiver) — a handoff that never reaches
         // READY is the only signal, so give it a deadline.

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/equalizer/AudioEffectsController.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/equalizer/AudioEffectsController.kt
@@ -1,0 +1,178 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.equalizer
+
+import android.media.audiofx.AudioEffect
+import android.media.audiofx.BassBoost
+import android.media.audiofx.DynamicsProcessing
+import android.media.audiofx.LoudnessEnhancer
+import app.campfire.audioplayer.impl.util.AUDIO_TAG
+import app.campfire.core.audio.EqualizerBands
+import app.campfire.core.audio.EqualizerProfile
+import app.campfire.core.logging.Cork
+import app.campfire.crashreporting.CrashReporter
+import kotlin.math.roundToInt
+
+/**
+ * Owns the `android.media.audiofx` effects that implement the equalizer on a single audio
+ * session: a [DynamicsProcessing] pre-EQ for the band faders, a [LoudnessEnhancer] for the
+ * loudness slider, and a [BassBoost] for the bass slider.
+ *
+ * Effects attach to the ExoPlayer audio session id delivered by
+ * `Player.Listener.onAudioSessionIdChanged` and must be re-created whenever it changes.
+ * Vendor DSP implementations can reject any of these effects at construction or
+ * configuration time, so every interaction is guarded — a failing effect is dropped in
+ * isolation and never interrupts playback.
+ */
+internal class AudioEffectsController : Cork {
+
+  override val tag: String = AUDIO_TAG
+  override val enabled: Boolean = true
+
+  // Strong references are required: audiofx effects detach when garbage collected.
+  private var dynamicsProcessing: DynamicsProcessing? = null
+  private var loudnessEnhancer: LoudnessEnhancer? = null
+  private var bassBoost: BassBoost? = null
+  private var attachedSessionId: Int? = null
+
+  private val hasEffects: Boolean
+    get() = dynamicsProcessing != null || loudnessEnhancer != null || bassBoost != null
+
+  /**
+   * Binds this controller to [audioSessionId], replacing any previous session. Effects are
+   * only created while the profile is enabled, so listeners who never touch the equalizer
+   * pay no DSP cost.
+   */
+  fun attach(audioSessionId: Int, profile: EqualizerProfile) {
+    release()
+    attachedSessionId = audioSessionId
+    if (profile.enabled) {
+      createEffects(audioSessionId)
+      apply(profile)
+    }
+  }
+
+  private fun createEffects(audioSessionId: Int) {
+    dbark { "Attaching audio effects to session $audioSessionId" }
+
+    dynamicsProcessing = guarded("DynamicsProcessing.create") {
+      val config = DynamicsProcessing.Config.Builder(
+        DynamicsProcessing.VARIANT_FAVOR_FREQUENCY_RESOLUTION,
+        CHANNEL_COUNT,
+        true, // preEqInUse
+        EqualizerBands.BAND_COUNT,
+        false, // mbcInUse
+        0,
+        false, // postEqInUse
+        0,
+        false, // limiterInUse
+      )
+        .setPreferredFrameDuration(PREFERRED_FRAME_DURATION_MS)
+        .build()
+      DynamicsProcessing(EFFECT_PRIORITY, audioSessionId, config)
+    }
+    loudnessEnhancer = guarded("LoudnessEnhancer.create") {
+      LoudnessEnhancer(audioSessionId)
+    }
+    bassBoost = guarded("BassBoost.create") {
+      BassBoost(EFFECT_PRIORITY, audioSessionId)
+    }
+  }
+
+  /**
+   * Pushes [profile] to the effects, lazily creating them the first time the profile is
+   * enabled on the bound session. No-ops when no session is bound.
+   */
+  fun apply(profile: EqualizerProfile) {
+    if (!hasEffects) {
+      val sessionId = attachedSessionId
+      if (!profile.enabled || sessionId == null) return
+      createEffects(sessionId)
+    }
+
+    dynamicsProcessing?.let { dp ->
+      dynamicsProcessing = guardedOrDrop("DynamicsProcessing.apply", dp) {
+        profile.bandGainsDb.take(EqualizerBands.BAND_COUNT).forEachIndexed { index, gainDb ->
+          val band = DynamicsProcessing.EqBand(
+            true,
+            EqualizerBands.centerFrequenciesHz[index].toFloat(),
+            gainDb.coerceIn(EqualizerBands.BandGainRangeDb),
+          )
+          dp.setPreEqBandAllChannelsTo(index, band)
+        }
+        dp.setEnabled(profile.enabled)
+      }
+    }
+
+    loudnessEnhancer?.let { loudness ->
+      loudnessEnhancer = guardedOrDrop("LoudnessEnhancer.apply", loudness) {
+        val gainDb = profile.loudnessGainDb.coerceIn(EqualizerBands.LoudnessGainRangeDb)
+        loudness.setTargetGain((gainDb * MILLIBELS_PER_DB).roundToInt())
+        loudness.setEnabled(profile.enabled && gainDb > 0f)
+      }
+    }
+
+    bassBoost?.let { bass ->
+      bassBoost = guardedOrDrop("BassBoost.apply", bass) {
+        val strength = profile.bassBoost.coerceIn(EqualizerBands.BassBoostRange)
+        if (bass.strengthSupported) {
+          bass.setStrength((strength * MAX_BASS_STRENGTH).roundToInt().toShort())
+        }
+        bass.setEnabled(profile.enabled && strength > 0f)
+      }
+    }
+  }
+
+  fun release() {
+    dynamicsProcessing?.releaseQuietly()
+    loudnessEnhancer?.releaseQuietly()
+    bassBoost?.releaseQuietly()
+    dynamicsProcessing = null
+    loudnessEnhancer = null
+    bassBoost = null
+    attachedSessionId = null
+  }
+
+  private inline fun <T : AudioEffect> guarded(operation: String, block: () -> T): T? {
+    return try {
+      block()
+    } catch (e: RuntimeException) {
+      wbark(e) { "Audio effect failed: $operation" }
+      CrashReporter.record(e)
+      null
+    }
+  }
+
+  /**
+   * Runs [block] against [effect], dropping (releasing and returning null for) the effect if
+   * the platform DSP rejects it so a broken effect can't repeatedly throw.
+   */
+  private inline fun <T : AudioEffect> guardedOrDrop(operation: String, effect: T, block: () -> Unit): T? {
+    return try {
+      block()
+      effect
+    } catch (e: RuntimeException) {
+      wbark(e) { "Audio effect failed: $operation" }
+      CrashReporter.record(e)
+      effect.releaseQuietly()
+      null
+    }
+  }
+
+  private fun AudioEffect.releaseQuietly() {
+    try {
+      release()
+    } catch (e: RuntimeException) {
+      wbark(e) { "Audio effect failed to release" }
+    }
+  }
+
+  companion object {
+    private const val EFFECT_PRIORITY = 0
+    private const val CHANNEL_COUNT = 2
+    private const val PREFERRED_FRAME_DURATION_MS = 10f
+    private const val MILLIBELS_PER_DB = 100f
+    private const val MAX_BASS_STRENGTH = 1000f
+  }
+}

--- a/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/IosAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/iosMain/kotlin/app/campfire/audioplayer/impl/IosAudioPlayer.kt
@@ -15,9 +15,11 @@ import app.campfire.audioplayer.impl.player.preferredIntervals
 import app.campfire.audioplayer.impl.player.supportedPlaybackRates
 import app.campfire.audioplayer.impl.sleep.SleepTimerManager
 import app.campfire.audioplayer.impl.sleep.VolumeFadeController
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.audioplayer.model.RunningTimer
+import app.campfire.core.audio.EqualizerProfile
 import app.campfire.core.extensions.seconds
 import app.campfire.core.logging.bark
 import app.campfire.core.model.Session
@@ -65,6 +67,11 @@ class IosAudioPlayer(
 
   override val currentMetadata = MutableStateFlow(Metadata())
   override val playbackSpeed = MutableStateFlow(settings.playbackSpeed)
+
+  // AVPlayer offers no equalizer hook; a future phase can add one via an
+  // MTAudioProcessingTap or an AVAudioEngine pipeline.
+  override val equalizer: StateFlow<EqualizerState> = MutableStateFlow(EqualizerState.Unsupported)
+
   override val runningTimer: StateFlow<RunningTimer?>
     get() = sleepTimerManager.runningTimer
 
@@ -340,6 +347,10 @@ class IosAudioPlayer(
     playbackSpeed.value = speed
     settings.setPlaybackSpeedFor(preparedSession?.libraryItem?.id, speed)
     player.setPlaybackSpeed(speed)
+  }
+
+  override fun setEqualizer(profile: EqualizerProfile) {
+    // Unsupported on iOS; see [equalizer]
   }
 
   override fun setTimer(timer: PlaybackTimer) {

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/DesktopPlaybackController.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/DesktopPlaybackController.kt
@@ -14,6 +14,7 @@ import app.campfire.core.di.qualifier.ForScope
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.model.PlayMethod
 import app.campfire.core.model.PodcastEpisodeId
+import app.campfire.settings.api.EqualizerSettings
 import app.campfire.settings.api.PlaybackSettings
 import com.r0adkll.kimchi.annotations.ContributesBinding
 import kotlinx.coroutines.launch
@@ -25,6 +26,7 @@ import me.tatarka.inject.annotations.Inject
 class DesktopPlaybackController(
   private val playbackSessionManager: PlaybackSessionManager,
   private val playbackSettings: PlaybackSettings,
+  private val equalizerSettings: EqualizerSettings,
   private val audioPlayerHolder: AudioPlayerHolder,
   private val sleepTimerManagerFactory: SleepTimerManager.Factory,
   @ForScope(UserScope::class) private val userScopeHolder: CoroutineScopeHolder,
@@ -56,7 +58,7 @@ class DesktopPlaybackController(
 
   private fun initializeAudioPlayerIfNeeded() {
     if (audioPlayerHolder.currentPlayer.value == null) {
-      audioPlayerHolder.setCurrentPlayer(VlcAudioPlayer(playbackSettings, sleepTimerManagerFactory))
+      audioPlayerHolder.setCurrentPlayer(VlcAudioPlayer(playbackSettings, equalizerSettings, sleepTimerManagerFactory))
     }
   }
 }

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/VlcAudioPlayer.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/VlcAudioPlayer.kt
@@ -10,15 +10,19 @@ import app.campfire.audioplayer.impl.mediaitem.MediaItemBuilder
 import app.campfire.audioplayer.impl.player.VlcPlayer
 import app.campfire.audioplayer.impl.sleep.SleepTimerManager
 import app.campfire.audioplayer.impl.sleep.VolumeFadeController
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.audioplayer.model.RunningTimer
+import app.campfire.core.audio.EqualizerBands
+import app.campfire.core.audio.EqualizerProfile
 import app.campfire.core.extensions.seconds
 import app.campfire.core.image.CoverUrls
 import app.campfire.core.logging.bark
 import app.campfire.core.model.Session
 import app.campfire.core.model.loggableId
 import app.campfire.crashreporting.CrashReporter
+import app.campfire.settings.api.EqualizerSettings
 import app.campfire.settings.api.PlaybackSettings
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -34,6 +38,7 @@ import kotlinx.coroutines.launch
 
 class VlcAudioPlayer(
   private val settings: PlaybackSettings,
+  private val equalizerSettings: EqualizerSettings,
   sleepTimerManagerFactory: SleepTimerManager.Factory,
 ) : AudioPlayer {
 
@@ -55,6 +60,9 @@ class VlcAudioPlayer(
   override val currentDuration = MutableStateFlow(0.seconds)
   override val currentMetadata = MutableStateFlow(Metadata())
   override val playbackSpeed = MutableStateFlow(settings.playbackSpeed)
+  override val equalizer = MutableStateFlow<EqualizerState>(
+    EqualizerState.Available(equalizerSettings.equalizerProfile),
+  )
 
   override val runningTimer: StateFlow<RunningTimer?>
     get() = sleepTimerManager.runningTimer
@@ -71,6 +79,7 @@ class VlcAudioPlayer(
     preparedSession = session
     finishedListener = onFinished
     playbackSpeed.value = settings.playbackSpeedFor(session.libraryItem.id)
+    applyEqualizer(equalizerSettings.equalizerProfileFor(session.libraryItem.id))
     state.value = AudioPlayer.State.Initializing
 
     // Build and set media items for the current session
@@ -262,6 +271,29 @@ class VlcAudioPlayer(
     mediaPlayer.setPlaybackSpeed(speed)
   }
 
+  override fun setEqualizer(profile: EqualizerProfile) {
+    equalizerSettings.setEqualizerProfileFor(preparedSession?.libraryItem?.id, profile)
+    applyEqualizer(profile)
+  }
+
+  private fun applyEqualizer(profile: EqualizerProfile) {
+    equalizer.value = EqualizerState.Available(profile)
+
+    // libvlc has no dedicated loudness/bass effects: the loudness slider maps onto the
+    // equalizer preamp, and the bass slider folds extra gain onto the two lowest bands
+    // (60/170 Hz). VlcPlayer re-clamps everything to libvlc's +/-20 dB limit.
+    val bassBoostDb = profile.bassBoost.coerceIn(EqualizerBands.BassBoostRange) * BASS_BOOST_MAX_DB
+    val bandGainsDb = profile.bandGainsDb.mapIndexed { index, gainDb ->
+      val gain = gainDb.coerceIn(EqualizerBands.BandGainRangeDb)
+      if (index < BASS_BOOST_BAND_COUNT) gain + bassBoostDb else gain
+    }
+    mediaPlayer.setEqualizer(
+      enabled = profile.enabled,
+      preampDb = profile.loudnessGainDb.coerceIn(EqualizerBands.LoudnessGainRangeDb),
+      bandGainsDb = bandGainsDb,
+    )
+  }
+
   override fun setTimer(timer: PlaybackTimer) {
     sleepTimerManager.setTimer(timer)
   }
@@ -313,5 +345,10 @@ class VlcAudioPlayer(
         finishedListener?.invoke(preparedSession?.libraryItem?.id ?: return@launch)
       }
     }
+  }
+
+  companion object {
+    private const val BASS_BOOST_MAX_DB = 6f
+    private const val BASS_BOOST_BAND_COUNT = 2
   }
 }

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/player/VlcPlayer.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/player/VlcPlayer.kt
@@ -18,6 +18,7 @@ import kotlin.math.floor
 import kotlin.math.roundToLong
 import uk.co.caprica.vlcj.factory.discovery.NativeDiscovery
 import uk.co.caprica.vlcj.media.MediaRef
+import uk.co.caprica.vlcj.player.base.Equalizer
 import uk.co.caprica.vlcj.player.base.MediaPlayer
 import uk.co.caprica.vlcj.player.base.MediaPlayerEventAdapter
 import uk.co.caprica.vlcj.player.base.State
@@ -42,6 +43,7 @@ class VlcPlayer {
   private var listener: Listener? = null
 
   private val mediaPlayer: MediaPlayer
+  private val vlcEqualizer: Equalizer
 
   private var didFinish: Boolean = false
 
@@ -55,8 +57,28 @@ class VlcPlayer {
 
   init {
     NativeDiscovery().discover()
-    mediaPlayer = AudioPlayerComponent().mediaPlayer()
+    val component = AudioPlayerComponent()
+    mediaPlayer = component.mediaPlayer()
+    vlcEqualizer = component.mediaPlayerFactory().equalizer().newEqualizer()
     mediaPlayer.events().addMediaPlayerEventListener(EventListener())
+  }
+
+  /**
+   * Applies the given equalizer configuration to the underlying player, or detaches the
+   * equalizer entirely when [enabled] is false. Gains map index-for-index onto libvlc's
+   * 10 ISO bands; [preampDb] is the overall pre-amplification.
+   */
+  fun setEqualizer(enabled: Boolean, preampDb: Float, bandGainsDb: List<Float>) {
+    if (!enabled) {
+      mediaPlayer.audio().setEqualizer(null)
+      return
+    }
+    vlcEqualizer.setPreamp(preampDb.coerceIn(VLC_GAIN_RANGE_DB))
+    bandGainsDb.take(vlcEqualizer.bandCount()).forEachIndexed { index, gainDb ->
+      vlcEqualizer.setAmp(index, gainDb.coerceIn(VLC_GAIN_RANGE_DB))
+    }
+    // (Re)setting the equalizer after amp changes ensures libvlc picks them up
+    mediaPlayer.audio().setEqualizer(vlcEqualizer)
   }
 
   fun setListener(listener: Listener) {
@@ -367,6 +389,9 @@ class VlcPlayer {
   companion object : Cork {
     override val tag: String = "VlcPlayer"
     override val enabled: Boolean = false
+
+    // libvlc constrains equalizer preamp/amps to +/-20 dB (LibVlcConst.MIN_GAIN/MAX_GAIN)
+    private val VLC_GAIN_RANGE_DB = -20f..20f
   }
 }
 

--- a/infra/audioplayer/test/src/commonMain/kotlin/app/campfire/audioplayer/test/FakeAudioPlayer.kt
+++ b/infra/audioplayer/test/src/commonMain/kotlin/app/campfire/audioplayer/test/FakeAudioPlayer.kt
@@ -5,8 +5,10 @@ package app.campfire.audioplayer.test
 
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.OnFinishedListener
+import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.model.PlaybackTimer
+import app.campfire.core.audio.EqualizerProfile
 import app.campfire.core.model.Session
 import kotlin.time.Duration
 import kotlinx.coroutines.Job
@@ -24,6 +26,7 @@ class FakeAudioPlayer : AudioPlayer {
   override val currentDuration = MutableStateFlow(Duration.ZERO)
   override val currentMetadata = MutableStateFlow(Metadata())
   override val playbackSpeed = MutableStateFlow(1f)
+  override val equalizer = MutableStateFlow<EqualizerState>(EqualizerState.Available(EqualizerProfile()))
   override val runningTimer = MutableStateFlow(null)
 
   override suspend fun prepare(
@@ -88,6 +91,11 @@ class FakeAudioPlayer : AudioPlayer {
     invocations += Invocation.SetPlaybackSpeed(speed)
   }
 
+  override fun setEqualizer(profile: EqualizerProfile) {
+    invocations += Invocation.SetEqualizer(profile)
+    equalizer.value = EqualizerState.Available(profile)
+  }
+
   override fun setTimer(timer: PlaybackTimer) {
     invocations += Invocation.SetTimer(timer)
   }
@@ -114,6 +122,7 @@ class FakeAudioPlayer : AudioPlayer {
     data object SeekBackward : Invocation
     data class SeekTo(val value: Any) : Invocation
     data class SetPlaybackSpeed(val speed: Float) : Invocation
+    data class SetEqualizer(val profile: EqualizerProfile) : Invocation
     data class SetTimer(val timer: PlaybackTimer) : Invocation
     data object ClearTimer : Invocation
   }


### PR DESCRIPTION
Closes #968

Adds a sound equalizer to the now-playing experience: a bottom sheet with preset chips, ten vertical band faders, and Loudness / Bass sliders — configurable globally or per-book (the per-book toggle mirrors the playback speed sheet's Book/Globe switch).

## What's included

- **Presets**: Flat, Voice Boost, Podcast, Bass Boost, Treble Boost, Warm, Reduce Noise, plus an implicit persisted **Custom** — touching any fader switches to Custom, and its curve survives preset switching. The set is audiobook-oriented (speech presence, hiss/rumble taming) and was benchmarked against Absorb's presets, dropping its redundant "audiobook" curve and its "loudness" smiley (which would name-clash with our Loudness slider).
- **Bands**: a fixed 10-band layout on VLC's ISO centers (60 Hz–16 kHz, ±12 dB) shared by every platform, so the UI is identical everywhere.
- **Per-book profiles**: `EqualizerSettings` follows the `itemPlaybackSpeeds` pattern — global profile + a per-item override map + the saved Custom gains, serialized with the existing manual-join convention.

## Platform engines

- **Android**: `AudioEffectsController` attaches `DynamicsProcessing` (10-band preEq) + `LoudnessEnhancer` + `BassBoost` to ExoPlayer's audio session via `onAudioSessionIdChanged` — registered on the raw ExoPlayer, since the cast composite player doesn't forward audio-sink callbacks. Effects are created lazily on first enable (zero DSP cost for users who never open the EQ) and every audiofx interaction is guarded so a vendor DSP failure can never break playback. No new permissions; framework APIs only, so no F-Droid impact.
- **Desktop**: libvlc's native 10-band equalizer via vlcj, mapping index-for-index; Loudness drives the preamp and Bass folds up to +6 dB onto the two lowest bands.
- **iOS**: reports `EqualizerState.Unsupported` and the EQ button is hidden — AVPlayer has no equalizer hook; a future phase can add one via `MTAudioProcessingTap` or an `AVAudioEngine` pipeline, and everything else lights up automatically once the state flow changes.
- **Casting**: DSP is device-side, so while a Cast route is active the state becomes `Unavailable` and the sheet renders disabled with a "not available while casting" caption; effects re-apply on return to local playback.

## UI

- New shared `VerticalSlider` widget in `common/compose` — a rotated M3 `Slider` with the thin-thumb styling, keeping Material semantics/keyboard/a11y; each fader also carries a per-band content description.
- `EqualizerBottomSheet` follows the `PlaybackSpeedBottomSheet` five-layer convention (input model → `OverlayHost` launcher → `Impression` analytics → `ComponentHolder` component → pure previewable `EqualizerSheet` with `@Preview`).
- Entry point added to all three playback surfaces (expanded bar, small expanded bar, desktop bottom bar) behind `IconButtonTooltip` with the existing `CampfireIcons.Rounded.Equalizer` icon.

## Testing

- Unit tests: preset band-count/round-trip/custom detection, settings serialization round-trips + corrupt-input fallback, per-book fallback logic.
- Verified compiling on all three targets (incl. alpha Android app + desktop jar for the Kimchi DI merge); `ktlint` clean.
- Platform engine code (audiofx/vlcj) isn't unit-testable, so changed-file coverage may need the `skip-coverage` label.
- Still to do before marking ready: on-device listening pass on Android (preset audibility, cast gating, per-book hydration) and a desktop pass with VLC installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
