### PR TITLE
Gate the local network permission to Android 17+ where LNP is actually enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other Notes & Contributions
 
-- The cast device list now offers to request local network access on Android 16+ when it may be needed to find devices
+- The cast device list now offers to request local network access on Android 17+ when it may be needed to find devices
 
 ## [1.0.5]
 

--- a/app/android/src/main/java/app/campfire/android/MainActivity.kt
+++ b/app/android/src/main/java/app/campfire/android/MainActivity.kt
@@ -62,7 +62,7 @@ class MainActivity : ComponentActivity() {
     }
 
     // Upgrade path: a user already signed in to a LAN server before the app began targeting
-    // Android 16+ won't pass through the login screen, so prompt for local-network access here
+    // Android 17+ won't pass through the login screen, so prompt for local-network access here
     // if their active server is private and the permission is missing. Waits for the session to
     // restore (it may still be Loading at onCreate), then requests once. No-ops otherwise.
     lifecycleScope.launch {

--- a/app/android/src/main/java/app/campfire/android/permission/AndroidLocalNetworkPermissionController.kt
+++ b/app/android/src/main/java/app/campfire/android/permission/AndroidLocalNetworkPermissionController.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.withContext
 import me.tatarka.inject.annotations.Inject
 
 /**
- * Android 16+ Local Network Protection gates private IP ranges behind the runtime
+ * Android 17+ Local Network Protection gates private IP ranges behind the runtime
  * `ACCESS_LOCAL_NETWORK` permission. This prompts for it lazily — only once the user enters a
  * LAN address — so people connecting to a remote server are never asked.
  */
@@ -40,7 +40,7 @@ class AndroidLocalNetworkPermissionController(
   private var requestedThisSession = false
 
   override suspend fun requestIfNeeded(serverUrl: String): Boolean {
-    // LNP only applies on Android 16+; older versions have no such gate.
+    // LNP only applies on Android 17+; older versions have no such gate.
     if (Build.VERSION.SDK_INT < LNP_MIN_SDK) return true
     if (isGranted()) return true
     if (!pointsAtPrivateNetwork(serverUrl)) return true
@@ -107,8 +107,10 @@ class AndroidLocalNetworkPermissionController(
     application.checkSelfPermission(ACCESS_LOCAL_NETWORK) == PackageManager.PERMISSION_GRANTED
 
   private companion object {
-    // Local Network Protection was introduced in Android 16 (API 36).
-    const val LNP_MIN_SDK = 36
+    // Local Network Protection is enforced starting in Android 17 (API 37). Android 16 shipped
+    // the permission as opt-in for testing only: checkSelfPermission reports it as denied there,
+    // but requesting it silently no-ops, so gating on 36 surfaced a dead permission prompt.
+    const val LNP_MIN_SDK = 37
 
     // String literal rather than Manifest.permission.ACCESS_LOCAL_NETWORK so this still compiles
     // against a compileSdk that predates the constant.

--- a/core/src/commonMain/kotlin/app/campfire/core/permission/LocalNetworkPermissionController.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/permission/LocalNetworkPermissionController.kt
@@ -4,7 +4,7 @@
 package app.campfire.core.permission
 
 /**
- * Gates access to the platform's "local network" permission (Android 16+ Local Network
+ * Gates access to the platform's "local network" permission (Android 17+ Local Network
  * Protection). Campfire talks to self-hosted Audiobookshelf servers that frequently live on the
  * LAN (e.g. `192.168.x.x`), and on affected platforms those connections are silently dropped
  * until the user grants access.

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginPresenter.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginPresenter.kt
@@ -259,7 +259,7 @@ class LoginPresenter(
         return@LaunchedEffect
       }
 
-      // A LAN server (e.g. 192.168.x.x) needs the local-network permission on Android 16+, or the
+      // A LAN server (e.g. 192.168.x.x) needs the local-network permission on Android 17+, or the
       // status probe below silently times out. Prompt lazily now that a private address is present.
       localNetworkPermission.requestIfNeeded(candidates.first())
 

--- a/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/cast/CastController.kt
+++ b/infra/audioplayer/api/src/commonMain/kotlin/app/campfire/audioplayer/cast/CastController.kt
@@ -13,7 +13,7 @@ interface CastController {
 
   /**
    * True when discovering devices may require a platform permission the user hasn't granted
-   * (Android 16+ local network access). The device picker surfaces an opt-in action for it —
+   * (Android 17+ local network access). The device picker surfaces an opt-in action for it —
    * the permission is never requested automatically.
    */
   val needsLocalNetworkPermission: StateFlow<Boolean> get() = MutableStateFlow(false)


### PR DESCRIPTION
## Summary

The cast device picker was showing its "allow local network access" row on Android 16 devices, where tapping it does nothing. Local Network Protection enforcement actually landed in [Android 17 (API 37)](https://developer.android.com/privacy-and-security/local-network-permission) — Android 16 shipped `ACCESS_LOCAL_NETWORK` as an opt-in testing feature only, where `checkSelfPermission` reports the permission as denied but requesting it silently no-ops with no dialog.

- Bump `LNP_MIN_SDK` from 36 to 37 in `AndroidLocalNetworkPermissionController`, gating all three paths: the cast-picker row (`isPermissionMissing`), the lazy login-time prompt (`requestIfNeeded`), and the explicit request
- Update the "Android 16+" doc comments to "Android 17+" across the touched files
- Amend the still-unreleased changelog line for the cast-picker row accordingly

## Test plan

- `:app:android:compileAlphaDebugKotlin` passes
- On an Android 16 (API 36) device/emulator the cast picker no longer shows the permission row; on API 37 it still appears when the permission is ungranted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN7aBL2faPaCAbpwFxN3eX