### PR TITLE
Add the Hardcover provider with a local cache and registry

### DIFF
--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -26,6 +26,8 @@ kotlin {
         api(projects.data.account.impl)
         api(projects.data.account.ui)
         api(projects.data.analytics.impl)
+        api(projects.data.bookinfo.impl)
+        api(projects.data.bookinfo.hardcover)
         api(projects.data.crashreporting.impl)
 
         // Infra Modules

--- a/data/bookinfo/hardcover/build.gradle.kts
+++ b/data/bookinfo/hardcover/build.gradle.kts
@@ -1,0 +1,47 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import app.campfire.convention.addKspDependencyForCommon
+
+plugins {
+  id("app.campfire.android.library")
+  id("app.campfire.multiplatform")
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.ksp)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.data.bookinfo.api)
+
+        implementation(projects.core)
+        implementation(projects.data.network.api)
+        implementation(libs.ktor.client.core)
+        implementation(libs.kotlinx.serialization.json)
+        implementation(libs.multiplatformsettings.core)
+        implementation(libs.multiplatformsettings.coroutines)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(projects.common.test)
+        implementation(libs.bundles.test.common)
+        implementation(libs.bundles.test.impl)
+        implementation(libs.ktor.client.mock)
+        implementation(libs.multiplatformsettings.test)
+      }
+    }
+
+    androidMain {
+      dependencies {
+        implementation(libs.androidx.security.crypto)
+      }
+    }
+  }
+}
+
+addKspDependencyForCommon(libs.kimchi.compiler)

--- a/data/bookinfo/hardcover/src/androidMain/kotlin/app/campfire/bookinfo/hardcover/settings/PlatformHardcoverSettingsComponent.android.kt
+++ b/data/bookinfo/hardcover/src/androidMain/kotlin/app/campfire/bookinfo/hardcover/settings/PlatformHardcoverSettingsComponent.android.kt
@@ -1,0 +1,38 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.settings
+
+import android.app.Application
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import app.campfire.bookinfo.hardcover.di.HardcoverSettings
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.SharedPreferencesSettings
+import me.tatarka.inject.annotations.Provides
+
+actual interface PlatformHardcoverSettingsComponent {
+
+  @SingleIn(AppScope::class)
+  @Provides
+  @HardcoverSettings
+  fun provideHardcoverSettings(
+    application: Application,
+  ): Settings {
+    val masterKey = MasterKey.Builder(application)
+      .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+      .build()
+
+    return SharedPreferencesSettings(
+      delegate = EncryptedSharedPreferences.create(
+        application,
+        "hardcover_prefs",
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+      ),
+    )
+  }
+}

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/HardcoverBookInfoProvider.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/HardcoverBookInfoProvider.kt
@@ -1,0 +1,177 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover
+
+import app.campfire.bookinfo.api.AccountLinkable
+import app.campfire.bookinfo.api.BookCommunityInfo
+import app.campfire.bookinfo.api.BookInfoProvider
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.LinkedAccount
+import app.campfire.bookinfo.api.ProviderCapabilities
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.hardcover.auth.HardcoverTokenStorage
+import app.campfire.bookinfo.hardcover.graphql.BOOK_REVIEWS_QUERY
+import app.campfire.bookinfo.hardcover.graphql.BooksData
+import app.campfire.bookinfo.hardcover.graphql.HardcoverBook
+import app.campfire.bookinfo.hardcover.graphql.HardcoverGraphQl
+import app.campfire.bookinfo.hardcover.graphql.HardcoverGraphQlException
+import app.campfire.bookinfo.hardcover.graphql.HardcoverResult
+import app.campfire.bookinfo.hardcover.graphql.ME_QUERY
+import app.campfire.bookinfo.hardcover.graphql.MeData
+import app.campfire.bookinfo.hardcover.graphql.UserBooksData
+import app.campfire.bookinfo.hardcover.graphql.bookByIdentifiersQuery
+import app.campfire.bookinfo.hardcover.graphql.parseCoverUrl
+import app.campfire.bookinfo.hardcover.graphql.parseRatingsDistribution
+import app.campfire.bookinfo.hardcover.graphql.parseUsername
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import app.campfire.core.session.UserSession
+import app.campfire.core.session.userId
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import me.tatarka.inject.annotations.Inject
+
+class InvalidHardcoverTokenException : Exception("Hardcover rejected the token")
+
+@SingleIn(UserScope::class)
+@ContributesMultibinding(UserScope::class, boundType = BookInfoProvider::class)
+@Inject
+class HardcoverBookInfoProvider(
+  private val graphQl: HardcoverGraphQl,
+  private val tokenStorage: HardcoverTokenStorage,
+  private val userSession: UserSession,
+) : BookInfoProvider, AccountLinkable {
+
+  override val id: ProviderId = ProviderId.Hardcover
+  override val displayName: String = "Hardcover"
+  override val linkHelpUrl: String = "https://hardcover.app/account/api"
+
+  // Series capabilities stay false until the series contract lands in the api.
+  override val capabilities: ProviderCapabilities = ProviderCapabilities(
+    hasReviewText = true,
+    hasAggregateRating = true,
+    hasSupplementalMetadata = true,
+    requiresAccountLink = true,
+  )
+
+  // Match → Hardcover book id, memoized so getReviews doesn't re-resolve a book
+  // that getBookInfo already matched this session.
+  private val matchedIds = mutableMapOf<BookMatch, Long>()
+
+  override fun observeLinkState(): Flow<ProviderLinkState> {
+    val userId = userSession.userId ?: return flowOf(ProviderLinkState.NotLinked)
+    return tokenStorage.observeLinkState(userId)
+  }
+
+  override suspend fun getBookInfo(match: BookMatch): BookInfoResult<BookCommunityInfo> {
+    val (document, variables) = when (match) {
+      is BookMatch.Identifiers -> {
+        val isbn = match.isbn?.filter { it.isLetterOrDigit() }?.takeUnless { it.isEmpty() }
+        val asin = match.asin?.trim()?.takeUnless { it.isEmpty() }
+        if (isbn == null && asin == null) return BookInfoResult.NotFound
+        bookByIdentifiersQuery(hasIsbn = isbn != null, hasAsin = asin != null) to buildJsonObject {
+          isbn?.let { put("isbn", it) }
+          asin?.let { put("asin", it) }
+        }
+      }
+      // Hardcover disables _like/_regex predicates; title matching needs their
+      // `search` endpoint, deferred until its response shape is verified live.
+      is BookMatch.TitleAuthor -> return BookInfoResult.NotFound
+    }
+
+    return when (val result = graphQl.execute(document, variables, BooksData.serializer())) {
+      is HardcoverResult.Success -> {
+        val book = result.data.books.firstOrNull() ?: return BookInfoResult.NotFound
+        matchedIds[match] = book.id
+        BookInfoResult.Success(book.toCommunityInfo())
+      }
+      else -> result.toBookInfoError()
+    }
+  }
+
+  override suspend fun getReviews(match: BookMatch, limit: Int): BookInfoResult<List<BookReview>> {
+    val bookId = matchedIds[match] ?: when (val resolved = getBookInfo(match)) {
+      is BookInfoResult.Success -> matchedIds[match] ?: return BookInfoResult.NotFound
+      is BookInfoResult.NotFound -> return resolved
+      is BookInfoResult.NotLinked -> return resolved
+      is BookInfoResult.TokenInvalid -> return resolved
+      is BookInfoResult.RateLimited -> return resolved
+      is BookInfoResult.Failure -> return resolved
+    }
+
+    val variables = buildJsonObject {
+      put("bookId", bookId)
+      put("limit", limit)
+    }
+
+    return when (val result = graphQl.execute(BOOK_REVIEWS_QUERY, variables, UserBooksData.serializer())) {
+      is HardcoverResult.Success -> BookInfoResult.Success(
+        result.data.userBooks.mapNotNull { userBook ->
+          val text = userBook.review?.takeUnless { it.isBlank() } ?: return@mapNotNull null
+          BookReview(
+            author = userBook.user?.name?.takeUnless { it.isBlank() } ?: userBook.user?.username,
+            rating = userBook.rating,
+            text = text,
+            hasSpoilers = userBook.hasSpoilers ?: false,
+            avatarUrl = parseCoverUrl(userBook.user?.cachedImage),
+            badge = userBook.user?.flair?.takeUnless { it.isBlank() },
+          )
+        },
+      )
+      else -> result.toBookInfoError()
+    }
+  }
+
+  override suspend fun verifyAndLink(token: String): Result<LinkedAccount> {
+    val userId = userSession.userId
+      ?: return Result.failure(IllegalStateException("No active user session"))
+    val trimmed = token.trim()
+    if (trimmed.isEmpty()) return Result.failure(InvalidHardcoverTokenException())
+
+    return when (val result = graphQl.executeWithToken(trimmed, ME_QUERY, deserializer = MeData.serializer())) {
+      is HardcoverResult.Success -> {
+        val username = parseUsername(result.data.me)
+        tokenStorage.link(userId, trimmed, username)
+        Result.success(LinkedAccount(username))
+      }
+      is HardcoverResult.TokenInvalid -> Result.failure(InvalidHardcoverTokenException())
+      is HardcoverResult.RateLimited -> Result.failure(Exception("Hardcover rate limit reached, try again shortly"))
+      is HardcoverResult.GraphQlErrors -> Result.failure(HardcoverGraphQlException(result.messages))
+      is HardcoverResult.NetworkFailure -> Result.failure(result.cause)
+      is HardcoverResult.NotLinked -> Result.failure(InvalidHardcoverTokenException())
+    }
+  }
+
+  override suspend fun unlink() {
+    val userId = userSession.userId ?: return
+    matchedIds.clear()
+    tokenStorage.unlink(userId)
+  }
+
+  private fun HardcoverBook.toCommunityInfo(): BookCommunityInfo = BookCommunityInfo(
+    providerBookId = id.toString(),
+    providerUrl = slug?.let { "https://hardcover.app/books/$it" },
+    rating = rating,
+    ratingsCount = ratingsCount,
+    ratingsDistribution = parseRatingsDistribution(ratingsDistribution),
+    reviewsCount = reviewsCount,
+    releaseDate = releaseDate,
+    coverUrl = parseCoverUrl(cachedImage),
+  )
+
+  private fun HardcoverResult<*>.toBookInfoError(): BookInfoResult<Nothing> = when (this) {
+    is HardcoverResult.Success -> error("Not an error result")
+    is HardcoverResult.NotLinked -> BookInfoResult.NotLinked
+    is HardcoverResult.TokenInvalid -> BookInfoResult.TokenInvalid
+    is HardcoverResult.RateLimited -> BookInfoResult.RateLimited(retryAfter)
+    is HardcoverResult.GraphQlErrors -> BookInfoResult.Failure(HardcoverGraphQlException(messages))
+    is HardcoverResult.NetworkFailure -> BookInfoResult.Failure(cause)
+  }
+}

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/auth/HardcoverTokenStorage.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/auth/HardcoverTokenStorage.kt
@@ -1,0 +1,77 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.auth
+
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.hardcover.di.HardcoverSettings
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.core.model.UserId
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.coroutines.toSuspendSettings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.map
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Encrypted storage for Hardcover personal access tokens, keyed by the ABS
+ * user they were linked under. Lives in AppScope (mirroring the ABS token
+ * storage) so links survive user-scope teardowns; the per-user view is
+ * resolved by callers passing the current [UserId].
+ */
+@OptIn(ExperimentalSettingsApi::class)
+@SingleIn(AppScope::class)
+@Inject
+class HardcoverTokenStorage(
+  @HardcoverSettings private val hardcoverSettings: Settings,
+  private val dispatcherProvider: DispatcherProvider,
+) {
+
+  private val settings by lazy {
+    hardcoverSettings.toSuspendSettings(dispatcherProvider.io)
+  }
+
+  private val changes = MutableSharedFlow<Unit>(replay = 1).also { it.tryEmit(Unit) }
+
+  fun observeLinkState(userId: UserId): Flow<ProviderLinkState> = changes.map { readLinkState(userId) }
+
+  suspend fun getToken(userId: UserId): String? {
+    return settings.getStringOrNull(tokenKey(userId))
+  }
+
+  suspend fun link(userId: UserId, token: String, accountName: String?) {
+    settings.putString(tokenKey(userId), token)
+    accountName?.let { settings.putString(accountNameKey(userId), it) }
+      ?: settings.remove(accountNameKey(userId))
+    settings.remove(invalidKey(userId))
+    changes.tryEmit(Unit)
+  }
+
+  suspend fun unlink(userId: UserId) {
+    settings.remove(tokenKey(userId))
+    settings.remove(accountNameKey(userId))
+    settings.remove(invalidKey(userId))
+    changes.tryEmit(Unit)
+  }
+
+  /** Records that the stored token was rejected by Hardcover, without deleting it. */
+  suspend fun markInvalid(userId: UserId) {
+    if (settings.getStringOrNull(tokenKey(userId)) == null) return
+    settings.putBoolean(invalidKey(userId), true)
+    changes.tryEmit(Unit)
+  }
+
+  private suspend fun readLinkState(userId: UserId): ProviderLinkState = when {
+    settings.getStringOrNull(tokenKey(userId)) == null -> ProviderLinkState.NotLinked
+    settings.getBoolean(invalidKey(userId), false) -> ProviderLinkState.Invalid
+    else -> ProviderLinkState.Linked(settings.getStringOrNull(accountNameKey(userId)))
+  }
+
+  private fun tokenKey(userId: UserId) = "hardcoverToken_$userId"
+  private fun accountNameKey(userId: UserId) = "hardcoverAccount_$userId"
+  private fun invalidKey(userId: UserId) = "hardcoverTokenInvalid_$userId"
+}

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/di/HardcoverHttpClientModule.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/di/HardcoverHttpClientModule.kt
@@ -1,0 +1,24 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.di
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.network.di.BaseClient
+import com.r0adkll.kimchi.annotations.ContributesTo
+import io.ktor.client.HttpClient
+import me.tatarka.inject.annotations.Provides
+
+@ContributesTo(AppScope::class)
+interface HardcoverHttpClientModule {
+
+  @HardcoverClient
+  @SingleIn(AppScope::class)
+  @Provides
+  fun provideHardcoverHttpClient(
+    @BaseClient baseClient: HttpClient,
+  ): HttpClient = baseClient.config {
+    expectSuccess = false
+  }
+}

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/di/HardcoverQualifiers.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/di/HardcoverQualifiers.kt
@@ -1,0 +1,16 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.di
+
+import me.tatarka.inject.annotations.Qualifier
+
+/** Qualifies the [io.ktor.client.HttpClient] configured for the Hardcover GraphQL API. */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class HardcoverClient
+
+/** Qualifies the encrypted [com.russhwolf.settings.Settings] holding Hardcover tokens. */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class HardcoverSettings

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverDocuments.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverDocuments.kt
@@ -1,0 +1,165 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.graphql
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+private const val BOOK_SELECTION = """
+      id
+      slug
+      title
+      rating
+      ratings_count
+      ratings_distribution
+      reviews_count
+      release_date
+      cached_image
+"""
+
+/**
+ * Builds a single lookup over every identifier the item carries — identifier
+ * coverage on Hardcover editions is uneven (audiobook ASINs especially), so one
+ * `_or` across all of them beats sequential per-identifier lookups. GraphQL
+ * requires every declared variable to be used, so the declaration list and the
+ * predicate list are built together.
+ */
+internal fun bookByIdentifiersQuery(hasIsbn: Boolean, hasAsin: Boolean): String {
+  require(hasIsbn || hasAsin) { "At least one identifier is required" }
+  val variables = buildList {
+    if (hasIsbn) add("${'$'}isbn: String!")
+    if (hasAsin) add("${'$'}asin: String!")
+  }.joinToString(", ")
+  val predicates = buildList {
+    if (hasIsbn) {
+      add("{isbn_13: {_eq: ${'$'}isbn}}")
+      add("{isbn_10: {_eq: ${'$'}isbn}}")
+    }
+    if (hasAsin) {
+      add("{asin: {_eq: ${'$'}asin}}")
+    }
+  }.joinToString(", ")
+  return """
+  query BookByIdentifiers($variables) {
+    books(
+      where: {editions: {_or: [$predicates]}}
+      order_by: {users_count: desc}
+      limit: 1
+    ) {$BOOK_SELECTION}
+  }
+  """.trimIndent()
+}
+
+internal val BOOK_REVIEWS_QUERY = """
+  query BookReviews(${'$'}bookId: Int!, ${'$'}limit: Int!) {
+    user_books(
+      where: {book_id: {_eq: ${'$'}bookId}, has_review: {_eq: true}}
+      limit: ${'$'}limit
+    ) {
+      rating
+      review
+      review_has_spoilers
+      user {
+        username
+        name
+        flair
+        cached_image
+      }
+    }
+  }
+""".trimIndent()
+
+internal val ME_QUERY = """
+  query Me {
+    me {
+      username
+    }
+  }
+""".trimIndent()
+
+@Serializable
+internal data class BooksData(
+  val books: List<HardcoverBook> = emptyList(),
+)
+
+@Serializable
+internal data class HardcoverBook(
+  val id: Long,
+  val slug: String? = null,
+  val title: String? = null,
+  val rating: Double? = null,
+  @SerialName("ratings_count") val ratingsCount: Int? = null,
+  @SerialName("ratings_distribution") val ratingsDistribution: JsonElement? = null,
+  @SerialName("reviews_count") val reviewsCount: Int? = null,
+  @SerialName("release_date") val releaseDate: String? = null,
+  @SerialName("cached_image") val cachedImage: JsonElement? = null,
+)
+
+@Serializable
+internal data class UserBooksData(
+  @SerialName("user_books") val userBooks: List<HardcoverUserBook> = emptyList(),
+)
+
+@Serializable
+internal data class HardcoverUserBook(
+  val rating: Double? = null,
+  val review: String? = null,
+  @SerialName("review_has_spoilers") val hasSpoilers: Boolean? = null,
+  val user: HardcoverUser? = null,
+)
+
+@Serializable
+internal data class HardcoverUser(
+  val username: String? = null,
+  val name: String? = null,
+  val flair: String? = null,
+  @SerialName("cached_image") val cachedImage: JsonElement? = null,
+)
+
+/**
+ * `ratings_distribution` is a jsonb column with no stable documented shape;
+ * tolerate the object (`{"1": 4}`) and array (`[{"rating": 1, "count": 4}]`)
+ * encodings and give up quietly on anything else.
+ */
+internal fun parseRatingsDistribution(element: JsonElement?): Map<Int, Int>? {
+  return when (element) {
+    is JsonObject -> element.entries.mapNotNull { (key, value) ->
+      val star = key.toIntOrNull() ?: return@mapNotNull null
+      val count = value.jsonPrimitive.intOrNull ?: return@mapNotNull null
+      star to count
+    }.toMap().ifEmpty { null }
+
+    is JsonArray -> element.mapNotNull { entry ->
+      val obj = entry as? JsonObject ?: return@mapNotNull null
+      val star = obj["rating"]?.jsonPrimitive?.intOrNull ?: return@mapNotNull null
+      val count = obj["count"]?.jsonPrimitive?.intOrNull ?: return@mapNotNull null
+      star to count
+    }.toMap().ifEmpty { null }
+
+    else -> null
+  }
+}
+
+/** `cached_image` is a jsonb blob shaped like `{"url": "...", ...}`. */
+internal fun parseCoverUrl(element: JsonElement?): String? {
+  val obj = element as? JsonObject ?: return null
+  return obj["url"]?.jsonPrimitive?.content?.takeUnless { it.isBlank() }
+}
+
+@Serializable
+internal data class MeData(
+  val me: JsonElement? = null,
+)
+
+/** `me` has been observed as both a single object and a one-element list. */
+internal fun parseUsername(me: JsonElement?): String? = when (me) {
+  is JsonObject -> me["username"]?.jsonPrimitive?.content
+  is JsonArray -> (me.firstOrNull() as? JsonObject)?.get("username")?.jsonPrimitive?.content
+  else -> null
+}

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverGraphQl.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverGraphQl.kt
@@ -1,0 +1,160 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.graphql
+
+import app.campfire.bookinfo.hardcover.auth.HardcoverTokenStorage
+import app.campfire.bookinfo.hardcover.di.HardcoverClient
+import app.campfire.core.session.UserSession
+import app.campfire.core.session.userId
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import me.tatarka.inject.annotations.Inject
+
+internal const val HARDCOVER_GRAPHQL_ENDPOINT = "https://api.hardcover.app/v1/graphql"
+
+/**
+ * Minimal GraphQL executor for the Hardcover API. Owns the request envelope,
+ * the `{data, errors}` response unwrap (GraphQL errors arrive with HTTP 200),
+ * and the auth/rate-limit error taxonomy. The bearer token is read from
+ * [HardcoverTokenStorage] per request — tokens have no refresh flow, so nothing
+ * may cache them across a re-link.
+ */
+@Inject
+class HardcoverGraphQl(
+  @HardcoverClient private val client: HttpClient,
+  private val tokenStorage: HardcoverTokenStorage,
+  private val userSession: UserSession,
+) {
+
+  val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  suspend fun <T> execute(
+    document: String,
+    variables: JsonObject = EmptyVariables,
+    deserializer: DeserializationStrategy<T>,
+  ): HardcoverResult<T> {
+    val userId = userSession.userId ?: return HardcoverResult.NotLinked
+    val token = tokenStorage.getToken(userId) ?: return HardcoverResult.NotLinked
+    val result = executeWithToken(token, document, variables, deserializer)
+    if (result is HardcoverResult.TokenInvalid) {
+      tokenStorage.markInvalid(userId)
+    }
+    return result
+  }
+
+  /**
+   * Executes with an explicit [token], bypassing storage — used to verify a
+   * pasted token before persisting it.
+   */
+  suspend fun <T> executeWithToken(
+    token: String,
+    document: String,
+    variables: JsonObject = EmptyVariables,
+    deserializer: DeserializationStrategy<T>,
+  ): HardcoverResult<T> {
+    val response = try {
+      client.post(HARDCOVER_GRAPHQL_ENDPOINT) {
+        contentType(ContentType.Application.Json)
+        header(HttpHeaders.Authorization, "Bearer $token")
+        setBody(
+          buildJsonObject {
+            put("query", document)
+            put("variables", variables)
+          }.toString(),
+        )
+      }
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      return HardcoverResult.NetworkFailure(e)
+    }
+
+    return when {
+      response.status == HttpStatusCode.Unauthorized ||
+        response.status == HttpStatusCode.Forbidden -> HardcoverResult.TokenInvalid
+
+      response.status == HttpStatusCode.TooManyRequests ->
+        HardcoverResult.RateLimited(parseRetryAfter(response.headers))
+
+      !response.status.isSuccess() ->
+        HardcoverResult.NetworkFailure(HardcoverHttpException(response.status.value))
+
+      else -> parseEnvelope(response.bodyAsText(), deserializer)
+    }
+  }
+
+  private fun <T> parseEnvelope(
+    body: String,
+    deserializer: DeserializationStrategy<T>,
+  ): HardcoverResult<T> {
+    return try {
+      val envelope = json.parseToJsonElement(body).jsonObject
+      val errors = envelope["errors"]?.jsonArray.orEmpty()
+      if (errors.isNotEmpty()) {
+        val messages = errors.mapNotNull { error ->
+          error.jsonObject["message"]?.jsonPrimitive?.content
+        }
+        return HardcoverResult.GraphQlErrors(messages)
+      }
+      val data = envelope["data"]
+        ?: return HardcoverResult.NetworkFailure(HardcoverGraphQlException(listOf("Missing data element")))
+      HardcoverResult.Success(json.decodeFromJsonElement(deserializer, data))
+    } catch (e: Exception) {
+      HardcoverResult.NetworkFailure(e)
+    }
+  }
+
+  companion object {
+    val EmptyVariables = buildJsonObject { }
+  }
+}
+
+/**
+ * Resolves a retry delay from a 429 response, checking `Retry-After`, the IETF
+ * draft `RateLimit` header, and the legacy `X-RateLimit-Reset` (epoch seconds).
+ */
+internal fun parseRetryAfter(
+  headers: Headers,
+  nowEpochSeconds: Long = Clock.System.now().epochSeconds,
+): Duration? {
+  headers[HttpHeaders.RetryAfter]?.toLongOrNull()?.let { return it.seconds }
+
+  headers["RateLimit"]?.let { value ->
+    RATE_LIMIT_RESET_REGEX.find(value)?.groupValues?.getOrNull(2)?.toLongOrNull()?.let { return it.seconds }
+  }
+
+  headers["X-RateLimit-Reset"]?.toLongOrNull()?.let { reset ->
+    // Some servers send epoch seconds, others send seconds-until-reset.
+    return if (reset > EPOCH_SECONDS_THRESHOLD) (reset - nowEpochSeconds).coerceAtLeast(0).seconds else reset.seconds
+  }
+
+  return null
+}
+
+private val RATE_LIMIT_RESET_REGEX = "\\b(reset|t)=(\\d+)".toRegex()
+private const val EPOCH_SECONDS_THRESHOLD = 1_000_000_000L

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverResult.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverResult.kt
@@ -1,0 +1,21 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.graphql
+
+import kotlin.time.Duration
+
+sealed interface HardcoverResult<out T> {
+  data class Success<T>(val data: T) : HardcoverResult<T>
+  data object NotLinked : HardcoverResult<Nothing>
+  data object TokenInvalid : HardcoverResult<Nothing>
+  data class RateLimited(val retryAfter: Duration?) : HardcoverResult<Nothing>
+  data class GraphQlErrors(val messages: List<String>) : HardcoverResult<Nothing>
+  data class NetworkFailure(val cause: Throwable) : HardcoverResult<Nothing>
+}
+
+class HardcoverGraphQlException(messages: List<String>) :
+  Exception("Hardcover GraphQL error: ${messages.joinToString()}")
+
+class HardcoverHttpException(val status: Int) :
+  Exception("Hardcover HTTP $status")

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/settings/PlatformHardcoverSettingsComponent.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/settings/PlatformHardcoverSettingsComponent.kt
@@ -1,0 +1,16 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.settings
+
+import app.campfire.core.di.AppScope
+import com.r0adkll.kimchi.annotations.ContributesTo
+
+/**
+ * Component to be implemented by platform configurations to provide the
+ * encrypted settings store for Hardcover credentials.
+ */
+expect interface PlatformHardcoverSettingsComponent
+
+@ContributesTo(AppScope::class)
+interface HardcoverSettingsComponent : PlatformHardcoverSettingsComponent

--- a/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/HardcoverBookInfoProviderTest.kt
+++ b/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/HardcoverBookInfoProviderTest.kt
@@ -1,0 +1,168 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover
+
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import app.campfire.bookinfo.hardcover.auth.HardcoverTokenStorage
+import app.campfire.bookinfo.hardcover.graphql.HardcoverGraphQl
+import app.campfire.common.test.coroutines.TestDispatcherProvider
+import app.campfire.common.test.user
+import app.campfire.core.session.UserSession
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import com.russhwolf.settings.MapSettings
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.content.TextContent
+import kotlin.test.Test
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+
+private const val BOOK_RESPONSE = """
+{"data": {"books": [{
+  "id": 386446,
+  "slug": "the-way-of-kings",
+  "rating": 4.63,
+  "ratings_count": 4109,
+  "reviews_count": 422,
+  "release_date": "2010-08-31",
+  "cached_image": {"url": "https://assets.hardcover.app/cover.jpg"}
+}]}}
+"""
+
+private const val REVIEWS_RESPONSE = """
+{"data": {"user_books": [
+  {
+    "rating": 5.0,
+    "review": "Loved it",
+    "review_has_spoilers": false,
+    "user": {
+      "username": "reader",
+      "name": "A Reader",
+      "flair": "Supporter",
+      "cached_image": {"url": "https://assets.hardcover.app/avatar.jpg"}
+    }
+  },
+  {
+    "rating": 4.0,
+    "review": "Solid",
+    "review_has_spoilers": true,
+    "user": {"username": "plain", "name": "", "flair": null, "cached_image": {}}
+  },
+  {
+    "rating": 3.0,
+    "review": "   ",
+    "review_has_spoilers": false,
+    "user": {"username": "empty"}
+  }
+]}}
+"""
+
+class HardcoverBookInfoProviderTest {
+
+  private val session: UserSession = UserSession.LoggedIn(user(id = "user-1"))
+  private val requests = mutableListOf<String>()
+
+  private suspend fun TestScope.provider(): HardcoverBookInfoProvider {
+    val storage = HardcoverTokenStorage(
+      hardcoverSettings = MapSettings(),
+      dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
+    )
+    storage.link("user-1", "token", "me")
+    val client = HttpClient(
+      MockEngine { request ->
+        val body = request.bodyText()
+        requests += body
+        when {
+          "BookReviews" in body -> respond(REVIEWS_RESPONSE)
+          else -> respond(BOOK_RESPONSE)
+        }
+      },
+    )
+    return HardcoverBookInfoProvider(
+      graphQl = HardcoverGraphQl(client, storage, session),
+      tokenStorage = storage,
+      userSession = session,
+    )
+  }
+
+  @Test
+  fun `book info maps rating fields and cover`() = runTest {
+    val result = provider().getBookInfo(BookMatch.Identifiers(isbn = "978-0-7653-9304-3", asin = null))
+
+    val info = (result as BookInfoResult.Success).data
+    assertThat(info.providerBookId).isEqualTo("386446")
+    assertThat(info.providerUrl).isEqualTo("https://hardcover.app/books/the-way-of-kings")
+    assertThat(info.rating).isEqualTo(4.63)
+    assertThat(info.coverUrl).isEqualTo("https://assets.hardcover.app/cover.jpg")
+    // ISBN is normalized before being sent as a query variable
+    assertThat(requests.single().contains("9780765393043")).isEqualTo(true)
+  }
+
+  @Test
+  fun `all available identifiers are sent in one lookup`() = runTest {
+    val result = provider().getBookInfo(
+      BookMatch.Identifiers(isbn = "9780765393043", asin = "B002RI9Z9E"),
+    )
+
+    assertThat(result is BookInfoResult.Success).isEqualTo(true)
+    val body = requests.single()
+    assertThat(body.contains("isbn_13")).isEqualTo(true)
+    assertThat(body.contains("{asin: {_eq: \$asin}}")).isEqualTo(true)
+    assertThat(body.contains("B002RI9Z9E")).isEqualTo(true)
+  }
+
+  @Test
+  fun `asin only lookups omit the isbn predicate`() = runTest {
+    provider().getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B002RI9Z9E"))
+
+    val body = requests.single()
+    assertThat(body.contains("isbn_13")).isEqualTo(false)
+    assertThat(body.contains("{asin: {_eq: \$asin}}")).isEqualTo(true)
+  }
+
+  @Test
+  fun `reviews map reviewer name, avatar, and badge`() = runTest {
+    val provider = provider()
+
+    val result = provider.getReviews(BookMatch.Identifiers(isbn = "9780765393043", asin = null))
+
+    val reviews = (result as BookInfoResult.Success).data
+    assertThat(reviews.size).isEqualTo(2)
+
+    val rich = reviews[0]
+    assertThat(rich.author).isEqualTo("A Reader")
+    assertThat(rich.avatarUrl).isEqualTo("https://assets.hardcover.app/avatar.jpg")
+    assertThat(rich.badge).isEqualTo("Supporter")
+    assertThat(rich.hasSpoilers).isEqualTo(false)
+
+    // Blank display name falls back to username; empty image blob and null
+    // flair map to nulls.
+    val plain = reviews[1]
+    assertThat(plain.author).isEqualTo("plain")
+    assertThat(plain.avatarUrl).isNull()
+    assertThat(plain.badge).isNull()
+    assertThat(plain.hasSpoilers).isEqualTo(true)
+  }
+
+  @Test
+  fun `resolving reviews after book info reuses the matched id`() = runTest {
+    val provider = provider()
+    val match = BookMatch.Identifiers(isbn = "9780765393043", asin = null)
+
+    provider.getBookInfo(match)
+    provider.getReviews(match)
+
+    // One book lookup + one reviews call — no second book resolution.
+    assertThat(requests.size).isEqualTo(2)
+    assertThat(requests.count { "BookReviews" in it }).isEqualTo(1)
+  }
+}
+
+private fun HttpRequestData.bodyText(): String = (body as TextContent).text

--- a/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/HardcoverGraphQlTest.kt
+++ b/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/HardcoverGraphQlTest.kt
@@ -1,0 +1,146 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover
+
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.hardcover.auth.HardcoverTokenStorage
+import app.campfire.bookinfo.hardcover.graphql.BooksData
+import app.campfire.bookinfo.hardcover.graphql.HardcoverGraphQl
+import app.campfire.bookinfo.hardcover.graphql.HardcoverResult
+import app.campfire.common.test.coroutines.TestDispatcherProvider
+import app.campfire.common.test.user
+import app.campfire.core.session.UserSession
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
+import com.russhwolf.settings.MapSettings
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class HardcoverGraphQlTest {
+
+  private val settings = MapSettings()
+  private val session: UserSession = UserSession.LoggedIn(user(id = "user-1"))
+
+  private fun graphQl(
+    scheduler: kotlinx.coroutines.test.TestCoroutineScheduler,
+    handler: MockRequestHandleScope.() -> io.ktor.client.request.HttpResponseData,
+  ): Pair<HardcoverGraphQl, HardcoverTokenStorage> {
+    val storage = HardcoverTokenStorage(
+      hardcoverSettings = settings,
+      dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(scheduler)),
+    )
+    val client = HttpClient(MockEngine { handler() })
+    return HardcoverGraphQl(client, storage, session) to storage
+  }
+
+  @Test
+  fun `missing token short circuits to not linked without a request`() = runTest {
+    var requested = false
+    val (graphQl, _) = graphQl(testScheduler) {
+      requested = true
+      respond("{}")
+    }
+
+    val result = graphQl.execute("query {}", deserializer = BooksData.serializer())
+
+    assertThat(result).isEqualTo(HardcoverResult.NotLinked)
+    assertThat(requested).isEqualTo(false)
+  }
+
+  @Test
+  fun `successful envelope decodes the data element`() = runTest {
+    val (graphQl, storage) = graphQl(testScheduler) {
+      respond(
+        """{"data": {"books": [{"id": 386446, "slug": "the-way-of-kings", "rating": 4.63, "ratings_count": 4109}]}}""",
+      )
+    }
+    storage.link("user-1", "token", "reader")
+
+    val result = graphQl.execute("query {}", deserializer = BooksData.serializer())
+
+    val success = result as HardcoverResult.Success
+    assertThat(success.data.books.single().id).isEqualTo(386446L)
+    assertThat(success.data.books.single().rating).isNotNull()
+  }
+
+  @Test
+  fun `graphql errors with http 200 are surfaced as errors`() = runTest {
+    val (graphQl, storage) = graphQl(testScheduler) {
+      respond("""{"errors": [{"message": "field 'nope' not found"}], "data": null}""")
+    }
+    storage.link("user-1", "token", null)
+
+    val result = graphQl.execute("query {}", deserializer = BooksData.serializer())
+
+    val errors = result as HardcoverResult.GraphQlErrors
+    assertThat(errors.messages).isEqualTo(listOf("field 'nope' not found"))
+  }
+
+  @Test
+  fun `unauthorized marks the stored token invalid`() = runTest {
+    val (graphQl, storage) = graphQl(testScheduler) {
+      respond("", HttpStatusCode.Unauthorized)
+    }
+    storage.link("user-1", "token", null)
+
+    val result = graphQl.execute("query {}", deserializer = BooksData.serializer())
+
+    assertThat(result).isEqualTo(HardcoverResult.TokenInvalid)
+    assertThat(storage.observeLinkState("user-1").first()).isEqualTo(ProviderLinkState.Invalid)
+  }
+
+  @Test
+  fun `too many requests carries the retry delay`() = runTest {
+    val (graphQl, storage) = graphQl(testScheduler) {
+      respond("", HttpStatusCode.TooManyRequests, headersOf("Retry-After", "42"))
+    }
+    storage.link("user-1", "token", null)
+
+    val result = graphQl.execute("query {}", deserializer = BooksData.serializer())
+
+    assertThat(result).isEqualTo(HardcoverResult.RateLimited(42.seconds))
+  }
+
+  @Test
+  fun `network failures are wrapped`() = runTest {
+    val (graphQl, storage) = graphQl(testScheduler) {
+      respond("oops", HttpStatusCode.InternalServerError)
+    }
+    storage.link("user-1", "token", null)
+
+    val result = graphQl.execute("query {}", deserializer = BooksData.serializer())
+
+    assertThat(result).isInstanceOf(HardcoverResult.NetworkFailure::class)
+  }
+
+  @Test
+  fun `relinking clears the invalid state`() = runTest {
+    val (_, storage) = graphQl(testScheduler) { respond("") }
+    storage.link("user-1", "token", null)
+    storage.markInvalid("user-1")
+    assertThat(storage.observeLinkState("user-1").first()).isEqualTo(ProviderLinkState.Invalid)
+
+    storage.link("user-1", "fresh-token", "reader")
+
+    assertThat(storage.observeLinkState("user-1").first())
+      .isEqualTo(ProviderLinkState.Linked("reader"))
+    assertThat(storage.getToken("user-1")).isEqualTo("fresh-token")
+
+    storage.unlink("user-1")
+    assertThat(storage.observeLinkState("user-1").first()).isEqualTo(ProviderLinkState.NotLinked)
+    assertThat(storage.getToken("user-1") == null).isTrue()
+  }
+}

--- a/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/HardcoverParsersTest.kt
+++ b/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/HardcoverParsersTest.kt
@@ -1,0 +1,86 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover
+
+import app.campfire.bookinfo.hardcover.graphql.parseCoverUrl
+import app.campfire.bookinfo.hardcover.graphql.parseRatingsDistribution
+import app.campfire.bookinfo.hardcover.graphql.parseRetryAfter
+import app.campfire.bookinfo.hardcover.graphql.parseUsername
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import io.ktor.http.headersOf
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+
+class HardcoverParsersTest {
+
+  @Test
+  fun `retry after header is used directly`() {
+    val headers = headersOf("Retry-After", "30")
+
+    assertThat(parseRetryAfter(headers)).isEqualTo(30.seconds)
+  }
+
+  @Test
+  fun `ietf ratelimit header reset is parsed`() {
+    val headers = headersOf("RateLimit", "limit=60, remaining=0, reset=25")
+
+    assertThat(parseRetryAfter(headers)).isEqualTo(25.seconds)
+  }
+
+  @Test
+  fun `legacy epoch reset header is converted to a delay`() {
+    val headers = headersOf("X-RateLimit-Reset", "1700000060")
+
+    assertThat(parseRetryAfter(headers, nowEpochSeconds = 1_700_000_000)).isEqualTo(60.seconds)
+  }
+
+  @Test
+  fun `legacy relative reset header is used as seconds`() {
+    val headers = headersOf("X-RateLimit-Reset", "45")
+
+    assertThat(parseRetryAfter(headers, nowEpochSeconds = 1_700_000_000)).isEqualTo(45.seconds)
+  }
+
+  @Test
+  fun `no known headers yields null`() {
+    assertThat(parseRetryAfter(headersOf())).isNull()
+  }
+
+  @Test
+  fun `ratings distribution object form is parsed`() {
+    val element = Json.parseToJsonElement("""{"1": 4, "2": 10, "5": 900}""")
+
+    assertThat(parseRatingsDistribution(element)).isEqualTo(mapOf(1 to 4, 2 to 10, 5 to 900))
+  }
+
+  @Test
+  fun `ratings distribution array form is parsed`() {
+    val element = Json.parseToJsonElement("""[{"rating": 1, "count": 4}, {"rating": 5, "count": 900}]""")
+
+    assertThat(parseRatingsDistribution(element)).isEqualTo(mapOf(1 to 4, 5 to 900))
+  }
+
+  @Test
+  fun `unknown ratings distribution shape yields null`() {
+    assertThat(parseRatingsDistribution(Json.parseToJsonElement(""""oops""""))).isNull()
+    assertThat(parseRatingsDistribution(null)).isNull()
+  }
+
+  @Test
+  fun `cover url is read from cached image blob`() {
+    val element = Json.parseToJsonElement("""{"url": "https://assets.hardcover.app/cover.jpg", "color": "#fff"}""")
+
+    assertThat(parseCoverUrl(element)).isEqualTo("https://assets.hardcover.app/cover.jpg")
+  }
+
+  @Test
+  fun `username is parsed from object and array forms`() {
+    assertThat(parseUsername(Json.parseToJsonElement("""{"username": "reader"}"""))).isEqualTo("reader")
+    assertThat(parseUsername(Json.parseToJsonElement("""[{"username": "reader"}]"""))).isEqualTo("reader")
+    assertThat(parseUsername(null)).isNull()
+  }
+}

--- a/data/bookinfo/hardcover/src/jvmMain/kotlin/app/campfire/bookinfo/hardcover/settings/PlatformHardcoverSettingsComponent.jvm.kt
+++ b/data/bookinfo/hardcover/src/jvmMain/kotlin/app/campfire/bookinfo/hardcover/settings/PlatformHardcoverSettingsComponent.jvm.kt
@@ -1,0 +1,22 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.settings
+
+import app.campfire.bookinfo.hardcover.di.HardcoverSettings
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import com.russhwolf.settings.PreferencesSettings
+import com.russhwolf.settings.Settings
+import java.util.prefs.Preferences
+import me.tatarka.inject.annotations.Provides
+
+actual interface PlatformHardcoverSettingsComponent {
+
+  @SingleIn(AppScope::class)
+  @Provides
+  @HardcoverSettings
+  fun provideHardcoverSettings(delegate: Preferences): Settings {
+    return PreferencesSettings(delegate)
+  }
+}

--- a/data/bookinfo/hardcover/src/nativeMain/kotlin/app/campfire/bookinfo/hardcover/settings/PlatformHardcoverSettingsComponent.native.kt
+++ b/data/bookinfo/hardcover/src/nativeMain/kotlin/app/campfire/bookinfo/hardcover/settings/PlatformHardcoverSettingsComponent.native.kt
@@ -1,0 +1,21 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.settings
+
+import app.campfire.bookinfo.hardcover.di.HardcoverSettings
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import com.russhwolf.settings.ExperimentalSettingsImplementation
+import com.russhwolf.settings.KeychainSettings
+import com.russhwolf.settings.Settings
+import me.tatarka.inject.annotations.Provides
+
+actual interface PlatformHardcoverSettingsComponent {
+
+  @OptIn(ExperimentalSettingsImplementation::class)
+  @SingleIn(AppScope::class)
+  @Provides
+  @HardcoverSettings
+  fun provideHardcoverSettings(): Settings = KeychainSettings("app.campfire.app.hardcover")
+}

--- a/data/bookinfo/impl/build.gradle.kts
+++ b/data/bookinfo/impl/build.gradle.kts
@@ -1,0 +1,71 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import app.campfire.convention.addKspDependencyForCommon
+
+plugins {
+  id("app.campfire.android.library")
+  id("app.campfire.multiplatform")
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.sqldelight)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+  sqldelight {
+    databases {
+      create("BookInfoDatabase") {
+        packageName.set("app.campfire.bookinfo.db")
+        generateAsync.set(true)
+      }
+    }
+    linkSqlite.set(true)
+  }
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.data.bookinfo.api)
+
+        implementation(projects.core)
+        implementation(libs.kotlinx.serialization.json)
+        implementation(libs.multiplatformsettings.core)
+        implementation(libs.multiplatformsettings.coroutines)
+        implementation(libs.sqldelight.coroutines)
+        implementation(libs.sqldelight.async)
+        implementation(libs.store)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(projects.common.test)
+        implementation(projects.data.bookinfo.test)
+        implementation(libs.bundles.test.common)
+        implementation(libs.bundles.test.impl)
+        implementation(libs.multiplatformsettings.test)
+      }
+    }
+
+    androidMain {
+      dependencies {
+        implementation(libs.sqldelight.android)
+      }
+    }
+
+    jvmMain {
+      dependencies {
+        implementation(libs.sqldelight.sqlite)
+      }
+    }
+
+    nativeMain {
+      dependencies {
+        implementation(libs.sqldelight.native)
+      }
+    }
+  }
+}
+
+addKspDependencyForCommon(libs.kimchi.compiler)

--- a/data/bookinfo/impl/src/androidMain/kotlin/app/campfire/bookinfo/db/BookInfoDatabaseComponent.android.kt
+++ b/data/bookinfo/impl/src/androidMain/kotlin/app/campfire/bookinfo/db/BookInfoDatabaseComponent.android.kt
@@ -1,0 +1,31 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.db
+
+import android.app.Application
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import me.tatarka.inject.annotations.Provides
+
+actual interface BookInfoDatabasePlatformComponent {
+
+  @SingleIn(AppScope::class)
+  @Provides
+  fun provideBookInfoDatabase(
+    application: Application,
+  ): BookInfoDatabase {
+    application.databaseList()
+      .filter { it.startsWith(BookInfoDatabaseFilePrefix) && !it.startsWith(BookInfoDatabaseFileName) }
+      .forEach { application.deleteDatabase(it) }
+
+    val driver = AndroidSqliteDriver(
+      schema = BookInfoDatabase.Schema.synchronous(),
+      context = application,
+      name = BookInfoDatabaseFileName,
+    )
+    return BookInfoDatabase(driver)
+  }
+}

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoProviderSettings.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoProviderSettings.kt
@@ -1,0 +1,43 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo
+
+import app.campfire.bookinfo.api.BookInfoProviderSettings
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import app.campfire.core.session.UserSession
+import app.campfire.core.session.userId
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.ObservableSettings
+import com.russhwolf.settings.coroutines.getBooleanFlow
+import kotlinx.coroutines.flow.Flow
+import me.tatarka.inject.annotations.Inject
+
+@OptIn(ExperimentalSettingsApi::class)
+@SingleIn(UserScope::class)
+@ContributesBinding(UserScope::class)
+@Inject
+class DefaultBookInfoProviderSettings(
+  private val settings: ObservableSettings,
+  private val userSession: UserSession,
+) : BookInfoProviderSettings {
+
+  override fun isEnabled(id: ProviderId): Boolean {
+    return settings.getBoolean(key(id), defaultValue = true)
+  }
+
+  override fun setEnabled(id: ProviderId, enabled: Boolean) {
+    settings.putBoolean(key(id), enabled)
+  }
+
+  override fun observeEnabled(id: ProviderId): Flow<Boolean> {
+    return settings.getBooleanFlow(key(id), defaultValue = true)
+  }
+
+  private fun key(id: ProviderId): String {
+    return "bookinfo_enabled_${id.key}_${userSession.userId.orEmpty()}"
+  }
+}

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -1,0 +1,148 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo
+
+import app.campfire.bookinfo.api.BookInfoProvider
+import app.campfire.bookinfo.api.BookInfoProviderSettings
+import app.campfire.bookinfo.api.BookInfoRegistry
+import app.campfire.bookinfo.api.CommunityInfoState
+import app.campfire.bookinfo.api.CommunitySource
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.api.ProviderStatus
+import app.campfire.bookinfo.api.bestMatch
+import app.campfire.bookinfo.store.BookInfoStore
+import app.campfire.bookinfo.store.CachedBookInfo
+import app.campfire.bookinfo.store.isStale
+import app.campfire.core.coroutines.LoadState
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import app.campfire.core.model.LibraryItem
+import app.campfire.core.session.UserSession
+import app.campfire.core.session.userId
+import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlin.time.Clock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import me.tatarka.inject.annotations.Inject
+import org.mobilenativefoundation.store.store5.StoreReadResponse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@SingleIn(UserScope::class)
+@ContributesBinding(UserScope::class)
+@Inject
+class DefaultBookInfoRegistry(
+  private val providers: Set<BookInfoProvider>,
+  private val settings: BookInfoProviderSettings,
+  private val store: BookInfoStore,
+  private val userSession: UserSession,
+) : BookInfoRegistry {
+
+  override fun observeProviders(): Flow<List<ProviderStatus>> {
+    if (providers.isEmpty()) return flowOf(emptyList())
+    val statusFlows = providers
+      .sortedBy { it.id.ordinal }
+      .map { provider ->
+        combine(settings.observeEnabled(provider.id), provider.observeLinkState()) { enabled, linkState ->
+          ProviderStatus(provider, enabled, linkState)
+        }
+      }
+    return combine(statusFlows) { it.toList() }
+  }
+
+  override fun observeCommunityInfo(
+    item: LibraryItem,
+    preferredProvider: ProviderId?,
+  ): Flow<LoadState<out CommunityInfoState?>> {
+    val userId = userSession.userId ?: return flowOf(LoadState.Loaded(null))
+    val match = item.bestMatch() ?: return flowOf(LoadState.Loaded(null))
+
+    return observeProviders()
+      .map { statuses -> statuses.filter { it.canServeBookInfo } }
+      .distinctUntilChanged { old, new ->
+        old.map { it.provider.id to it.linkState } == new.map { it.provider.id to it.linkState }
+      }
+      .flatMapLatest { usable ->
+        val status = usable.firstOrNull { it.provider.id == preferredProvider }
+          ?: usable.firstOrNull()
+        if (status == null) {
+          flowOf(LoadState.Loaded(null))
+        } else {
+          streamFromStore(
+            status = status,
+            key = BookInfoStore.Key(userId, status.provider.id, item.id, match),
+            sources = usable.map { CommunitySource(it.provider.id, it.provider.displayName) },
+          )
+        }
+      }
+  }
+
+  override suspend fun clearCache() {
+    store.clearAll()
+  }
+
+  private fun streamFromStore(
+    status: ProviderStatus,
+    key: BookInfoStore.Key,
+    sources: List<CommunitySource>,
+  ): Flow<LoadState<out CommunityInfoState?>> = flow {
+    val cached = store.cached(key)
+    val invalidLink = status.linkState is ProviderLinkState.Invalid
+
+    // A rejected token means fetches would just 401; serve whatever is cached.
+    if (invalidLink && cached == null) {
+      emit(LoadState.Loaded(null))
+      return@flow
+    }
+
+    val refresh = !invalidLink &&
+      (
+        cached == null ||
+          cached.isStale(
+            nowMillis = Clock.System.now().toEpochMilliseconds(),
+            currentMatchKey = key.match.cacheKey,
+          )
+        )
+
+    var emittedData = false
+    store.stream(key, refresh = refresh).collect { response ->
+      when (response) {
+        is StoreReadResponse.Loading -> if (!emittedData) emit(LoadState.Loading)
+        is StoreReadResponse.Data -> {
+          emittedData = true
+          emit(LoadState.Loaded(response.value.toState(status, sources)))
+        }
+        is StoreReadResponse.Error -> if (!emittedData) emit(LoadState.Loaded(null))
+        else -> Unit
+      }
+    }
+  }
+
+  private fun CachedBookInfo.toState(
+    status: ProviderStatus,
+    sources: List<CommunitySource>,
+  ): CommunityInfoState? {
+    val info = info ?: return null
+    return CommunityInfoState(
+      providerId = status.provider.id,
+      providerName = status.provider.displayName,
+      providerUrl = info.providerUrl,
+      info = info,
+      reviews = reviews,
+      needsRelink = status.linkState is ProviderLinkState.Invalid,
+      availableSources = sources,
+    )
+  }
+
+  private val ProviderStatus.canServeBookInfo: Boolean
+    get() = enabled &&
+      provider.capabilities.hasAggregateRating &&
+      linkState !is ProviderLinkState.NotLinked
+}

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/db/BookInfoDatabaseComponent.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/db/BookInfoDatabaseComponent.kt
@@ -1,0 +1,24 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.db
+
+import app.campfire.core.di.AppScope
+import com.r0adkll.kimchi.annotations.ContributesTo
+
+/**
+ * Platform components provide the [BookInfoDatabase] directly. This database is
+ * a disposable third-party cache with a destructive migration strategy: the
+ * database file name is versioned by the schema version, so any schema change
+ * lands in a fresh file and stale files are cleaned up opportunistically —
+ * there are no .sqm migrations to maintain.
+ */
+expect interface BookInfoDatabasePlatformComponent
+
+@ContributesTo(AppScope::class)
+interface BookInfoDatabaseComponent : BookInfoDatabasePlatformComponent
+
+internal val BookInfoDatabaseFileName: String
+  get() = "bookinfo_v${BookInfoDatabase.Schema.version}.db"
+
+internal const val BookInfoDatabaseFilePrefix = "bookinfo_v"

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/BookInfoStore.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/BookInfoStore.kt
@@ -1,0 +1,151 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.store
+
+import app.campfire.bookinfo.api.BookInfoProvider
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.db.BookInfoDatabase
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import app.campfire.core.model.LibraryItemId
+import app.campfire.core.model.UserId
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import kotlin.time.Clock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import me.tatarka.inject.annotations.Inject
+import org.mobilenativefoundation.store.store5.Fetcher
+import org.mobilenativefoundation.store.store5.FetcherResult
+import org.mobilenativefoundation.store.store5.SourceOfTruth
+import org.mobilenativefoundation.store.store5.Store
+import org.mobilenativefoundation.store.store5.StoreBuilder
+import org.mobilenativefoundation.store.store5.StoreReadRequest
+import org.mobilenativefoundation.store.store5.StoreReadResponse
+
+class BookInfoNotLinkedException : Exception("Provider is not linked")
+class BookInfoTokenInvalidException : Exception("Provider token was rejected")
+class BookInfoRateLimitedException : Exception("Provider rate limit reached")
+
+/**
+ * Store5 pipeline for [CachedBookInfo]: fetches from the keyed provider and
+ * persists in the bookinfo cache database. Callers decide refresh policy via
+ * [stream]'s `refresh` flag (see [isStale]); everything read serves from the
+ * source of truth first, which is what keeps Campfire inside provider rate
+ * limits.
+ */
+@SingleIn(UserScope::class)
+@Inject
+class BookInfoStore(
+  private val providers: Set<BookInfoProvider>,
+  private val db: BookInfoDatabase,
+  private val dispatcherProvider: DispatcherProvider,
+) {
+
+  data class Key(
+    val userId: UserId,
+    val providerId: ProviderId,
+    val libraryItemId: LibraryItemId,
+    val match: BookMatch,
+  )
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private val store: Store<Key, CachedBookInfo> = StoreBuilder.from(
+    fetcher = Fetcher.ofResult { key: Key -> fetch(key) },
+    sourceOfTruth = SourceOfTruth.of<Key, CachedBookInfo, CachedBookInfo>(
+      reader = { key ->
+        db.bookInfoCacheQueries
+          .select(key.userId, key.providerId.key, key.libraryItemId)
+          .asFlow()
+          .mapToOneOrNull(dispatcherProvider.io)
+          .map { row -> row?.let { decode(it.payload) } }
+      },
+      writer = { key, value ->
+        db.bookInfoCacheQueries.upsert(
+          userId = key.userId,
+          providerId = key.providerId.key,
+          libraryItemId = key.libraryItemId,
+          payload = json.encodeToString(CachedBookInfo.serializer(), value),
+          fetchedAt = value.fetchedAt,
+        )
+      },
+      delete = { key ->
+        db.bookInfoCacheQueries.delete(key.userId, key.providerId.key, key.libraryItemId)
+      },
+      deleteAll = {
+        db.bookInfoCacheQueries.deleteAll()
+      },
+    ),
+  ).build()
+
+  fun stream(key: Key, refresh: Boolean): Flow<StoreReadResponse<CachedBookInfo>> {
+    return store.stream(StoreReadRequest.cached(key, refresh = refresh))
+  }
+
+  suspend fun clearAll() {
+    store.clear()
+  }
+
+  suspend fun cached(key: Key): CachedBookInfo? {
+    return db.bookInfoCacheQueries
+      .select(key.userId, key.providerId.key, key.libraryItemId)
+      .awaitAsOneOrNull()
+      ?.let { decode(it.payload) }
+  }
+
+  private suspend fun fetch(key: Key): FetcherResult<CachedBookInfo> {
+    val provider = providers.firstOrNull { it.id == key.providerId }
+      ?: return FetcherResult.Error.Message("No provider installed for ${key.providerId.key}")
+
+    return when (val result = provider.getBookInfo(key.match)) {
+      is BookInfoResult.Success -> {
+        val reviews = if (provider.capabilities.hasReviewText) {
+          (provider.getReviews(key.match) as? BookInfoResult.Success)?.data.orEmpty()
+        } else {
+          emptyList()
+        }
+        FetcherResult.Data(
+          CachedBookInfo(
+            info = result.data,
+            reviews = reviews,
+            fetchedAt = nowMillis(),
+            matchKey = key.match.cacheKey,
+          ),
+        )
+      }
+
+      // Cache the miss so unknown books aren't re-queried on every screen open
+      // (short TTL — see CachedBookInfo).
+      is BookInfoResult.NotFound -> FetcherResult.Data(
+        CachedBookInfo(
+          info = null,
+          reviews = emptyList(),
+          fetchedAt = nowMillis(),
+          matchKey = key.match.cacheKey,
+        ),
+      )
+
+      is BookInfoResult.NotLinked -> FetcherResult.Error.Exception(BookInfoNotLinkedException())
+      is BookInfoResult.TokenInvalid -> FetcherResult.Error.Exception(BookInfoTokenInvalidException())
+      is BookInfoResult.RateLimited -> FetcherResult.Error.Exception(BookInfoRateLimitedException())
+      is BookInfoResult.Failure -> FetcherResult.Error.Exception(result.cause)
+    }
+  }
+
+  private fun decode(payload: String): CachedBookInfo? {
+    return try {
+      json.decodeFromString(CachedBookInfo.serializer(), payload)
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  private fun nowMillis(): Long = Clock.System.now().toEpochMilliseconds()
+}

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/CachedBookInfo.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/CachedBookInfo.kt
@@ -1,0 +1,38 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.store
+
+import app.campfire.bookinfo.api.BookCommunityInfo
+import app.campfire.bookinfo.api.BookReview
+import kotlin.time.Duration.Companion.hours
+import kotlinx.serialization.Serializable
+
+/**
+ * The cached unit for one (user, provider, library item). A null [info] is a
+ * cached "provider has no record of this book" so misses aren't re-fetched on
+ * every screen open — misses use a much shorter TTL than hits, since the item
+ * may be matchable later (identifier coverage on providers improves over time).
+ *
+ * [matchKey] records which identifiers produced this row (see
+ * [app.campfire.bookinfo.api.BookMatch.cacheKey]); a row fetched with different
+ * identifiers than the item currently carries is treated as stale immediately,
+ * so editing ISBN/ASIN metadata on the server takes effect without waiting out
+ * the TTL. Rows cached before this field existed decode as null and refetch.
+ */
+@Serializable
+data class CachedBookInfo(
+  val info: BookCommunityInfo? = null,
+  val reviews: List<BookReview> = emptyList(),
+  val fetchedAt: Long,
+  val matchKey: String? = null,
+)
+
+internal val BOOK_INFO_CACHE_TTL = 24.hours
+internal val BOOK_INFO_MISS_TTL = 1.hours
+
+internal fun CachedBookInfo.isStale(nowMillis: Long, currentMatchKey: String): Boolean {
+  if (matchKey != currentMatchKey) return true
+  val ttl = if (info == null) BOOK_INFO_MISS_TTL else BOOK_INFO_CACHE_TTL
+  return nowMillis - fetchedAt > ttl.inWholeMilliseconds
+}

--- a/data/bookinfo/impl/src/commonMain/sqldelight/app/campfire/bookinfo/db/bookInfoCache.sq
+++ b/data/bookinfo/impl/src/commonMain/sqldelight/app/campfire/bookinfo/db/bookInfoCache.sq
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS bookInfoCache (
+  userId TEXT NOT NULL,
+  providerId TEXT NOT NULL,
+  libraryItemId TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  fetchedAt INTEGER NOT NULL,
+  PRIMARY KEY (userId, providerId, libraryItemId)
+);
+
+select:
+SELECT * FROM bookInfoCache
+WHERE userId = :userId AND providerId = :providerId AND libraryItemId = :libraryItemId;
+
+upsert:
+INSERT OR REPLACE INTO bookInfoCache(userId, providerId, libraryItemId, payload, fetchedAt)
+VALUES (:userId, :providerId, :libraryItemId, :payload, :fetchedAt);
+
+delete:
+DELETE FROM bookInfoCache
+WHERE userId = :userId AND providerId = :providerId AND libraryItemId = :libraryItemId;
+
+deleteAll:
+DELETE FROM bookInfoCache;

--- a/data/bookinfo/impl/src/commonTest/kotlin/app/campfire/bookinfo/CachedBookInfoTest.kt
+++ b/data/bookinfo/impl/src/commonTest/kotlin/app/campfire/bookinfo/CachedBookInfoTest.kt
@@ -1,0 +1,67 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo
+
+import app.campfire.bookinfo.api.BookCommunityInfo
+import app.campfire.bookinfo.store.CachedBookInfo
+import app.campfire.bookinfo.store.isStale
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+class CachedBookInfoTest {
+
+  private val now = 1_700_000_000_000L
+  private val matchKey = "isbn:9780765393043;asin:"
+
+  private val hitInfo = BookCommunityInfo(
+    providerBookId = "386446",
+    providerUrl = null,
+    rating = 4.63,
+    ratingsCount = 4109,
+    ratingsDistribution = null,
+    reviewsCount = 422,
+    releaseDate = null,
+    coverUrl = null,
+  )
+
+  private fun hit(fetchedAt: Long, key: String = matchKey) =
+    CachedBookInfo(info = hitInfo, fetchedAt = fetchedAt, matchKey = key)
+
+  private fun miss(fetchedAt: Long, key: String = matchKey) =
+    CachedBookInfo(info = null, fetchedAt = fetchedAt, matchKey = key)
+
+  @Test
+  fun `fresh hits are not stale`() {
+    assertThat(hit(now - 23.hours.inWholeMilliseconds).isStale(now, matchKey)).isFalse()
+  }
+
+  @Test
+  fun `hits older than the ttl are stale`() {
+    assertThat(hit(now - 25.hours.inWholeMilliseconds).isStale(now, matchKey)).isTrue()
+  }
+
+  @Test
+  fun `misses expire on the short ttl`() {
+    assertThat(miss(now - 30.minutes.inWholeMilliseconds).isStale(now, matchKey)).isFalse()
+    assertThat(miss(now - 2.hours.inWholeMilliseconds).isStale(now, matchKey)).isTrue()
+  }
+
+  @Test
+  fun `changed identifiers make even a fresh row stale`() {
+    val fresh = hit(now, key = "isbn:;asin:B002RI9Z9E")
+
+    assertThat(fresh.isStale(now, currentMatchKey = matchKey)).isTrue()
+  }
+
+  @Test
+  fun `rows cached before match keys existed are stale`() {
+    val legacy = CachedBookInfo(info = hitInfo, fetchedAt = now, matchKey = null)
+
+    assertThat(legacy.isStale(now, currentMatchKey = matchKey)).isTrue()
+  }
+}

--- a/data/bookinfo/impl/src/jvmMain/kotlin/app/campfire/bookinfo/db/BookInfoDatabaseComponent.jvm.kt
+++ b/data/bookinfo/impl/src/jvmMain/kotlin/app/campfire/bookinfo/db/BookInfoDatabaseComponent.jvm.kt
@@ -1,0 +1,35 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.db
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import java.io.File
+import me.tatarka.inject.annotations.Provides
+
+actual interface BookInfoDatabasePlatformComponent {
+
+  @SingleIn(AppScope::class)
+  @Provides
+  fun provideBookInfoDatabase(): BookInfoDatabase {
+    val userRoot = System.getProperty(
+      "java.util.prefs.userRoot",
+      System.getProperty("user.home"),
+    )
+    val appDir = File(File(userRoot), ".config/Campfire").apply { mkdirs() }
+
+    appDir.listFiles()
+      ?.filter { it.name.startsWith(BookInfoDatabaseFilePrefix) && !it.name.startsWith(BookInfoDatabaseFileName) }
+      ?.forEach { it.delete() }
+
+    val databaseFile = File(appDir, BookInfoDatabaseFileName)
+    val driver = JdbcSqliteDriver("jdbc:sqlite:${databaseFile.absolutePath}")
+    BookInfoDatabase.Schema
+      .synchronous()
+      .create(driver)
+    return BookInfoDatabase(driver)
+  }
+}

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -1,0 +1,240 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo
+
+import app.campfire.bookinfo.api.BookCommunityInfo
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.CommunitySource
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.db.BookInfoDatabase
+import app.campfire.bookinfo.store.BookInfoStore
+import app.campfire.bookinfo.test.FakeBookInfoProvider
+import app.campfire.common.test.coroutines.TestDispatcherProvider
+import app.campfire.common.test.user
+import app.campfire.core.coroutines.LoadState
+import app.campfire.core.session.UserSession
+import app.campfire.home.ui.libraryItem
+import app.campfire.home.ui.media
+import app.campfire.home.ui.mediaMetadata
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import com.russhwolf.settings.MapSettings
+import kotlin.test.Test
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+
+class DefaultBookInfoRegistryTest {
+
+  private val session: UserSession = UserSession.LoggedIn(user(id = "user-1"))
+  private val item = libraryItem()
+
+  private val communityInfo = BookCommunityInfo(
+    providerBookId = "386446",
+    providerUrl = "https://hardcover.app/books/the-way-of-kings",
+    rating = 4.63,
+    ratingsCount = 4109,
+    ratingsDistribution = mapOf(5 to 3000),
+    reviewsCount = 422,
+    releaseDate = "2010-08-31",
+    coverUrl = null,
+  )
+
+  private fun TestScope.registry(
+    provider: FakeBookInfoProvider,
+    settings: DefaultBookInfoProviderSettings = DefaultBookInfoProviderSettings(MapSettings(), session),
+  ): DefaultBookInfoRegistry {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    BookInfoDatabase.Schema.synchronous().create(driver)
+    val store = BookInfoStore(
+      providers = setOf(provider),
+      db = BookInfoDatabase(driver),
+      dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
+    )
+    return DefaultBookInfoRegistry(
+      providers = setOf(provider),
+      settings = settings,
+      store = store,
+      userSession = session,
+    )
+  }
+
+  @Test
+  fun `providers are reported with enablement and link state`() = runTest {
+    val provider = FakeBookInfoProvider()
+    val registry = registry(provider)
+
+    val statuses = registry.observeProviders().first()
+
+    assertThat(statuses.size).isEqualTo(1)
+    assertThat(statuses.single().enabled).isTrue()
+    assertThat(statuses.single().linkState).isEqualTo(ProviderLinkState.Linked(null))
+  }
+
+  @Test
+  fun `community info is loaded from a linked provider with attribution`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    val loaded = (state as LoadState.Loaded).data
+    assertThat(loaded).isNotNull()
+    assertThat(loaded!!.providerId).isEqualTo(ProviderId.Hardcover)
+    assertThat(loaded.providerName).isEqualTo("Fake Provider")
+    assertThat(loaded.info.rating).isEqualTo(4.63)
+    assertThat(provider.bookInfoRequests.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `a fresh cache is served without refetching`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    assertThat(provider.bookInfoRequests.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `an unlinked provider yields no community info`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.linkState.value = ProviderLinkState.NotLinked
+    val registry = registry(provider)
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    assertThat((state as LoadState.Loaded).data).isNull()
+  }
+
+  @Test
+  fun `a disabled provider yields no community info`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val settings = DefaultBookInfoProviderSettings(MapSettings(), session)
+    settings.setEnabled(ProviderId.Hardcover, false)
+    val registry = registry(provider, settings)
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    assertThat((state as LoadState.Loaded).data).isNull()
+    assertThat(provider.bookInfoRequests.size).isEqualTo(0)
+  }
+
+  @Test
+  fun `an invalid link serves cached data with a relink flag and no refetch`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    provider.linkState.value = ProviderLinkState.Invalid
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    val loaded = (state as LoadState.Loaded).data
+    assertThat(loaded).isNotNull()
+    assertThat(loaded!!.needsRelink).isTrue()
+    assertThat(provider.bookInfoRequests.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `community info carries the available sources`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    val loaded = (state as LoadState.Loaded).data
+    assertThat(loaded!!.availableSources)
+      .isEqualTo(listOf(CommunitySource(ProviderId.Hardcover, "Fake Provider")))
+  }
+
+  @Test
+  fun `a preferred provider is used when it can serve`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    val state = registry
+      .observeCommunityInfo(item, preferredProvider = ProviderId.Hardcover)
+      .first { it is LoadState.Loaded<*> }
+
+    assertThat((state as LoadState.Loaded).data!!.providerId).isEqualTo(ProviderId.Hardcover)
+  }
+
+  @Test
+  fun `an unusable preferred provider falls back to the automatic pick`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    val state = registry
+      .observeCommunityInfo(item, preferredProvider = ProviderId.OpenLibrary)
+      .first { it is LoadState.Loaded<*> }
+
+    assertThat((state as LoadState.Loaded).data!!.providerId).isEqualTo(ProviderId.Hardcover)
+  }
+
+  @Test
+  fun `changed item identifiers invalidate a fresh cache`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+    val asinOnly = libraryItem(
+      id = item.id,
+      media = media(metadata = mediaMetadata(ISBN = null, ASIN = "B002RI9Z9E")),
+    )
+    val withIsbn = libraryItem(
+      id = item.id,
+      media = media(metadata = mediaMetadata(ISBN = "9780765393043", ASIN = "B002RI9Z9E")),
+    )
+
+    registry.observeCommunityInfo(asinOnly).first { it is LoadState.Loaded<*> }
+    // The store serves the stale row first, then refetches with the new
+    // identifiers — wait for the refetch to land.
+    registry.observeCommunityInfo(withIsbn).first {
+      it is LoadState.Loaded<*> && provider.bookInfoRequests.size == 2
+    }
+
+    assertThat(provider.bookInfoRequests.size).isEqualTo(2)
+  }
+
+  @Test
+  fun `clearing the cache forces a refetch`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    registry.clearCache()
+    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    assertThat(provider.bookInfoRequests.size).isEqualTo(2)
+  }
+
+  @Test
+  fun `a provider miss is cached as no info`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.NotFound
+    val registry = registry(provider)
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    assertThat((state as LoadState.Loaded).data).isNull()
+    assertThat(provider.bookInfoRequests.size).isEqualTo(1)
+  }
+}

--- a/data/bookinfo/impl/src/nativeMain/kotlin/app/campfire/bookinfo/db/BookInfoDatabaseComponent.native.kt
+++ b/data/bookinfo/impl/src/nativeMain/kotlin/app/campfire/bookinfo/db/BookInfoDatabaseComponent.native.kt
@@ -1,0 +1,25 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.db
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import me.tatarka.inject.annotations.Provides
+
+actual interface BookInfoDatabasePlatformComponent {
+
+  @SingleIn(AppScope::class)
+  @Provides
+  fun provideBookInfoDatabase(): BookInfoDatabase {
+    // Stale versioned files from prior schema versions are left in place on
+    // native; they are tiny and the OS cleans caches under storage pressure.
+    val driver = NativeSqliteDriver(
+      schema = BookInfoDatabase.Schema.synchronous(),
+      name = BookInfoDatabaseFileName,
+    )
+    return BookInfoDatabase(driver)
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -144,6 +144,8 @@ include(
 )
 include(
   ":data:bookinfo:api",
+  ":data:bookinfo:hardcover",
+  ":data:bookinfo:impl",
   ":data:bookinfo:test",
 )
 include(


### PR DESCRIPTION
## Summary

Second in the bookinfo stack (on top of #1018). Implements the first `BookInfoProvider` and the registry/cache plumbing:

- **Hardcover GraphQL client**: hand-rolled over the `@BaseClient` Ktor stack (no Apollo). One lookup query `_or`s across every identifier the item carries (isbn_13/isbn_10/asin) since Hardcover's per-identifier edition coverage is uneven. Owns the `{data, errors}`-on-HTTP-200 unwrap, 401→token-invalid marking, and 429 retry-delay parsing across all three rate-limit header shapes
- **Per-user PAT auth**: encrypted storage per platform (EncryptedSharedPreferences / Keychain / Preferences), verify-before-save via a `me` query, invalid-token state for re-link UX. Tokens are read per request — never cached across a re-link
- **Cache**: separate `BookInfoDatabase` (schema-versioned file name = destructive migration, no .sqm ceremony for a disposable cache) behind a Store5 pipeline. Hits cache 24h, misses 1h, and rows are stamped with the identifiers that produced them — editing ISBN/ASIN on the server invalidates immediately
- **`DefaultBookInfoRegistry`**: selects providers by capability/enablement/link state with optional per-call source pinning, serves cached data during rate limiting or an invalid link, and exposes `clearCache()`

## Test plan
- `./gradlew :data:bookinfo:hardcover:jvmTest :data:bookinfo:impl:jvmTest` (executor envelope/auth/rate-limit handling, provider mapping incl. combined-identifier queries, registry selection matrix, TTLs, match-change invalidation)
- Verified the commit builds standalone (desktop DI graph compiles) in an isolated worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu