### PR TITLE
Add the Book Info settings page for connecting sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The five quick playback speed options can now be customized in Settings → Playback, with sliders from 0.5x to 3x and tap-to-type exact values
 - Sound equalizer on the playing screen (Android and desktop) with presets, 10-band adjustment, loudness and bass boost, and per-book profiles
 - Community ratings and reviews from Hardcover on the book detail page, with attribution and a tap-through to the book on Hardcover
-- Social page in Settings to connect book info providers like Hardcover (paste an API token), toggle sources, and clear cached data
+- Book Info page in Settings to connect sources like Hardcover (paste an API token), toggle them, and clear cached data
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The five quick playback speed options can now be customized in Settings → Playback, with sliders from 0.5x to 3x and tap-to-type exact values
 - Sound equalizer on the playing screen (Android and desktop) with presets, 10-band adjustment, loudness and bass boost, and per-book profiles
 - Community ratings and reviews from Hardcover on the book detail page, with attribution and a tap-through to the book on Hardcover
+- Social page in Settings to connect book info providers like Hardcover (paste an API token), toggle sources, and clear cached data
 
 ### Changed
 

--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
         api(projects.data.analytics.impl)
         api(projects.data.bookinfo.impl)
         api(projects.data.bookinfo.hardcover)
+        api(projects.data.bookinfo.ui)
         api(projects.data.crashreporting.impl)
 
         // Infra Modules

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/rounded/LocalLibrary.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/rounded/LocalLibrary.kt
@@ -1,0 +1,55 @@
+package app.campfire.common.compose.icons.rounded
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.CampfireIcons
+
+val CampfireIcons.Rounded.LocalLibrary: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
+  ImageVector.Builder(
+    name = "LocalLibrary",
+    defaultWidth = 24.dp,
+    defaultHeight = 24.dp,
+    viewportWidth = 960f,
+    viewportHeight = 960f,
+  ).apply {
+    path(fill = SolidColor(Color.Black)) {
+      moveTo(120f, 686f)
+      verticalLineToRelative(-286f)
+      quadToRelative(0f, -32f, 23.5f, -54f)
+      reflectiveQuadToRelative(55.5f, -20f)
+      quadToRelative(79f, 12f, 150.5f, 46.5f)
+      reflectiveQuadTo(480f, 462f)
+      quadToRelative(59f, -55f, 130.5f, -89.5f)
+      reflectiveQuadTo(761f, 326f)
+      quadToRelative(32f, -2f, 55.5f, 20f)
+      reflectiveQuadToRelative(23.5f, 54f)
+      verticalLineToRelative(286f)
+      quadToRelative(0f, 32f, -21f, 54.5f)
+      reflectiveQuadTo(766f, 765f)
+      quadToRelative(-64f, 10f, -124f, 33f)
+      reflectiveQuadToRelative(-112f, 61f)
+      quadToRelative(-11f, 9f, -23.5f, 13.5f)
+      reflectiveQuadTo(480f, 877f)
+      quadToRelative(-14f, 0f, -26.5f, -4.5f)
+      reflectiveQuadTo(430f, 859f)
+      quadToRelative(-52f, -38f, -112f, -61f)
+      reflectiveQuadToRelative(-124f, -33f)
+      quadToRelative(-32f, -2f, -53f, -24.5f)
+      reflectiveQuadTo(120f, 686f)
+      close()
+      moveTo(367f, 313f)
+      quadToRelative(-47f, -47f, -47f, -113f)
+      reflectiveQuadToRelative(47f, -113f)
+      quadToRelative(47f, -47f, 113f, -47f)
+      reflectiveQuadToRelative(113f, 47f)
+      quadToRelative(47f, 47f, 47f, 113f)
+      reflectiveQuadToRelative(-47f, 113f)
+      quadToRelative(-47f, 47f, -113f, 47f)
+      reflectiveQuadToRelative(-113f, -47f)
+      close()
+    }
+  }.build()
+}

--- a/data/bookinfo/ui/build.gradle.kts
+++ b/data/bookinfo/ui/build.gradle.kts
@@ -1,0 +1,28 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+plugins {
+  id("app.campfire.ui")
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation(projects.common.screens)
+        implementation(projects.data.bookinfo.api)
+
+        implementation(libs.compose.components.resources)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(projects.common.test)
+        implementation(projects.data.bookinfo.test)
+        implementation(libs.bundles.test.ui)
+        implementation(libs.bundles.test.common)
+      }
+    }
+  }
+}

--- a/data/bookinfo/ui/src/commonMain/composeResources/values/bookinfo_ui_strings.xml
+++ b/data/bookinfo/ui/src/commonMain/composeResources/values/bookinfo_ui_strings.xml
@@ -1,6 +1,6 @@
 <resources>
-  <string name="connected_providers_title">Social</string>
-  <string name="connected_providers_description">Connect services like Hardcover to see community ratings and reviews for your books.</string>
+  <string name="connected_providers_title">Book Info</string>
+  <string name="connected_providers_description">Connect sources like Hardcover to see community ratings and reviews for your books.</string>
   <string name="action_back">Back</string>
 
   <string name="capability_ratings">Ratings</string>

--- a/data/bookinfo/ui/src/commonMain/composeResources/values/bookinfo_ui_strings.xml
+++ b/data/bookinfo/ui/src/commonMain/composeResources/values/bookinfo_ui_strings.xml
@@ -1,0 +1,22 @@
+<resources>
+  <string name="connected_providers_title">Social</string>
+  <string name="connected_providers_description">Connect services like Hardcover to see community ratings and reviews for your books.</string>
+  <string name="action_back">Back</string>
+
+  <string name="capability_ratings">Ratings</string>
+  <string name="capability_reviews">Reviews</string>
+  <string name="capability_series">Series</string>
+  <string name="capability_metadata">Metadata</string>
+
+  <string name="provider_linked_as">Connected as %1$s</string>
+  <string name="provider_linked">Connected</string>
+  <string name="provider_link_invalid">Your token was rejected. Paste a new one to reconnect.</string>
+  <string name="provider_token_hint">Paste your API token</string>
+  <string name="provider_get_token">Get a token</string>
+  <string name="provider_connect">Connect</string>
+  <string name="provider_disconnect">Disconnect</string>
+  <string name="provider_link_error">Couldn\'t verify that token. Check it and try again.</string>
+
+  <string name="provider_clear_cache">Clear cached data</string>
+  <string name="provider_clear_cache_subtitle">Removes saved ratings and reviews. They'll be fetched fresh the next time you view a book.</string>
+</resources>

--- a/data/bookinfo/ui/src/commonMain/composeResources/values/bookinfo_ui_strings.xml
+++ b/data/bookinfo/ui/src/commonMain/composeResources/values/bookinfo_ui_strings.xml
@@ -15,7 +15,7 @@
   <string name="provider_get_token">Get a token</string>
   <string name="provider_connect">Connect</string>
   <string name="provider_disconnect">Disconnect</string>
-  <string name="provider_link_error">Couldn\'t verify that token. Check it and try again.</string>
+  <string name="provider_link_error">Couldn't verify that token. Check it and try again.</string>
 
   <string name="provider_clear_cache">Clear cached data</string>
   <string name="provider_clear_cache_subtitle">Removes saved ratings and reviews. They'll be fetched fresh the next time you view a book.</string>

--- a/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersPresenter.kt
+++ b/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersPresenter.kt
@@ -1,0 +1,114 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import app.campfire.bookinfo.api.AccountLinkable
+import app.campfire.bookinfo.api.BookInfoProviderSettings
+import app.campfire.bookinfo.api.BookInfoRegistry
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.common.screens.ConnectedProvidersScreen
+import app.campfire.common.screens.UrlScreen
+import app.campfire.core.di.UserScope
+import com.r0adkll.kimchi.circuit.annotations.CircuitInject
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import kotlinx.coroutines.launch
+import me.tatarka.inject.annotations.Assisted
+import me.tatarka.inject.annotations.Inject
+
+@CircuitInject(ConnectedProvidersScreen::class, UserScope::class)
+@Inject
+class ConnectedProvidersPresenter(
+  @Assisted private val navigator: Navigator,
+  private val bookInfoRegistry: BookInfoRegistry,
+  private val settings: BookInfoProviderSettings,
+) : Presenter<ConnectedProvidersUiState> {
+
+  @Composable
+  override fun present(): ConnectedProvidersUiState {
+    val scope = rememberCoroutineScope()
+
+    val statuses by remember {
+      bookInfoRegistry.observeProviders()
+    }.collectAsState(emptyList())
+
+    var verifyingId by remember { mutableStateOf<ProviderId?>(null) }
+    var failedId by remember { mutableStateOf<ProviderId?>(null) }
+    var clearingCache by remember { mutableStateOf(false) }
+
+    val rows = statuses.map { status ->
+      val linkable = status.provider as? AccountLinkable
+      ProviderRowState(
+        id = status.provider.id,
+        name = status.provider.displayName,
+        capabilities = status.provider.capabilities,
+        enabled = status.enabled,
+        linkState = status.linkState,
+        supportsLinking = linkable != null,
+        linkHelpUrl = linkable?.linkHelpUrl,
+        isVerifying = verifyingId == status.provider.id,
+        linkFailed = failedId == status.provider.id,
+      )
+    }
+
+    return ConnectedProvidersUiState(
+      providers = rows,
+      isClearingCache = clearingCache,
+    ) { event ->
+      when (event) {
+        ConnectedProvidersUiEvent.Back -> navigator.pop()
+
+        ConnectedProvidersUiEvent.ClearCache -> {
+          if (!clearingCache) {
+            clearingCache = true
+            scope.launch {
+              bookInfoRegistry.clearCache()
+              clearingCache = false
+            }
+          }
+        }
+
+        is ConnectedProvidersUiEvent.ToggleEnabled -> {
+          settings.setEnabled(event.id, event.enabled)
+        }
+
+        is ConnectedProvidersUiEvent.Link -> {
+          val linkable = statuses
+            .firstOrNull { it.provider.id == event.id }
+            ?.provider as? AccountLinkable
+            ?: return@ConnectedProvidersUiState
+          verifyingId = event.id
+          failedId = null
+          scope.launch {
+            val result = linkable.verifyAndLink(event.token)
+            verifyingId = null
+            if (result.isFailure) {
+              failedId = event.id
+            }
+          }
+        }
+
+        is ConnectedProvidersUiEvent.Unlink -> {
+          val linkable = statuses
+            .firstOrNull { it.provider.id == event.id }
+            ?.provider as? AccountLinkable
+            ?: return@ConnectedProvidersUiState
+          failedId = null
+          scope.launch { linkable.unlink() }
+        }
+
+        is ConnectedProvidersUiEvent.OpenLinkHelp -> {
+          navigator.goTo(UrlScreen(event.url))
+        }
+      }
+    }
+  }
+}

--- a/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersUi.kt
+++ b/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersUi.kt
@@ -1,0 +1,406 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.unit.dp
+import app.campfire.bookinfo.api.ProviderCapabilities
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.common.compose.CampfireWindowInsets
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.providerBrandColor
+import app.campfire.common.compose.icons.providerBrandIcon
+import app.campfire.common.compose.icons.providerBrandSecondaryColor
+import app.campfire.common.compose.icons.providerOnBrandColor
+import app.campfire.common.compose.icons.rounded.Disconnected
+import app.campfire.common.compose.theme.LocalUseDarkColors
+import app.campfire.common.compose.widgets.CampfireTopAppBar
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.screens.ConnectedProvidersScreen
+import app.campfire.core.di.UserScope
+import campfire.data.bookinfo.ui.generated.resources.Res
+import campfire.data.bookinfo.ui.generated.resources.action_back
+import campfire.data.bookinfo.ui.generated.resources.capability_metadata
+import campfire.data.bookinfo.ui.generated.resources.capability_ratings
+import campfire.data.bookinfo.ui.generated.resources.capability_reviews
+import campfire.data.bookinfo.ui.generated.resources.capability_series
+import campfire.data.bookinfo.ui.generated.resources.connected_providers_description
+import campfire.data.bookinfo.ui.generated.resources.connected_providers_title
+import campfire.data.bookinfo.ui.generated.resources.provider_clear_cache
+import campfire.data.bookinfo.ui.generated.resources.provider_clear_cache_subtitle
+import campfire.data.bookinfo.ui.generated.resources.provider_connect
+import campfire.data.bookinfo.ui.generated.resources.provider_disconnect
+import campfire.data.bookinfo.ui.generated.resources.provider_get_token
+import campfire.data.bookinfo.ui.generated.resources.provider_link_error
+import campfire.data.bookinfo.ui.generated.resources.provider_link_invalid
+import campfire.data.bookinfo.ui.generated.resources.provider_linked
+import campfire.data.bookinfo.ui.generated.resources.provider_linked_as
+import campfire.data.bookinfo.ui.generated.resources.provider_token_hint
+import com.r0adkll.kimchi.circuit.annotations.CircuitInject
+import org.jetbrains.compose.resources.stringResource
+
+@CircuitInject(ConnectedProvidersScreen::class, UserScope::class)
+@Composable
+fun ConnectedProvidersUi(
+  state: ConnectedProvidersUiState,
+  modifier: Modifier = Modifier,
+) {
+  val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+  Scaffold(
+    topBar = {
+      CampfireTopAppBar(
+        title = { Text(stringResource(Res.string.connected_providers_title)) },
+        navigationIcon = {
+          val backLabel = stringResource(Res.string.action_back)
+          IconButtonTooltip(text = backLabel) {
+            IconButton(
+              onClick = { state.eventSink(ConnectedProvidersUiEvent.Back) },
+            ) {
+              Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
+            }
+          }
+        },
+        scrollBehavior = scrollBehavior,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+      )
+    },
+    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+    modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    contentWindowInsets = CampfireWindowInsets,
+  ) { paddingValues ->
+    LazyColumn(
+      contentPadding = paddingValues,
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      item("description") {
+        Text(
+          text = stringResource(Res.string.connected_providers_description),
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+      }
+      items(state.providers, key = { it.id.key }) { provider ->
+        ProviderCard(
+          provider = provider,
+          eventSink = state.eventSink,
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        )
+      }
+      item("clear_cache") {
+        ClearCacheRow(
+          isClearing = state.isClearingCache,
+          onClick = { state.eventSink(ConnectedProvidersUiEvent.ClearCache) },
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ClearCacheRow(
+  isClearing: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  ListItem(
+    headlineContent = {
+      Text(stringResource(Res.string.provider_clear_cache))
+    },
+    supportingContent = {
+      Text(stringResource(Res.string.provider_clear_cache_subtitle))
+    },
+    trailingContent = if (isClearing) {
+      {
+        CircularProgressIndicator(modifier = Modifier.size(16.dp))
+      }
+    } else {
+      null
+    },
+    colors = ListItemDefaults.colors(
+      containerColor = Color.Transparent,
+    ),
+    modifier = modifier.clickable(onClick = onClick),
+  )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun ProviderCard(
+  provider: ProviderRowState,
+  eventSink: (ConnectedProvidersUiEvent) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val surfaceCompositeAlpha = if (LocalUseDarkColors.current) 0.25f else 0.68f
+  val providerBrandColor = providerBrandColor(provider.id.key)
+  val providerOnBrandColor = providerOnBrandColor(provider.id.key)
+  val providerOnBrandVariantColor = providerOnBrandColor?.copy(alpha = 0.68f)
+  val providerBrandSecondaryColor = providerBrandSecondaryColor(provider.id.key)
+  Surface(
+    shape = MaterialTheme.shapes.largeIncreased,
+    color = providerBrandColor
+      ?.copy(alpha = surfaceCompositeAlpha)
+      ?.compositeOver(MaterialTheme.colorScheme.surface)
+      ?: MaterialTheme.colorScheme.surface,
+    contentColor = providerBrandColor ?: MaterialTheme.colorScheme.onSurface,
+    modifier = modifier,
+  ) {
+    Column(
+      modifier = Modifier.padding(16.dp),
+    ) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        providerBrandIcon(provider.id.key)?.let { brandIcon ->
+          Image(
+            imageVector = brandIcon,
+            contentDescription = null,
+            modifier = Modifier.size(40.dp),
+          )
+          Spacer(Modifier.width(12.dp))
+        }
+        Column(
+          modifier = Modifier.weight(1f),
+        ) {
+          Text(
+            text = provider.name,
+            style = MaterialTheme.typography.titleMedium,
+            color = providerOnBrandColor ?: MaterialTheme.colorScheme.onSurface,
+          )
+          Text(
+            text = provider.capabilities.summary(),
+            style = MaterialTheme.typography.bodySmall,
+            color = providerOnBrandVariantColor ?: MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+        Spacer(Modifier.width(16.dp))
+        Switch(
+          checked = provider.enabled,
+          onCheckedChange = { checked ->
+            eventSink(ConnectedProvidersUiEvent.ToggleEnabled(provider.id, checked))
+          },
+          colors = if (
+            providerBrandColor != null &&
+            providerBrandSecondaryColor != null &&
+            providerOnBrandColor != null
+          ) {
+            SwitchDefaults.colors(
+              checkedTrackColor = providerBrandColor,
+              checkedThumbColor = providerBrandSecondaryColor,
+              checkedIconColor = providerOnBrandColor,
+            )
+          } else SwitchDefaults.colors(),
+        )
+      }
+
+      if (provider.supportsLinking) {
+        Spacer(Modifier.height(12.dp))
+        when (val linkState = provider.linkState) {
+          is ProviderLinkState.Linked -> LinkedContent(provider, linkState, eventSink)
+          is ProviderLinkState.Invalid -> UnlinkedContent(provider, eventSink, invalid = true)
+          ProviderLinkState.NotLinked -> UnlinkedContent(provider, eventSink, invalid = false)
+        }
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun LinkedContent(
+  provider: ProviderRowState,
+  linkState: ProviderLinkState.Linked,
+  eventSink: (ConnectedProvidersUiEvent) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val providerOnBrandColor = providerOnBrandColor(provider.id.key)
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier.fillMaxWidth(),
+  ) {
+    Text(
+      text = linkState.accountName
+        ?.let { stringResource(Res.string.provider_linked_as, it) }
+        ?: stringResource(Res.string.provider_linked),
+      style = MaterialTheme.typography.bodyLarge,
+      color = providerOnBrandColor
+        ?: MaterialTheme.colorScheme.onSurfaceVariant,
+      modifier = Modifier.weight(1f),
+    )
+
+    val buttonSize = ButtonDefaults.ExtraSmallContainerHeight
+    Button(
+      onClick = { eventSink(ConnectedProvidersUiEvent.Unlink(provider.id)) },
+      shapes = ButtonDefaults.shapes(),
+      colors = ButtonDefaults.buttonColors(
+        containerColor = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+      ),
+      contentPadding = ButtonDefaults.contentPaddingFor(buttonSize, hasStartIcon = true),
+      modifier = Modifier
+        .heightIn(buttonSize),
+    ) {
+      Icon(
+        CampfireIcons.Rounded.Disconnected,
+        contentDescription = null,
+        modifier = Modifier.size(ButtonDefaults.iconSizeFor(buttonSize)),
+      )
+      Spacer(Modifier.size(ButtonDefaults.iconSpacingFor(buttonSize)))
+      Text(
+        text = stringResource(Res.string.provider_disconnect),
+        style = ButtonDefaults.textStyleFor(buttonSize),
+      )
+    }
+  }
+}
+
+@Composable
+private fun UnlinkedContent(
+  provider: ProviderRowState,
+  eventSink: (ConnectedProvidersUiEvent) -> Unit,
+  invalid: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  var token by rememberSaveable(provider.id) { mutableStateOf("") }
+
+  val providerBrandColor = providerBrandColor(provider.id.key)
+  val providerOnBrandColor = providerOnBrandColor(provider.id.key)
+  val providerOnBrandVariantColor = providerOnBrandColor?.copy(alpha = 0.68f)
+
+  Column(modifier = modifier) {
+    if (invalid) {
+      Text(
+        text = stringResource(Res.string.provider_link_invalid),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error,
+      )
+      Spacer(Modifier.height(8.dp))
+    }
+    OutlinedTextField(
+      value = token,
+      onValueChange = { token = it },
+      placeholder = { Text(stringResource(Res.string.provider_token_hint)) },
+      singleLine = true,
+      isError = provider.linkFailed,
+      supportingText = if (provider.linkFailed) {
+        { Text(stringResource(Res.string.provider_link_error)) }
+      } else {
+        null
+      },
+      modifier = Modifier.fillMaxWidth(),
+      colors = if (
+        providerBrandColor != null &&
+        providerOnBrandColor != null &&
+        providerOnBrandVariantColor != null
+      ) {
+        OutlinedTextFieldDefaults.colors(
+          focusedBorderColor = providerBrandColor,
+          cursorColor = providerBrandColor,
+          unfocusedBorderColor = providerOnBrandVariantColor,
+          unfocusedPlaceholderColor = providerOnBrandVariantColor,
+          focusedPlaceholderColor = providerOnBrandVariantColor,
+          focusedTextColor = providerOnBrandColor,
+        )
+      } else OutlinedTextFieldDefaults.colors(),
+    )
+    Spacer(Modifier.height(8.dp))
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      provider.linkHelpUrl?.let { url ->
+        OutlinedButton(
+          onClick = { eventSink(ConnectedProvidersUiEvent.OpenLinkHelp(url)) },
+          colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = providerOnBrandColor ?: Color.Unspecified,
+          ),
+          border = BorderStroke(1.dp, providerOnBrandColor ?: MaterialTheme.colorScheme.outlineVariant),
+        ) {
+          Text(stringResource(Res.string.provider_get_token))
+        }
+      }
+      Spacer(Modifier.weight(1f))
+      if (provider.isVerifying) {
+        CircularProgressIndicator(modifier = Modifier.padding(end = 8.dp))
+      } else {
+        Button(
+          onClick = { eventSink(ConnectedProvidersUiEvent.Link(provider.id, token)) },
+          enabled = token.isNotBlank(),
+          colors = if (providerBrandColor != null) {
+            ButtonDefaults.buttonColors(
+              containerColor = providerBrandColor,
+              contentColor = providerOnBrandColor ?: MaterialTheme.colorScheme.onPrimary,
+            )
+          } else {
+            ButtonDefaults.buttonColors()
+          },
+        ) {
+          Text(stringResource(Res.string.provider_connect))
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ProviderCapabilities.summary(): String {
+  val labels = buildList {
+    if (hasAggregateRating) add(stringResource(Res.string.capability_ratings))
+    if (hasReviewText) add(stringResource(Res.string.capability_reviews))
+    if (hasSeriesOrdering) add(stringResource(Res.string.capability_series))
+    if (hasSupplementalMetadata) add(stringResource(Res.string.capability_metadata))
+  }
+  return labels.joinToString(" · ")
+}

--- a/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersUiState.kt
+++ b/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersUiState.kt
@@ -1,0 +1,40 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.ui
+
+import androidx.compose.runtime.Immutable
+import app.campfire.bookinfo.api.ProviderCapabilities
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderLinkState
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+
+@Immutable
+data class ConnectedProvidersUiState(
+  val providers: List<ProviderRowState>,
+  val isClearingCache: Boolean = false,
+  val eventSink: (ConnectedProvidersUiEvent) -> Unit,
+) : CircuitUiState
+
+@Immutable
+data class ProviderRowState(
+  val id: ProviderId,
+  val name: String,
+  val capabilities: ProviderCapabilities,
+  val enabled: Boolean,
+  val linkState: ProviderLinkState,
+  val supportsLinking: Boolean,
+  val linkHelpUrl: String?,
+  val isVerifying: Boolean = false,
+  val linkFailed: Boolean = false,
+)
+
+sealed interface ConnectedProvidersUiEvent : CircuitUiEvent {
+  data object Back : ConnectedProvidersUiEvent
+  data object ClearCache : ConnectedProvidersUiEvent
+  data class ToggleEnabled(val id: ProviderId, val enabled: Boolean) : ConnectedProvidersUiEvent
+  data class Link(val id: ProviderId, val token: String) : ConnectedProvidersUiEvent
+  data class Unlink(val id: ProviderId) : ConnectedProvidersUiEvent
+  data class OpenLinkHelp(val url: String) : ConnectedProvidersUiEvent
+}

--- a/data/bookinfo/ui/src/commonTest/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersPresenterTest.kt
+++ b/data/bookinfo/ui/src/commonTest/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersPresenterTest.kt
@@ -1,0 +1,213 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.ui
+
+import app.campfire.bookinfo.api.AccountLinkable
+import app.campfire.bookinfo.api.BookInfoProvider
+import app.campfire.bookinfo.api.BookInfoProviderSettings
+import app.campfire.bookinfo.api.LinkedAccount
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.api.ProviderStatus
+import app.campfire.bookinfo.test.FakeBookInfoProvider
+import app.campfire.bookinfo.test.FakeBookInfoRegistry
+import app.campfire.common.screens.ConnectedProvidersScreen
+import app.campfire.common.screens.UrlScreen
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlin.test.Test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+
+private class FakeLinkableProvider(
+  private val delegate: FakeBookInfoProvider = FakeBookInfoProvider(),
+) : BookInfoProvider by delegate, AccountLinkable {
+
+  override val linkHelpUrl: String = "https://hardcover.app/account/api"
+
+  var linkResult: Result<LinkedAccount> = Result.success(LinkedAccount("reader"))
+  val linkedTokens = mutableListOf<String>()
+  var unlinked = false
+
+  override suspend fun verifyAndLink(token: String): Result<LinkedAccount> {
+    linkedTokens += token
+    return linkResult
+  }
+
+  override suspend fun unlink() {
+    unlinked = true
+  }
+}
+
+private class FakeProviderSettings : BookInfoProviderSettings {
+  val enabled = MutableStateFlow(mapOf<ProviderId, Boolean>())
+  override fun isEnabled(id: ProviderId): Boolean = enabled.value[id] ?: true
+  override fun setEnabled(id: ProviderId, enabled: Boolean) {
+    this.enabled.value = this.enabled.value + (id to enabled)
+  }
+  override fun observeEnabled(id: ProviderId): Flow<Boolean> = enabled.map { it[id] ?: true }
+}
+
+class ConnectedProvidersPresenterTest {
+
+  private val navigator = FakeNavigator(ConnectedProvidersScreen)
+  private val registry = FakeBookInfoRegistry()
+  private val settings = FakeProviderSettings()
+  private val provider = FakeLinkableProvider()
+
+  private val presenter = ConnectedProvidersPresenter(
+    navigator = navigator,
+    bookInfoRegistry = registry,
+    settings = settings,
+  )
+
+  private suspend fun emitProvider(linkState: ProviderLinkState = ProviderLinkState.NotLinked) {
+    registry.providersFlow.emit(
+      listOf(ProviderStatus(provider = provider, enabled = true, linkState = linkState)),
+    )
+  }
+
+  @Test
+  fun present_MapsProviderRows() = runTest {
+    emitProvider(ProviderLinkState.Linked("reader"))
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      val row = state.providers.single()
+      assertThat(row.name).isEqualTo("Fake Provider")
+      assertThat(row.supportsLinking).isTrue()
+      assertThat(row.linkState).isEqualTo(ProviderLinkState.Linked("reader"))
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_ToggleEnabled_UpdatesSettings() = runTest {
+    emitProvider()
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      state.eventSink(ConnectedProvidersUiEvent.ToggleEnabled(ProviderId.Hardcover, false))
+
+      assertThat(settings.isEnabled(ProviderId.Hardcover)).isFalse()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_Link_VerifiesToken() = runTest {
+    emitProvider()
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      state.eventSink(ConnectedProvidersUiEvent.Link(ProviderId.Hardcover, "a-token"))
+
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    assertThat(provider.linkedTokens).isEqualTo(listOf("a-token"))
+  }
+
+  @Test
+  fun present_LinkFailure_FlagsRow() = runTest {
+    provider.linkResult = Result.failure(Exception("nope"))
+    emitProvider()
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      state.eventSink(ConnectedProvidersUiEvent.Link(ProviderId.Hardcover, "bad-token"))
+
+      val failed = awaitItemMatching { it.providers.single().linkFailed }
+      assertThat(failed.providers.single().isVerifying).isFalse()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_Unlink_DelegatesToProvider() = runTest {
+    emitProvider(ProviderLinkState.Linked("reader"))
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      state.eventSink(ConnectedProvidersUiEvent.Unlink(ProviderId.Hardcover))
+
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    assertThat(provider.unlinked).isTrue()
+  }
+
+  @Test
+  fun present_OpenLinkHelp_NavigatesToUrl() = runTest {
+    emitProvider()
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      state.eventSink(ConnectedProvidersUiEvent.OpenLinkHelp("https://hardcover.app/account/api"))
+
+      assertThat(navigator.awaitNextScreen())
+        .isEqualTo(UrlScreen("https://hardcover.app/account/api"))
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_ClearCache_DelegatesToRegistry() = runTest {
+    emitProvider()
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      state.eventSink(ConnectedProvidersUiEvent.ClearCache)
+
+      awaitItemMatching { !it.isClearingCache && registry.clearCacheCount == 1 }
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    assertThat(registry.clearCacheCount).isEqualTo(1)
+  }
+
+  @Test
+  fun present_Back_PopsNavigator() = runTest {
+    emitProvider()
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      state.eventSink(ConnectedProvidersUiEvent.Back)
+
+      navigator.awaitPop()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+}
+
+private suspend inline fun app.cash.turbine.ReceiveTurbine<ConnectedProvidersUiState>.awaitItemMatching(
+  predicate: (ConnectedProvidersUiState) -> Boolean,
+): ConnectedProvidersUiState {
+  while (true) {
+    val item = awaitItem()
+    if (predicate(item)) return item
+  }
+}

--- a/docs/architecture/MODULARIZATION.md
+++ b/docs/architecture/MODULARIZATION.md
@@ -427,6 +427,10 @@ graph LR
   :features:sessions:ui --> :features:sessions:api
   :features:sessions:ui --> :features:user:api
   :features:sessions:ui --> :features:libraries:api
+  :features:sessions:ui --> :features:libraries:test
+  :features:sessions:ui --> :features:sessions:test
+  :features:sessions:ui --> :features:settings:test
+  :features:sessions:ui --> :features:user:test
   :features:sessions:ui --> :
   :app:desktop --> :
   :app:ios --> :
@@ -530,5 +534,6 @@ graph LR
   :features:home:ui --> :features:home:api
   :features:home:ui --> :features:libraries:api
   :features:home:ui --> :features:user:api
+  :features:home:ui --> :features:user:test
   :features:home:ui --> :
 ```

--- a/features/auth/ui/src/commonMain/composeResources/values/auth_ui_strings.xml
+++ b/features/auth/ui/src/commonMain/composeResources/values/auth_ui_strings.xml
@@ -16,7 +16,7 @@
   <string name="label_authenticating_loading_message">Logging in…</string>
   <string name="label_login_error_network">A network error has occurred. Please try again.</string>
   <string name="label_login_error_auth">The provided username and password combination is incorrect.</string>
-  <string name="label_login_error_no_libraries">Your account doesn\'t have access to any libraries on this server. Ask your server admin to grant library access, then try again.</string>
+  <string name="label_login_error_no_libraries">Your account doesn't have access to any libraries on this server. Ask your server admin to grant library access, then try again.</string>
   <string name="label_login_error_unexpected_response">The server returned an unexpected response. Please try again, and check that Campfire and your server are up to date.</string>
   <string name="label_login_error_oauth">Something went wrong with the OpenID provider.</string>
   <string name="label_login_error_oauth_invalid_redirect_uri">The server rejected the mobile redirect URI. Please configure "campfireaudiobooks://oauth" as an allowed Mobile Redirect URI in your Audiobookshelf OpenID settings.</string>

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -130,7 +130,7 @@
   <string name="dialog_delete_podcast_action_confirm">Delete</string>
   <string name="dialog_delete_podcast_action_confirm_hard">Delete &amp; remove files</string>
   <string name="dialog_delete_podcast_action_cancel">Cancel</string>
-  <string name="error_delete_podcast">Couldn\'t delete podcast. Try again.</string>
+  <string name="error_delete_podcast">Couldn't delete podcast. Try again.</string>
 
   <string name="podcast_downloads_banner_one">%1$d episode downloading on server</string>
   <string name="podcast_downloads_banner_other">%1$d episodes downloading on server</string>

--- a/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
+++ b/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
@@ -30,7 +30,7 @@
   <string name="equalizer_preset_custom">Custom</string>
   <string name="equalizer_loudness_label">Loudness</string>
   <string name="equalizer_bass_label">Bass</string>
-  <string name="equalizer_unavailable_casting">The equalizer isn\'t available while casting</string>
+  <string name="equalizer_unavailable_casting">The equalizer isn't available while casting</string>
   <string name="equalizer_band_gain_cd">%1$s equalizer band gain</string>
   <string name="timer_bottomsheet_title">Sleep Timer</string>
   <string name="timer_end_of_chapter">End of Chapter</string>

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -16,6 +16,8 @@
   <string name="setting_android_auto_subtitle">Categories, ordering, and layout</string>
   <string name="setting_about_title">About</string>
   <string name="setting_about_subtitle">Developer, attributions, and version</string>
+  <string name="setting_providers_title">Social</string>
+  <string name="setting_providers_subtitle">Community ratings and reviews</string>
   <string name="setting_developer_title">Developer</string>
   <string name="setting_developer_subtitle">Debug, Troubleshooting, and other</string>
 

--- a/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
+++ b/features/settings/ui/src/commonMain/composeResources/values/ui_settings_strings.xml
@@ -16,8 +16,8 @@
   <string name="setting_android_auto_subtitle">Categories, ordering, and layout</string>
   <string name="setting_about_title">About</string>
   <string name="setting_about_subtitle">Developer, attributions, and version</string>
-  <string name="setting_providers_title">Social</string>
-  <string name="setting_providers_subtitle">Community ratings and reviews</string>
+  <string name="setting_providers_title">Book Info</string>
+  <string name="setting_providers_subtitle">Community ratings, reviews &amp; sources</string>
   <string name="setting_developer_title">Developer</string>
   <string name="setting_developer_subtitle">Debug, Troubleshooting, and other</string>
 

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsPresenter.kt
@@ -18,6 +18,7 @@ import app.campfire.audioplayer.history.PlaybackHistoryRepository
 import app.campfire.audioplayer.model.PlaybackTimer
 import app.campfire.audioplayer.offline.OfflineDownloadManager
 import app.campfire.common.screens.AttributionScreen
+import app.campfire.common.screens.ConnectedProvidersScreen
 import app.campfire.common.screens.SettingsScreen
 import app.campfire.common.screens.UrlScreen
 import app.campfire.core.Platform
@@ -324,6 +325,7 @@ class SettingsPresenter(
       when (event) {
         SettingsUiEvent.Back -> navigator.pop()
         is SettingsUiEvent.SettingsPaneClick -> navigator.goTo(SettingsScreen(event.pane.screenPage))
+        SettingsUiEvent.ConnectedProvidersClick -> navigator.goTo(ConnectedProvidersScreen)
 
         is SettingsUiEvent.AccountSettingEvent -> when (event) {
           is ChangeName -> {

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUi.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUi.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.extensions.thenIf
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.rounded.LocalLibrary
 import app.campfire.common.compose.layout.LocalSupportingContentState
 import app.campfire.common.compose.layout.SupportingContentState
 import app.campfire.common.compose.layout.isSupportingPaneEnabled
@@ -83,6 +85,8 @@ import campfire.features.settings.ui.generated.resources.setting_downloads_subti
 import campfire.features.settings.ui.generated.resources.setting_downloads_title
 import campfire.features.settings.ui.generated.resources.setting_playback_subtitle
 import campfire.features.settings.ui.generated.resources.setting_playback_title
+import campfire.features.settings.ui.generated.resources.setting_providers_subtitle
+import campfire.features.settings.ui.generated.resources.setting_providers_title
 import campfire.features.settings.ui.generated.resources.setting_sleep_subtitle
 import campfire.features.settings.ui.generated.resources.setting_sleep_title
 import campfire.features.settings.ui.generated.resources.settings_title
@@ -158,6 +162,7 @@ private fun TwoPaneLayout(
       isTwoPane = true,
       pane = forcedPane,
       onPaneClick = onPaneClick,
+      onConnectedProvidersClick = { state.eventSink(SettingsUiEvent.ConnectedProvidersClick) },
       onBackClick = { state.eventSink(SettingsUiEvent.Back) },
       showDeveloperPane = state.developerSettings.developerModeEnabled,
       showAndroidAutoPane = state.isAndroidAutoPaneVisible,
@@ -215,6 +220,7 @@ private fun OnePaneLayout(
   SettingsRootPane(
     pane = pane,
     onPaneClick = onPaneClick,
+    onConnectedProvidersClick = { state.eventSink(SettingsUiEvent.ConnectedProvidersClick) },
     onBackClick = { state.eventSink(SettingsUiEvent.Back) },
     showDeveloperPane = state.developerSettings.developerModeEnabled,
     showAndroidAutoPane = state.isAndroidAutoPaneVisible,
@@ -248,6 +254,7 @@ private fun OnlyPaneLayout(
 private fun SettingsRootPane(
   pane: SettingsPane?,
   onPaneClick: (SettingsPane) -> Unit,
+  onConnectedProvidersClick: () -> Unit,
   onBackClick: () -> Unit,
   showDeveloperPane: Boolean,
   showAndroidAutoPane: Boolean,
@@ -321,6 +328,21 @@ private fun SettingsRootPane(
         onClick = {
           onPaneClick(SettingsPane.Appearance)
         },
+        shape = SettingsPaneDefaults.middleShape(),
+      )
+
+      // Connected book info providers (standalone screen)
+      SettingPaneListItem(
+        selected = false,
+        icon = {
+          Icon(
+            CampfireIcons.Rounded.LocalLibrary,
+            contentDescription = null,
+          )
+        },
+        title = { Text(stringResource(Res.string.setting_providers_title)) },
+        subtitle = { Text(stringResource(Res.string.setting_providers_subtitle)) },
+        onClick = onConnectedProvidersClick,
         shape = SettingsPaneDefaults.bottomShape(),
       )
 

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUiState.kt
@@ -168,6 +168,7 @@ enum class SettingsPane {
 sealed interface SettingsUiEvent : CircuitUiEvent {
   data object Back : SettingsUiEvent
   data class SettingsPaneClick(val pane: SettingsPane) : SettingsUiEvent
+  data object ConnectedProvidersClick : SettingsUiEvent
 
   // Account Pane Events
   sealed interface AccountSettingEvent : SettingsUiEvent {

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/analytics/SettingsAnalyticUiEventHandler.kt
@@ -58,6 +58,7 @@ class SettingsAnalyticUiEventHandler(
   fun handle(event: SettingsUiEvent) = when (event) {
     SettingsUiEvent.Back -> Unit
     is SettingsUiEvent.SettingsPaneClick -> Unit
+    SettingsUiEvent.ConnectedProvidersClick -> send("connected_providers", Click)
 
     is SettingsUiEvent.AccountSettingEvent -> when (event) {
       is ChangeName -> send("account_name", Updated)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -147,6 +147,7 @@ include(
   ":data:bookinfo:hardcover",
   ":data:bookinfo:impl",
   ":data:bookinfo:test",
+  ":data:bookinfo:ui",
 )
 include(
   ":data:crashreporting:api",


### PR DESCRIPTION
## Summary

Last in the bookinfo stack (on top of #1020). Provider management UI:

- New `:data:bookinfo:ui` module (the `data/account/ui` precedent) with the `ConnectedProvidersScreen`: per-provider cards showing the brand mark, capability summary, and an enable/disable switch
- Hardcover linking: token paste field with a "Get a token" link-out to hardcover.app/account/api, verify-before-save (brand-colored Connect button), connected-account display, disconnect, and a rejected-token error state
- Clear-cached-data action that drops the bookinfo cache so ratings/reviews refetch on next view
- New **Book Info** row in settings root navigating to the screen (standalone-screen pattern like ThemePicker)

The provider list is registry-driven, so Phase 3's keyless providers (Open Library, Audnexus) will appear here with no UI changes.

## Test plan
- `./gradlew :data:bookinfo:ui:jvmTest` (row mapping, toggle, link/unlink/verify-failure, clear cache, navigation)
- Full desktop DI graph compiles; module graph doc regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu