### PR TITLE
Show community ratings and reviews on the book detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Per-book playback speed — a toggle in the playback speed sheet saves a speed for just that book instead of changing the global speed
 - The five quick playback speed options can now be customized in Settings → Playback, with sliders from 0.5x to 3x and tap-to-type exact values
 - Sound equalizer on the playing screen (Android and desktop) with presets, 10-band adjustment, loudness and bass boost, and per-book profiles
+- Community ratings and reviews from Hardcover on the book detail page, with attribution and a tap-through to the book on Hardcover
 
 ### Changed
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/extensions/Double.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/extensions/Double.kt
@@ -1,0 +1,7 @@
+package app.campfire.common.compose.extensions
+
+import kotlin.math.roundToInt
+
+fun Double.roundToSingleDecimal(): String {
+  return ((this * 10).roundToInt() / 10.0).toString()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/extensions/Html.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/extensions/Html.kt
@@ -3,7 +3,11 @@
 
 package app.campfire.common.compose.extensions
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import app.campfire.core.extensions.fluentIf
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
 
 const val CampfireTimestampScheme = "campfire-timestamp:"
 
@@ -83,4 +87,19 @@ private inline fun String.replaceOutsideAnchors(transform: (String) -> String): 
     }
   }
   return builder.toString()
+}
+
+@Composable
+fun rememberHtmlRichTextState(
+  html: String,
+  linkify: Boolean = true,
+  transformHtml: (String) -> String = { it },
+  block: suspend RichTextState.() -> Unit = {},
+): RichTextState {
+  val state = rememberRichTextState()
+  LaunchedEffect(html) {
+    state.setHtml(transformHtml(html.toRichTextHtml(linkify)))
+    state.block()
+  }
+  return state
 }

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/Hardcover.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/Hardcover.kt
@@ -1,0 +1,121 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val CampfireIcons.Hardcover: ImageVector
+  get() {
+    if (_Hardcover != null) {
+      return _Hardcover!!
+    }
+    _Hardcover = ImageVector.Builder(
+      name = "Hardcover",
+      defaultWidth = 40.dp,
+      defaultHeight = 40.dp,
+      viewportWidth = 40f,
+      viewportHeight = 40f,
+    ).apply {
+      path(fill = SolidColor(Color(0xFF4F46E5))) {
+        moveTo(12.889f, 32.598f)
+        curveTo(12.666f, 31.766f, 13.16f, 30.911f, 13.992f, 30.688f)
+        lineTo(30.297f, 26.319f)
+        curveTo(31.129f, 26.096f, 31.985f, 26.59f, 32.208f, 27.422f)
+        lineTo(32.874f, 29.909f)
+        curveTo(33.171f, 31.018f, 32.513f, 32.159f, 31.403f, 32.456f)
+        lineTo(18.111f, 36.018f)
+        curveTo(15.892f, 36.612f, 13.612f, 35.295f, 13.017f, 33.076f)
+        lineTo(12.889f, 32.598f)
+        close()
+      }
+      path(fill = SolidColor(Color(0xFF4F46E5))) {
+        moveTo(7.623f, 12.946f)
+        curveTo(7.051f, 10.812f, 8.318f, 8.619f, 10.452f, 8.047f)
+        lineTo(16.885f, 32.057f)
+        lineTo(13.021f, 33.092f)
+        lineTo(7.623f, 12.946f)
+        close()
+      }
+      path(fill = SolidColor(Color(0xFF4338CA))) {
+        moveTo(29.336f, 24.432f)
+        lineTo(31.268f, 23.914f)
+        lineTo(32.358f, 27.985f)
+        curveTo(32.644f, 29.052f, 32.011f, 30.149f, 30.944f, 30.434f)
+        lineTo(29.336f, 24.432f)
+        close()
+      }
+      path(fill = SolidColor(Color(0xFF6366F1))) {
+        moveTo(26.445f, 5.915f)
+        curveTo(26.147f, 4.805f, 25.007f, 4.147f, 23.897f, 4.444f)
+        lineTo(10.529f, 8.026f)
+        curveTo(9.419f, 8.324f, 8.761f, 9.464f, 9.058f, 10.573f)
+        lineTo(14.953f, 32.575f)
+        lineTo(22.646f, 30.514f)
+        curveTo(23.199f, 30.365f, 23.527f, 29.798f, 23.378f, 29.245f)
+        curveTo(23.23f, 28.692f, 23.558f, 28.125f, 24.111f, 27.976f)
+        lineTo(29.795f, 26.454f)
+        curveTo(30.904f, 26.156f, 31.563f, 25.016f, 31.265f, 23.906f)
+        lineTo(26.445f, 5.915f)
+        close()
+      }
+      path(fill = SolidColor(Color(0xFF312E81))) {
+        moveTo(21.095f, 11.281f)
+        curveTo(21.145f, 10.665f, 21.941f, 10.451f, 22.293f, 10.96f)
+        lineTo(22.442f, 11.176f)
+        curveTo(22.551f, 11.334f, 22.724f, 11.436f, 22.915f, 11.457f)
+        lineTo(23.237f, 11.49f)
+        curveTo(23.838f, 11.553f, 24.045f, 12.323f, 23.556f, 12.678f)
+        lineTo(23.294f, 12.868f)
+        curveTo(23.138f, 12.981f, 23.039f, 13.156f, 23.024f, 13.348f)
+        lineTo(23.003f, 13.61f)
+        curveTo(22.952f, 14.226f, 22.156f, 14.439f, 21.805f, 13.931f)
+        lineTo(21.655f, 13.715f)
+        curveTo(21.546f, 13.557f, 21.373f, 13.454f, 21.182f, 13.434f)
+        lineTo(20.86f, 13.401f)
+        curveTo(20.259f, 13.338f, 20.053f, 12.567f, 20.542f, 12.213f)
+        lineTo(20.804f, 12.022f)
+        curveTo(20.959f, 11.909f, 21.058f, 11.734f, 21.073f, 11.543f)
+        lineTo(21.095f, 11.281f)
+        close()
+      }
+      path(fill = SolidColor(Color(0xFF312E81))) {
+        moveTo(18.303f, 16.318f)
+        curveTo(18.353f, 15.701f, 19.149f, 15.488f, 19.501f, 15.997f)
+        lineTo(20.563f, 17.534f)
+        curveTo(20.673f, 17.692f, 20.846f, 17.794f, 21.037f, 17.814f)
+        lineTo(22.914f, 18.01f)
+        curveTo(23.514f, 18.073f, 23.721f, 18.844f, 23.232f, 19.198f)
+        lineTo(21.705f, 20.307f)
+        curveTo(21.549f, 20.42f, 21.451f, 20.595f, 21.435f, 20.786f)
+        lineTo(21.283f, 22.648f)
+        curveTo(21.233f, 23.265f, 20.437f, 23.478f, 20.085f, 22.969f)
+        lineTo(19.023f, 21.433f)
+        curveTo(18.914f, 21.275f, 18.741f, 21.172f, 18.55f, 21.152f)
+        lineTo(16.672f, 20.956f)
+        curveTo(16.072f, 20.893f, 15.865f, 20.123f, 16.354f, 19.768f)
+        lineTo(17.882f, 18.659f)
+        curveTo(18.037f, 18.547f, 18.136f, 18.372f, 18.151f, 18.18f)
+        lineTo(18.303f, 16.318f)
+        close()
+      }
+      path(fill = SolidColor(Color(0xFFEEF2FF))) {
+        moveTo(14.953f, 32.575f)
+        curveTo(14.657f, 31.47f, 15.313f, 30.334f, 16.418f, 30.038f)
+        lineTo(29.872f, 26.433f)
+        lineTo(30.944f, 30.434f)
+        lineTo(17.49f, 34.04f)
+        curveTo(16.385f, 34.336f, 15.249f, 33.68f, 14.953f, 32.575f)
+        close()
+      }
+    }.build()
+
+    return _Hardcover!!
+  }
+
+@Suppress("ObjectPropertyName")
+private var _Hardcover: ImageVector? = null

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/ProviderBranding.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/ProviderBranding.kt
@@ -1,0 +1,38 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * Branding for book info providers, keyed by the provider's stable string key
+ * (`ProviderId.key` in `:data:bookinfo:api`) so this module doesn't depend on
+ * the bookinfo api. Multi-color vectors — render with `Image` (or `Icon` with
+ * `tint = Color.Unspecified`) so the brand colors survive.
+ */
+private const val HARDCOVER = "hardcover"
+
+fun providerBrandIcon(providerKey: String): ImageVector? = when (providerKey) {
+  HARDCOVER -> CampfireIcons.Hardcover
+  else -> null
+}
+
+/** The provider's primary brand color (Hardcover declares #6366F1 as its theme color). */
+fun providerBrandColor(providerKey: String): Color? = when (providerKey) {
+  HARDCOVER -> Color(0xFF6366F1)
+  else -> null
+}
+
+/** The provider's primary brand color (Hardcover declares #6366F1 as its theme color). */
+fun providerBrandSecondaryColor(providerKey: String): Color? = when (providerKey) {
+  HARDCOVER -> Color(0xFF312E81)
+  else -> null
+}
+
+/** Content color that stays legible on top of [providerBrandColor]. */
+fun providerOnBrandColor(providerKey: String): Color? = when (providerKey) {
+  HARDCOVER -> Color.White
+  else -> null
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/EpisodeListItem.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/EpisodeListItem.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -44,6 +43,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.DisabledAlpha
 import app.campfire.common.compose.extensions.relativeDayLabel
+import app.campfire.common.compose.extensions.rememberHtmlRichTextState
 import app.campfire.common.compose.extensions.thenIf
 import app.campfire.common.compose.extensions.thresholdReadoutFormat
 import app.campfire.common.compose.extensions.toRichTextHtml
@@ -60,8 +60,6 @@ import campfire.common.compose.generated.resources.Res
 import campfire.common.compose.generated.resources.duration_finished
 import campfire.common.compose.generated.resources.duration_remaining
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
-import com.mohamedrejeb.richeditor.model.RichTextState
-import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material.RichText
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -180,6 +178,7 @@ fun EpisodeListItem(
       RichText(
         state = rememberHtmlRichTextState(
           episode.description?.toRichTextHtml() ?: "--",
+          linkify = false,
         ),
         style = MaterialTheme.typography.bodySmall,
         color = LocalContentColor.current.copy(
@@ -353,15 +352,6 @@ object EpisodeListItemDefaults {
     containerColor = containerColor,
     contentColor = contentColor,
   )
-}
-
-@Composable
-private fun rememberHtmlRichTextState(html: String): RichTextState {
-  val state = rememberRichTextState()
-  LaunchedEffect(html) {
-    state.setHtml(html.toRichTextHtml(linkify = false))
-  }
-  return state
 }
 
 @Preview

--- a/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
+++ b/common/screens/src/commonMain/kotlin/app.campfire.common.screens/Screens.kt
@@ -116,6 +116,12 @@ data object StatisticsScreen : BaseScreen(name = "Statistics") {
 data object StorageScreen : BaseScreen(name = "Storage")
 
 @Parcelize
+data object ConnectedProvidersScreen : BaseScreen(name = "ConnectedProviders") {
+  override val presentation: Presentation
+    get() = Presentation(hideBottomNav = true)
+}
+
+@Parcelize
 data class SettingsScreen(
   val page: Page = Page.Root,
 ) : BaseScreen(name = "Settings.$page") {

--- a/features/libraries/ui/build.gradle.kts
+++ b/features/libraries/ui/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        implementation(projects.data.bookinfo.api)
         implementation(projects.infra.audioplayer.api)
         implementation(projects.features.author.api)
         implementation(projects.features.collections.api)
@@ -36,6 +37,7 @@ kotlin {
     commonTest {
       dependencies {
         implementation(projects.data.analytics.test)
+        implementation(projects.data.bookinfo.test)
         implementation(projects.features.libraries.test)
         implementation(projects.features.sessions.test)
         implementation(projects.features.series.test)

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -134,4 +134,17 @@
 
   <string name="podcast_downloads_banner_one">%1$d episode downloading on server</string>
   <string name="podcast_downloads_banner_other">%1$d episodes downloading on server</string>
+
+  <string name="community_title">Community</string>
+  <string name="community_rating_title">Community rating</string>
+  <string name="community_rating_attribution">%1$s rating</string>
+  <string name="community_rating_count">%1$s ratings</string>
+  <string name="community_reviews_title">Reviews</string>
+  <string name="community_reviews_from">From %1$s members</string>
+  <string name="community_review_sheet_title">Review</string>
+  <string name="community_review_by_author">by %1$s</string>
+  <string name="community_review_spoiler_warning">Contains spoilers</string>
+  <string name="community_review_show_spoiler">Show review</string>
+  <string name="community_relink_provider">Reconnect %1$s to refresh</string>
+  <string name="community_open_on_provider">Open on %1$s</string>
 </resources>

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUiState.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUiState.kt
@@ -5,6 +5,7 @@ package app.campfire.libraries.ui.detail
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
+import app.campfire.bookinfo.api.ProviderId
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.AudioTrack
 import app.campfire.core.model.Chapter
@@ -80,6 +81,10 @@ sealed interface LibraryItemUiEvent : CircuitUiEvent {
   data class OpenEpisode(val episode: PodcastEpisode) : LibraryItemUiEvent
   data object FindEpisodes : LibraryItemUiEvent
   data object OpenDownloads : LibraryItemUiEvent
+
+  data class OpenProviderPage(val url: String) : LibraryItemUiEvent
+  data object RelinkProvider : LibraryItemUiEvent
+  data class SelectCommunitySource(val providerId: ProviderId) : LibraryItemUiEvent
 
   data class DeleteItemClick(val hardDelete: Boolean) : LibraryItemUiEvent
   data object ClearError : LibraryItemUiEvent

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/book/BookPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/book/BookPresenter.kt
@@ -20,8 +20,14 @@ import app.campfire.audioplayer.PlaybackController
 import app.campfire.audioplayer.history.PlaybackHistoryRepository
 import app.campfire.audioplayer.offline.OfflineDownload
 import app.campfire.audioplayer.offline.OfflineDownloadManager
+import app.campfire.bookinfo.api.BookInfoRegistry
+import app.campfire.bookinfo.api.CommunityInfoState
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.bestMatch
 import app.campfire.common.screens.AuthorDetailScreen
+import app.campfire.common.screens.ConnectedProvidersScreen
 import app.campfire.common.screens.SeriesDetailScreen
+import app.campfire.common.screens.UrlScreen
 import app.campfire.core.coroutines.DispatcherProvider
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.coroutines.onLoaded
@@ -43,6 +49,7 @@ import app.campfire.libraries.ui.detail.composables.slots.ChapterSlot
 import app.campfire.libraries.ui.detail.composables.slots.ChipsSlot
 import app.campfire.libraries.ui.detail.composables.slots.ChipsTitle
 import app.campfire.libraries.ui.detail.composables.slots.CollapsedChapterSlot
+import app.campfire.libraries.ui.detail.composables.slots.CommunitySlot
 import app.campfire.libraries.ui.detail.composables.slots.ContentSlot
 import app.campfire.libraries.ui.detail.composables.slots.CoverImageSlot
 import app.campfire.libraries.ui.detail.composables.slots.ExpressiveControlSlot
@@ -87,6 +94,7 @@ import org.jetbrains.compose.resources.stringResource
 @Inject
 class BookPresenter(
   private val validator: LibraryItemValidator,
+  private val bookInfoRegistry: BookInfoRegistry,
   private val seriesRepository: SeriesRepository,
   private val sessionsRepository: SessionsRepository,
   private val sessionQueue: SessionQueue,
@@ -152,6 +160,17 @@ class BookPresenter(
       offlineDownloadManager.observeForItem(libraryItem)
     }.collectAsState(null)
 
+    // Session-local community source override; null lets the registry pick.
+    var communitySource by remember { mutableStateOf<ProviderId?>(null) }
+
+    // Keyed on the match identifiers so the flow rebuilds when the expanded
+    // metadata (carrying ISBN/ASIN) loads in after the initial minified item.
+    val bookMatch = libraryItem.bestMatch()
+    val communityInfoState by remember(bookMatch, communitySource) {
+      bookInfoRegistry.observeCommunityInfo(libraryItem, communitySource)
+        .catch { emit(LoadState.Loaded(null)) }
+    }.collectAsState(LoadState.Loading)
+
     val itemValidation by remember {
       flow { emit(validator.validate(libraryItem)) }
     }.collectAsState(LibraryItemValidation.Success)
@@ -211,6 +230,7 @@ class BookPresenter(
       mediaProgressState = mediaProgressState,
       offlineDownloadState = offlineDownloadState,
       seriesContentState = seriesContentState,
+      communityInfoState = communityInfoState,
       showTimeInBook = showTimeInBook,
       showConfirmDownloadDialog = showConfirmDownloadDialog,
       hasSession = currentSession != null,
@@ -362,6 +382,21 @@ class BookPresenter(
           navigator.goTo(PlaylistDetailScreen(event.playlistId, null, null, event.isCreated))
         }
 
+        is LibraryItemUiEvent.OpenProviderPage -> {
+          analytics.send(ActionEvent("bookinfo_provider_page", Click))
+          navigator.goTo(UrlScreen(event.url))
+        }
+
+        LibraryItemUiEvent.RelinkProvider -> {
+          analytics.send(ActionEvent("bookinfo_relink", Click))
+          navigator.goTo(ConnectedProvidersScreen)
+        }
+
+        is LibraryItemUiEvent.SelectCommunitySource -> {
+          analytics.send(ActionEvent("bookinfo_source", Click))
+          communitySource = event.providerId
+        }
+
         // Drop unhandled events
         else -> Unit
       }
@@ -379,6 +414,7 @@ private fun buildSlots(
   mediaProgressState: LoadState<out MediaProgress?>,
   offlineDownloadState: OfflineDownload?,
   seriesContentState: LoadState<out List<SeriesWithBooks>>,
+  communityInfoState: LoadState<out CommunityInfoState?>,
   showTimeInBook: Boolean,
   showConfirmDownloadDialog: Boolean,
   hasSession: Boolean,
@@ -467,6 +503,13 @@ private fun buildSlots(
         publisher = libraryItem.media.metadata.publisher,
         publishedYear = libraryItem.media.metadata.publishedYear,
       )
+    }
+
+    communityInfoState.onLoaded { communityInfo ->
+      if (communityInfo != null && communityInfo.info.rating != null) {
+        this += SpacerSlot.medium("community_spacer")
+        this += CommunitySlot(communityInfo)
+      }
     }
 
     seriesContentState.onLoaded { seriesWithBooks ->

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ReviewBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ReviewBottomSheet.kt
@@ -1,0 +1,172 @@
+package app.campfire.libraries.ui.detail.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.CommunityInfoState
+import app.campfire.common.compose.extensions.rememberHtmlRichTextState
+import app.campfire.common.compose.extensions.roundToSingleDecimal
+import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.community_review_by_author
+import campfire.features.libraries.ui.generated.resources.community_review_sheet_title
+import campfire.features.libraries.ui.generated.resources.community_review_show_spoiler
+import campfire.features.libraries.ui.generated.resources.community_review_spoiler_warning
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.ui.material.RichText
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalRichTextApi::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun ReviewBottomSheet(
+  review: BookReview,
+  state: CommunityInfoState,
+  onOpenProvider: (String) -> Unit,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val sheetState = rememberModalBottomSheetState()
+  var spoilerRevealed by remember(review) { mutableStateOf(false) }
+  val obscured = review.hasSpoilers && !spoilerRevealed
+
+  ModalBottomSheet(
+    onDismissRequest = onDismiss,
+    sheetState = sheetState,
+    modifier = modifier,
+  ) {
+    Column(
+      modifier = Modifier
+        .padding(horizontal = 24.dp)
+        .navigationBarsPadding(),
+    ) {
+      Text(
+        text = stringResource(Res.string.community_review_sheet_title),
+        style = MaterialTheme.typography.titleLarge,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier
+          .align(Alignment.CenterHorizontally),
+      )
+
+      // Header
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+          .align(Alignment.CenterHorizontally),
+      ) {
+        review.avatarUrl?.let { avatarUrl ->
+          ReviewerAvatar(url = avatarUrl, fallbackName = review.author, size = 24.dp)
+          Spacer(Modifier.width(6.dp))
+        }
+        review.author?.let { author ->
+          // Localized as a full "by %1$s" sentence (word order is language-
+          // dependent); the author's span is bolded wherever it lands.
+          val byAuthor = stringResource(Res.string.community_review_by_author, author)
+          Text(
+            text = buildAnnotatedString {
+              append(byAuthor)
+              val start = byAuthor.indexOf(author)
+              if (start >= 0) {
+                addStyle(
+                  SpanStyle(fontWeight = FontWeight.SemiBold),
+                  start,
+                  start + author.length,
+                )
+              }
+            },
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+          )
+          Spacer(Modifier.width(8.dp))
+        }
+        review.badge?.let { badge ->
+          ReviewerBadge(text = badge, providerKey = state.providerId.key)
+          Spacer(Modifier.width(8.dp))
+        }
+        review.rating?.let { rating ->
+          Icon(
+            imageVector = Icons.Rounded.Star,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(16.dp),
+          )
+          Spacer(Modifier.width(2.dp))
+          Text(
+            text = rating.roundToSingleDecimal(),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+          )
+        }
+      }
+
+      Spacer(Modifier.height(16.dp))
+
+      Box(
+        modifier = Modifier.weight(1f, fill = false),
+      ) {
+        RichText(
+          state = rememberHtmlRichTextState(review.text),
+          style = MaterialTheme.typography.bodyLarge,
+          color = MaterialTheme.colorScheme.onSurface,
+          modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .then(if (obscured) Modifier.blur(12.dp) else Modifier),
+        )
+
+        if (obscured) {
+          Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+              .align(Alignment.Center)
+              .padding(8.dp),
+          ) {
+            Text(
+              text = stringResource(Res.string.community_review_spoiler_warning),
+              style = MaterialTheme.typography.labelMedium,
+              color = MaterialTheme.colorScheme.onSurface,
+            )
+            TextButton(onClick = { spoilerRevealed = true }) {
+              Text(stringResource(Res.string.community_review_show_spoiler))
+            }
+          }
+        }
+      }
+
+      Spacer(Modifier.height(24.dp))
+    }
+  }
+}

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ReviewerChips.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ReviewerChips.kt
@@ -1,0 +1,99 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.libraries.ui.detail.composables
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.providerBrandColor
+import coil3.compose.rememberAsyncImagePainter
+
+/**
+ * Circular reviewer profile image. Falls back to a monogram (or person glyph)
+ * when the reviewer has no image, so layouts reserve the same space either way.
+ */
+@Composable
+internal fun ReviewerAvatar(
+  url: String?,
+  fallbackName: String?,
+  modifier: Modifier = Modifier,
+  size: Dp = 32.dp,
+) {
+  if (url != null) {
+    Image(
+      painter = rememberAsyncImagePainter(url),
+      contentDescription = null,
+      contentScale = ContentScale.Crop,
+      modifier = modifier
+        .size(size)
+        .clip(CircleShape),
+    )
+  } else {
+    Box(
+      contentAlignment = Alignment.Center,
+      modifier = modifier
+        .size(size)
+        .clip(CircleShape)
+        .background(MaterialTheme.colorScheme.secondaryContainer),
+    ) {
+      val initial = fallbackName?.firstOrNull { it.isLetterOrDigit() }?.uppercase()
+      if (initial != null) {
+        Text(
+          text = initial,
+          style = MaterialTheme.typography.labelMedium,
+          color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+      } else {
+        Icon(
+          imageVector = Icons.Rounded.Person,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.onSecondaryContainer,
+          modifier = Modifier.size(size * 0.6f),
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Provider-issued profile badge (e.g. Hardcover's "Supporter" flair), tinted
+ * with the provider's brand color when one is defined.
+ */
+@Composable
+internal fun ReviewerBadge(
+  text: String,
+  providerKey: String,
+  modifier: Modifier = Modifier,
+) {
+  val brandColor = providerBrandColor(providerKey)
+  Surface(
+    shape = CircleShape,
+    color = brandColor?.copy(alpha = 0.15f) ?: MaterialTheme.colorScheme.secondaryContainer,
+    contentColor = brandColor ?: MaterialTheme.colorScheme.onSecondaryContainer,
+    modifier = modifier,
+  ) {
+    Text(
+      text = text,
+      style = MaterialTheme.typography.labelSmall,
+      maxLines = 1,
+      modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+    )
+  }
+}

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
@@ -1,0 +1,444 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.libraries.ui.detail.composables.slots
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowDropDown
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.CommunityInfoState
+import app.campfire.common.compose.extensions.rememberHtmlRichTextState
+import app.campfire.common.compose.extensions.roundToSingleDecimal
+import app.campfire.common.compose.extensions.thenIf
+import app.campfire.common.compose.icons.providerBrandIcon
+import app.campfire.common.compose.widgets.MetadataHeader
+import app.campfire.libraries.ui.detail.LibraryItemUiEvent
+import app.campfire.libraries.ui.detail.composables.ReviewBottomSheet
+import app.campfire.libraries.ui.detail.composables.ReviewerAvatar
+import app.campfire.libraries.ui.detail.composables.ReviewerBadge
+import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.community_rating_attribution
+import campfire.features.libraries.ui.generated.resources.community_rating_count
+import campfire.features.libraries.ui.generated.resources.community_relink_provider
+import campfire.features.libraries.ui.generated.resources.community_review_show_spoiler
+import campfire.features.libraries.ui.generated.resources.community_review_spoiler_warning
+import campfire.features.libraries.ui.generated.resources.community_reviews_title
+import campfire.features.libraries.ui.generated.resources.community_title
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.ui.material.RichText
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Combined community section: aggregate rating and reviews from one third-party
+ * source, with a source pill in the header that switches provider when more
+ * than one can serve this book.
+ */
+class CommunitySlot(
+  private val state: CommunityInfoState,
+) : ContentSlot {
+
+  override val id: String = "community"
+
+  @Composable
+  override fun Content(modifier: Modifier, eventSink: (LibraryItemUiEvent) -> Unit) {
+    val rating = state.info.rating ?: return
+    var expandedReview by remember { mutableStateOf<BookReview?>(null) }
+
+    Column(
+      modifier = modifier,
+    ) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+          .fillMaxWidth()
+          .heightIn(min = 56.dp)
+          .padding(horizontal = 16.dp),
+      ) {
+        MetadataHeader(
+          title = stringResource(Res.string.community_title),
+          textStyle = MaterialTheme.typography.titleLarge,
+          textColor = MaterialTheme.colorScheme.onSurface,
+          modifier = Modifier.weight(1f),
+        )
+        SourcePill(state = state, eventSink = eventSink)
+      }
+
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+          .fillMaxWidth()
+          .thenIf(state.providerUrl != null) {
+            clickable {
+              eventSink(LibraryItemUiEvent.OpenProviderPage(state.providerUrl!!))
+            }
+          },
+      ) {
+        Spacer(Modifier.width(16.dp))
+
+        Text(
+          text = rating.roundToSingleDecimal(),
+          style = MaterialTheme.typography.headlineLarge,
+          color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        Spacer(Modifier.width(16.dp))
+
+        Column(
+          modifier = Modifier
+            .padding(vertical = 12.dp),
+        ) {
+          StarRow(rating = rating)
+
+          Spacer(Modifier.height(2.dp))
+
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            providerBrandIcon(state.providerId.key)?.let { brandIcon ->
+              Image(
+                imageVector = brandIcon,
+                contentDescription = state.providerName,
+                modifier = Modifier.size(16.dp),
+              )
+              Spacer(Modifier.width(4.dp))
+            }
+            Text(
+              text = buildString {
+                append(stringResource(Res.string.community_rating_attribution, state.providerName))
+                state.info.ratingsCount?.let { count ->
+                  append(" · ")
+                  append(stringResource(Res.string.community_rating_count, count.toString()))
+                }
+              },
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        }
+        Spacer(Modifier.width(16.dp))
+      }
+
+      if (state.needsRelink) {
+        TextButton(
+          onClick = { eventSink(LibraryItemUiEvent.RelinkProvider) },
+          modifier = Modifier.padding(horizontal = 8.dp),
+        ) {
+          Text(stringResource(Res.string.community_relink_provider, state.providerName))
+        }
+      }
+
+      if (state.reviews.isNotEmpty()) {
+        MetadataHeader(
+          title = stringResource(Res.string.community_reviews_title),
+          textStyle = MaterialTheme.typography.titleMedium,
+          textColor = MaterialTheme.colorScheme.onSurface,
+          modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        LazyRow(
+          contentPadding = PaddingValues(horizontal = 16.dp),
+          horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+          items(state.reviews) { review ->
+            ReviewCard(
+              review = review,
+              providerKey = state.providerId.key,
+              onClick = { expandedReview = review },
+            )
+          }
+        }
+      }
+    }
+
+    expandedReview?.let { review ->
+      ReviewBottomSheet(
+        review = review,
+        state = state,
+        onOpenProvider = { url ->
+          expandedReview = null
+          eventSink(LibraryItemUiEvent.OpenProviderPage(url))
+        },
+        onDismiss = { expandedReview = null },
+      )
+    }
+  }
+}
+
+@Composable
+private fun SourcePill(
+  state: CommunityInfoState,
+  eventSink: (LibraryItemUiEvent) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var expanded by remember { mutableStateOf(false) }
+  val canSwitch = state.availableSources.size > 1
+
+  Box(modifier = modifier) {
+    Surface(
+      onClick = { expanded = true },
+      enabled = canSwitch,
+      shape = CircleShape,
+      color = MaterialTheme.colorScheme.surfaceContainerHigh,
+      contentColor = MaterialTheme.colorScheme.onSurface,
+    ) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(
+          start = 12.dp,
+          end = if (canSwitch) 6.dp else 12.dp,
+          top = 6.dp,
+          bottom = 6.dp,
+        ),
+      ) {
+        providerBrandIcon(state.providerId.key)?.let { brandIcon ->
+          Image(
+            imageVector = brandIcon,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+          )
+          Spacer(Modifier.width(4.dp))
+        }
+        Text(
+          text = state.providerName,
+          style = MaterialTheme.typography.labelMedium,
+        )
+        if (canSwitch) {
+          Icon(
+            imageVector = Icons.Rounded.ArrowDropDown,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+          )
+        }
+      }
+    }
+
+    DropdownMenu(
+      expanded = expanded,
+      onDismissRequest = { expanded = false },
+    ) {
+      state.availableSources.forEach { source ->
+        DropdownMenuItem(
+          text = { Text(source.name) },
+          leadingIcon = {
+            providerBrandIcon(source.id.key)?.let { brandIcon ->
+              Image(
+                imageVector = brandIcon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+              )
+            }
+          },
+          trailingIcon = if (source.id == state.providerId) {
+            {
+              Icon(
+                imageVector = Icons.Rounded.Check,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+              )
+            }
+          } else {
+            null
+          },
+          onClick = {
+            expanded = false
+            eventSink(LibraryItemUiEvent.SelectCommunitySource(source.id))
+          },
+        )
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalRichTextApi::class)
+@Composable
+private fun ReviewCard(
+  review: BookReview,
+  providerKey: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var spoilerRevealed by remember(review) { mutableStateOf(false) }
+  val obscured = review.hasSpoilers && !spoilerRevealed
+
+  Surface(
+    onClick = onClick,
+    shape = MaterialTheme.shapes.large,
+    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    modifier = modifier.width(280.dp),
+  ) {
+    Box {
+      Column(
+        modifier = Modifier.padding(16.dp),
+      ) {
+        ReviewHeader(review = review, providerKey = providerKey)
+        Spacer(Modifier.height(8.dp))
+        // minLines == maxLines keeps every card in the row the same height
+        // regardless of how long the review is.
+        RichText(
+          state = rememberHtmlRichTextState(review.text),
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          minLines = 5,
+          maxLines = 5,
+          overflow = TextOverflow.Ellipsis,
+          modifier = if (obscured) Modifier.blur(12.dp) else Modifier,
+        )
+      }
+
+      if (obscured) {
+        Column(
+          horizontalAlignment = Alignment.CenterHorizontally,
+          modifier = Modifier
+            .align(Alignment.Center)
+            .padding(8.dp),
+        ) {
+          Text(
+            text = stringResource(Res.string.community_review_spoiler_warning),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+          )
+          TextButton(onClick = { spoilerRevealed = true }) {
+            Text(stringResource(Res.string.community_review_show_spoiler))
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ReviewHeader(
+  review: BookReview,
+  providerKey: String,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier.fillMaxWidth(),
+  ) {
+    // Avatar always renders (monogram fallback) and the badge sits inline with
+    // the name, so every card header measures the same height.
+    ReviewerAvatar(url = review.avatarUrl, fallbackName = review.author)
+    Spacer(Modifier.width(8.dp))
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.weight(1f),
+    ) {
+      review.author?.let { author ->
+        Text(
+          text = author,
+          style = MaterialTheme.typography.titleMedium,
+          color = MaterialTheme.colorScheme.onSurface,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          modifier = Modifier.weight(1f, fill = false),
+        )
+      }
+      review.badge?.let { badge ->
+        Spacer(Modifier.width(6.dp))
+        ReviewerBadge(text = badge, providerKey = providerKey)
+      }
+    }
+    Spacer(Modifier.width(8.dp))
+    review.rating?.let { rating ->
+      Icon(
+        imageVector = Icons.Rounded.Star,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.size(18.dp),
+      )
+      Spacer(Modifier.width(2.dp))
+      Text(
+        text = rating.roundToSingleDecimal(),
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+  }
+}
+
+@Composable
+private fun StarRow(
+  rating: Double,
+  modifier: Modifier = Modifier,
+) {
+  val layoutDirection = LocalLayoutDirection.current
+  Row(modifier = modifier) {
+    repeat(5) { index ->
+      val fill = starFillFraction(rating, index)
+      Box(
+        modifier = Modifier.size(18.dp),
+      ) {
+        Icon(
+          imageVector = Icons.Rounded.Star,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
+          modifier = Modifier.matchParentSize(),
+        )
+        if (fill > 0f) {
+          Icon(
+            imageVector = Icons.Rounded.Star,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+              .matchParentSize()
+              .drawWithContent {
+                val fillWidth = size.width * fill
+                val left = when (layoutDirection) {
+                  LayoutDirection.Rtl -> size.width - fillWidth
+                  LayoutDirection.Ltr -> 0f
+                }
+                clipRect(left = left, right = left + fillWidth) {
+                  this@drawWithContent.drawContent()
+                }
+              },
+          )
+        }
+      }
+    }
+  }
+}
+
+/** How much of the star at [index] (0-based) is filled for [rating], in 0f..1f. */
+internal fun starFillFraction(rating: Double, index: Int): Float {
+  return (rating - index).toFloat().coerceIn(0f, 1f)
+}

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BaseLibraryItemPresenterTest.kt
@@ -9,6 +9,7 @@ import app.campfire.audioplayer.test.FakeAudioPlayerHolder
 import app.campfire.audioplayer.test.FakePlaybackController
 import app.campfire.audioplayer.test.history.FakePlaybackHistoryRepository
 import app.campfire.audioplayer.test.offline.FakeOfflineDownloadManager
+import app.campfire.bookinfo.test.FakeBookInfoRegistry
 import app.campfire.common.test.coroutines.TestDispatcherProvider
 import app.campfire.common.test.user
 import app.campfire.core.model.LibraryItemId
@@ -61,9 +62,11 @@ abstract class BaseLibraryItemPresenterTest {
   internal val settings = TestCampfireSettings()
   internal val analytics = FakeAnalytics()
   internal val dispatcherProvider = TestDispatcherProvider()
+  internal val bookInfoRegistry = FakeBookInfoRegistry()
 
   internal val bookPresenter = BookPresenter(
     validator = libraryItemValidator,
+    bookInfoRegistry = bookInfoRegistry,
     seriesRepository = seriesRepository,
     sessionsRepository = sessionsRepository,
     sessionQueue = sessionQueue,

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BookPresenterCommunityInfoTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BookPresenterCommunityInfoTest.kt
@@ -1,0 +1,178 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.libraries.ui.detail
+
+import app.campfire.bookinfo.api.BookCommunityInfo
+import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.CommunityInfoState
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.common.screens.ConnectedProvidersScreen
+import app.campfire.common.screens.UrlScreen
+import app.campfire.common.test.assert.containsInstance
+import app.campfire.common.test.assert.doesNotContainInstance
+import app.campfire.core.coroutines.LoadState
+import app.campfire.libraries.ui.detail.composables.slots.CommunitySlot
+import app.campfire.libraries.ui.detail.composables.slots.ContentSlot
+import app.cash.turbine.ReceiveTurbine
+import assertk.Assert
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import com.slack.circuit.test.test
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class BookPresenterCommunityInfoTest : BaseLibraryItemPresenterTest() {
+
+  private val communityInfo = CommunityInfoState(
+    providerId = ProviderId.Hardcover,
+    providerName = "Hardcover",
+    providerUrl = "https://hardcover.app/books/the-way-of-kings",
+    info = BookCommunityInfo(
+      providerBookId = "386446",
+      providerUrl = "https://hardcover.app/books/the-way-of-kings",
+      rating = 4.63,
+      ratingsCount = 4109,
+      ratingsDistribution = null,
+      reviewsCount = 422,
+      releaseDate = "2010-08-31",
+      coverUrl = null,
+    ),
+    reviews = emptyList(),
+  )
+
+  @Test
+  fun present_CommunityInfo_GeneratesRatingSlot() = runTest {
+    libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
+    bookInfoRegistry.communityInfoFlow.emit(LoadState.Loaded(communityInfo))
+
+    presenter.test {
+      assertThat(awaitItemWithSlot<CommunitySlot>())
+        .loadedSlots
+        .all {
+          containsInstance<CommunitySlot>()
+        }
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_CommunityInfoWithReviews_GeneratesCommunitySlot() = runTest {
+    libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
+    bookInfoRegistry.communityInfoFlow.emit(
+      LoadState.Loaded(
+        communityInfo.copy(
+          reviews = listOf(
+            BookReview(author = "reader", rating = 5.0, text = "Loved it", hasSpoilers = false),
+          ),
+        ),
+      ),
+    )
+
+    presenter.test {
+      assertThat(awaitItemWithSlot<CommunitySlot>())
+        .loadedSlots
+        .containsInstance<CommunitySlot>()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_NoCommunityInfo_GeneratesNoSlots() = runTest {
+    libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
+    bookInfoRegistry.communityInfoFlow.emit(LoadState.Loaded(null))
+
+    presenter.test {
+      assertThat(awaitLoadedItem())
+        .loadedSlots
+        .all {
+          doesNotContainInstance<CommunitySlot>()
+        }
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_OpenProviderPage_NavigatesToUrl() = runTest {
+    libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
+    bookInfoRegistry.communityInfoFlow.emit(LoadState.Loaded(communityInfo))
+
+    presenter.test {
+      val state = awaitItemWithSlot<CommunitySlot>()
+      state.eventSink(
+        LibraryItemUiEvent.OpenProviderPage("https://hardcover.app/books/the-way-of-kings"),
+      )
+
+      assertThat(navigator.awaitNextScreen())
+        .isEqualTo(UrlScreen("https://hardcover.app/books/the-way-of-kings"))
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_SelectCommunitySource_ResubscribesWithPreferredProvider() = runTest {
+    libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
+    bookInfoRegistry.communityInfoFlow.emit(LoadState.Loaded(communityInfo))
+
+    presenter.test {
+      val state = awaitItemWithSlot<CommunitySlot>()
+
+      state.eventSink(LibraryItemUiEvent.SelectCommunitySource(ProviderId.OpenLibrary))
+
+      awaitItemMatching {
+        bookInfoRegistry.communityInfoRequests.lastOrNull()?.second == ProviderId.OpenLibrary
+      }
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    assertThat(bookInfoRegistry.communityInfoRequests.last().second)
+      .isEqualTo(ProviderId.OpenLibrary)
+  }
+
+  @Test
+  fun present_RelinkProvider_NavigatesToConnectedProviders() = runTest {
+    libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
+    bookInfoRegistry.communityInfoFlow.emit(
+      LoadState.Loaded(communityInfo.copy(needsRelink = true)),
+    )
+
+    presenter.test {
+      val state = awaitItemWithSlot<CommunitySlot>()
+      state.eventSink(LibraryItemUiEvent.RelinkProvider)
+
+      assertThat(navigator.awaitNextScreen()).isEqualTo(ConnectedProvidersScreen)
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+}
+
+private suspend fun ReceiveTurbine<LibraryItemUiState>.awaitLoadedItem(): LibraryItemUiState {
+  return awaitItemMatching { it.contentState is LoadState.Loaded<*> }
+}
+
+private suspend inline fun <reified S : ContentSlot>
+  ReceiveTurbine<LibraryItemUiState>.awaitItemWithSlot(): LibraryItemUiState {
+  return awaitItemMatching { state ->
+    val loaded = state.contentState as? LoadState.Loaded<*> ?: return@awaitItemMatching false
+    val content = loaded.data as? ContentUiState ?: return@awaitItemMatching false
+    content.slots.any { it is S }
+  }
+}
+
+private suspend inline fun ReceiveTurbine<LibraryItemUiState>.awaitItemMatching(
+  predicate: (LibraryItemUiState) -> Boolean,
+): LibraryItemUiState {
+  while (true) {
+    val item = awaitItem()
+    if (predicate(item)) return item
+  }
+}
+
+private val Assert<LibraryItemUiState>.loadedSlots: Assert<List<ContentSlot>>
+  get() = prop(LibraryItemUiState::contentState)
+    .isInstanceOf<LoadState.Loaded<ContentUiState>>()
+    .prop(LoadState.Loaded<ContentUiState>::data)
+    .prop(ContentUiState::slots)

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/composables/slots/StarFillFractionTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/composables/slots/StarFillFractionTest.kt
@@ -1,0 +1,35 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.libraries.ui.detail.composables.slots
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class StarFillFractionTest {
+
+  @Test
+  fun `stars below the rating are fully filled`() {
+    assertThat(starFillFraction(rating = 4.63, index = 0)).isEqualTo(1f)
+    assertThat(starFillFraction(rating = 4.63, index = 3)).isEqualTo(1f)
+  }
+
+  @Test
+  fun `the star at the rating boundary is partially filled`() {
+    assertThat(starFillFraction(rating = 4.63, index = 4)).isEqualTo(0.63f)
+    assertThat(starFillFraction(rating = 2.5, index = 2)).isEqualTo(0.5f)
+  }
+
+  @Test
+  fun `stars above the rating are empty`() {
+    assertThat(starFillFraction(rating = 2.5, index = 3)).isEqualTo(0f)
+    assertThat(starFillFraction(rating = 0.0, index = 0)).isEqualTo(0f)
+  }
+
+  @Test
+  fun `out of range ratings are clamped`() {
+    assertThat(starFillFraction(rating = 7.2, index = 4)).isEqualTo(1f)
+    assertThat(starFillFraction(rating = -1.0, index = 0)).isEqualTo(0f)
+  }
+}

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/description/EpisodeDescriptionBottomSheet.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/sheets/description/EpisodeDescriptionBottomSheet.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -47,7 +46,7 @@ import app.campfire.common.compose.extensions.ReadoutStyle
 import app.campfire.common.compose.extensions.asRelativeDayLabel
 import app.campfire.common.compose.extensions.linkifyTimestamps
 import app.campfire.common.compose.extensions.readoutAtMost
-import app.campfire.common.compose.extensions.toRichTextHtml
+import app.campfire.common.compose.extensions.rememberHtmlRichTextState
 import app.campfire.common.compose.widgets.WithTimestampUriHandler
 import app.campfire.common.compose.widgets.bottomSheetShape
 import app.campfire.core.extensions.asDate
@@ -58,9 +57,7 @@ import app.campfire.sessions.ui.sheets.SessionSheetLayout
 import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.description_bottomsheet_empty_message
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
-import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.model.TokenClickHandler
-import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 import com.slack.circuit.overlay.OverlayHost
 import com.slack.circuitx.overlays.BottomSheetOverlay
@@ -158,7 +155,7 @@ private fun EpisodeDescriptionBottomSheet(
     } else {
       WithTimestampUriHandler(onSeek = onSeek) {
         RichText(
-          state = rememberHtmlRichTextState(description),
+          state = rememberHtmlRichTextState(description, transformHtml = { it.linkifyTimestamps() }),
           style = MaterialTheme.typography.bodyLarge,
           modifier = Modifier.fillMaxWidth(),
           onTokenClick = TokenClickHandler { token, offset ->
@@ -171,15 +168,6 @@ private fun EpisodeDescriptionBottomSheet(
     Spacer(Modifier.height(16.dp))
     Spacer(Modifier.navigationBarsPadding())
   }
-}
-
-@Composable
-private fun rememberHtmlRichTextState(html: String): RichTextState {
-  val state = rememberRichTextState()
-  LaunchedEffect(html) {
-    state.setHtml(html.toRichTextHtml().linkifyTimestamps())
-  }
-  return state
 }
 
 @Composable


### PR DESCRIPTION
## Summary

Third in the bookinfo stack (on top of #1019). The user-facing Community section on book detail:

- Average rating with fractionally filled stars (RTL-aware clip), ratings count, and the ToS-required provider attribution with the Hardcover brand mark; tap-through to the book's Hardcover page
- Uniform review cards in a horizontal row: reviewer avatar (monogram fallback), display name, provider profile badge (e.g. Supporter flair) inline so card heights stay consistent, 5-line clamped rich-text body, spoiler blur with reveal
- Tapping a card opens the full review in a bottom sheet (independent spoiler gating)
- A source pill in the section header shows the serving provider and becomes a dropdown to switch sources once more than one provider can serve the book (session-local selection)
- Invalid-token state surfaces a reconnect affordance routing to the providers screen (added in #1021)
- Shared `rememberHtmlRichTextState` helper extracted; podcast episode description UI now reuses it
- Hardcover logo as a `CampfireIcons` vector (from their open-source docs repo favicon) + brand color helpers keyed by provider id string, so `common/compose` takes no bookinfo dependency

## Test plan
- `./gradlew :features:libraries:ui:jvmTest` (slot generation states, event routing, source-switch re-subscription, star fill math)
- Verified the commit builds standalone (desktop DI graph compiles) in an isolated worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu