### PR TITLE
Add series listings with gap and upcoming-book detection

### DIFF
--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoProvider.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoProvider.kt
@@ -29,4 +29,11 @@ interface BookInfoProvider {
   suspend fun getBookInfo(match: BookMatch): BookInfoResult<BookCommunityInfo>
 
   suspend fun getReviews(match: BookMatch, limit: Int = 10): BookInfoResult<List<BookReview>>
+
+  /**
+   * The provider's canonical listing for a series, including unreleased
+   * entries. Only providers with [ProviderCapabilities.hasSeriesOrdering]
+   * implement this; the default reports no data.
+   */
+  suspend fun getSeries(match: SeriesMatch): BookInfoResult<ProviderSeries> = BookInfoResult.NotFound
 }

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
@@ -30,6 +30,19 @@ interface BookInfoRegistry {
   ): Flow<LoadState<out CommunityInfoState?>>
 
   /**
+   * The full series listing for [seriesName], merging the user's [ownedItems]
+   * with the best available provider's canonical entries — released books the
+   * user doesn't own become [SeriesEntry.Missing] and announced-but-unreleased
+   * ones [SeriesEntry.Upcoming]. Degrades to owned-only entries when no
+   * series-capable provider is available, so callers render the same shape
+   * either way.
+   */
+  fun observeSeriesEntries(
+    seriesName: String,
+    ownedItems: List<LibraryItem>,
+  ): Flow<LoadState<out SeriesInfoState>>
+
+  /**
    * Drops all locally cached provider data (for every provider and user).
    * Fresh data is fetched on the next read.
    */

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/ProviderSeries.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/ProviderSeries.kt
@@ -1,0 +1,40 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.api
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A series as one provider knows it: canonical entries in reading order,
+ * including announced-but-unreleased books. Serializable so implementations
+ * can persist it in their local cache.
+ */
+@Serializable
+data class ProviderSeries(
+  val providerSeriesId: String,
+  val name: String,
+  val isCompleted: Boolean?,
+  val entries: List<ProviderSeriesEntry>,
+)
+
+/**
+ * One canonical book in a provider's series listing.
+ *
+ * @param position reading-order position; fractional positions are companion
+ * works (e.g. 0.5 novellas)
+ * @param isReleased false for announced/placeholder entries with future or
+ * unknown release dates
+ */
+@Serializable
+data class ProviderSeriesEntry(
+  val providerBookId: String,
+  val position: Double,
+  val title: String,
+  val releaseDate: String?,
+  val isReleased: Boolean,
+  val providerUrl: String?,
+  val coverUrl: String?,
+  val isbns: List<String> = emptyList(),
+  val asins: List<String> = emptyList(),
+)

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/SeriesEntry.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/SeriesEntry.kt
@@ -1,0 +1,39 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.api
+
+import app.campfire.core.model.LibraryItem
+
+/**
+ * One row of a series as shown to the user: a book they own, a released book
+ * missing from their library, or an announced-but-unreleased book. [key] is
+ * unique within a series listing and stable for lazy-list keying.
+ */
+sealed interface SeriesEntry {
+  val key: String
+
+  data class Owned(val item: LibraryItem) : SeriesEntry {
+    override val key: String get() = item.id
+  }
+
+  data class Missing(val entry: ProviderSeriesEntry, val providerId: ProviderId) : SeriesEntry {
+    override val key: String get() = "missing:${providerId.key}:${entry.providerBookId}"
+  }
+
+  data class Upcoming(val entry: ProviderSeriesEntry, val providerId: ProviderId) : SeriesEntry {
+    override val key: String get() = "upcoming:${providerId.key}:${entry.providerBookId}"
+  }
+}
+
+/**
+ * Presentation-ready series listing. [providerId]/[providerName] are null when
+ * no provider could serve the series — [entries] then contains only [SeriesEntry.Owned]
+ * rows. Provider attribution must be shown when provider-sourced rows render.
+ */
+data class SeriesInfoState(
+  val providerId: ProviderId?,
+  val providerName: String?,
+  val isCompleted: Boolean?,
+  val entries: List<SeriesEntry>,
+)

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/SeriesMatch.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/SeriesMatch.kt
@@ -1,0 +1,32 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.api
+
+import app.campfire.core.model.LibraryItem
+
+/**
+ * How a library series is identified against an external provider's catalog.
+ * Series carry no hard identifiers in Audiobookshelf, so matching goes through
+ * the series name plus the identifiers of the books the user owns in it —
+ * providers should verify a candidate series by member overlap, not name alone.
+ */
+data class SeriesMatch(
+  val seriesName: String,
+  val memberMatches: List<BookMatch.Identifiers>,
+) {
+  /** Stable string form, used to detect when a series' identity changes. */
+  val cacheKey: String
+    get() = "series:$seriesName;" + memberMatches.joinToString("|") { it.cacheKey }
+}
+
+/**
+ * Derives a [SeriesMatch] from a series name and the user's items in it, or
+ * null when no member carries an identifier a catalog can key on.
+ */
+fun seriesMatch(seriesName: String, ownedItems: List<LibraryItem>): SeriesMatch? {
+  val members = ownedItems
+    .mapNotNull { it.bestMatch() as? BookMatch.Identifiers }
+  if (members.isEmpty()) return null
+  return SeriesMatch(seriesName = seriesName, memberMatches = members)
+}

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/HardcoverBookInfoProvider.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/HardcoverBookInfoProvider.kt
@@ -24,6 +24,8 @@ import app.campfire.bookinfo.hardcover.graphql.HardcoverGraphQlException
 import app.campfire.bookinfo.hardcover.graphql.HardcoverResult
 import app.campfire.bookinfo.hardcover.graphql.ME_QUERY
 import app.campfire.bookinfo.hardcover.graphql.MeData
+import app.campfire.bookinfo.hardcover.graphql.SERIES_BOOKS_QUERY
+import app.campfire.bookinfo.hardcover.graphql.SeriesCandidatesData
 import app.campfire.bookinfo.hardcover.graphql.SeriesData
 import app.campfire.bookinfo.hardcover.graphql.UserBooksData
 import app.campfire.bookinfo.hardcover.graphql.bookByIdentifiersQuery
@@ -32,8 +34,8 @@ import app.campfire.bookinfo.hardcover.graphql.normalizedIdentifier
 import app.campfire.bookinfo.hardcover.graphql.parseCoverUrl
 import app.campfire.bookinfo.hardcover.graphql.parseRatingsDistribution
 import app.campfire.bookinfo.hardcover.graphql.parseUsername
-import app.campfire.bookinfo.hardcover.graphql.pickSeriesCandidate
-import app.campfire.bookinfo.hardcover.graphql.seriesByMembersQuery
+import app.campfire.bookinfo.hardcover.graphql.pickSeriesId
+import app.campfire.bookinfo.hardcover.graphql.seriesCandidatesQuery
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.session.UserSession
@@ -142,24 +144,42 @@ class HardcoverBookInfoProvider(
     }
   }
 
+  /**
+   * Resolves a series in two steps: read the series off the books the user owns
+   * (Hardcover's own book→series edges), then fetch that one series' books.
+   * Two small queries beat one reverse-search — see [seriesCandidatesQuery].
+   */
   override suspend fun getSeries(match: SeriesMatch): BookInfoResult<ProviderSeries> {
     val isbns = match.memberMatches.mapNotNull { it.isbn?.normalizedIdentifier() }.distinct()
     val asins = match.memberMatches.mapNotNull { it.asin?.normalizedIdentifier() }.distinct()
     if (isbns.isEmpty() && asins.isEmpty()) return BookInfoResult.NotFound
 
-    val document = seriesByMembersQuery(hasIsbns = isbns.isNotEmpty(), hasAsins = asins.isNotEmpty())
-    val variables = buildJsonObject {
+    val candidatesDocument = seriesCandidatesQuery(
+      hasIsbns = isbns.isNotEmpty(),
+      hasAsins = asins.isNotEmpty(),
+    )
+    val candidatesVariables = buildJsonObject {
       if (isbns.isNotEmpty()) put("isbns", JsonArray(isbns.map { JsonPrimitive(it) }))
       if (asins.isNotEmpty()) put("asins", JsonArray(asins.map { JsonPrimitive(it) }))
     }
 
-    return when (val result = graphQl.execute(document, variables, SeriesData.serializer())) {
+    val candidates = when (
+      val result =
+        graphQl.execute(candidatesDocument, candidatesVariables, SeriesCandidatesData.serializer())
+    ) {
+      is HardcoverResult.Success -> result.data
+      else -> return result.toBookInfoError()
+    }
+
+    val picked = pickSeriesId(candidates, match) ?: return BookInfoResult.NotFound
+
+    val booksVariables = buildJsonObject { put("seriesId", picked.id) }
+    return when (
+      val result = graphQl.execute(SERIES_BOOKS_QUERY, booksVariables, SeriesData.serializer())
+    ) {
       is HardcoverResult.Success -> {
-        val candidate = pickSeriesCandidate(result.data.series, match)
-          ?: return BookInfoResult.NotFound
-        BookInfoResult.Success(
-          canonicalizeSeries(candidate, nowIsoDate = todayIsoDate()),
-        )
+        val series = result.data.series.firstOrNull() ?: return BookInfoResult.NotFound
+        BookInfoResult.Success(canonicalizeSeries(series, nowIsoDate = todayIsoDate()))
       }
       else -> result.toBookInfoError()
     }

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/HardcoverBookInfoProvider.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/HardcoverBookInfoProvider.kt
@@ -13,6 +13,8 @@ import app.campfire.bookinfo.api.LinkedAccount
 import app.campfire.bookinfo.api.ProviderCapabilities
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.api.ProviderSeries
+import app.campfire.bookinfo.api.SeriesMatch
 import app.campfire.bookinfo.hardcover.auth.HardcoverTokenStorage
 import app.campfire.bookinfo.hardcover.graphql.BOOK_REVIEWS_QUERY
 import app.campfire.bookinfo.hardcover.graphql.BooksData
@@ -22,18 +24,28 @@ import app.campfire.bookinfo.hardcover.graphql.HardcoverGraphQlException
 import app.campfire.bookinfo.hardcover.graphql.HardcoverResult
 import app.campfire.bookinfo.hardcover.graphql.ME_QUERY
 import app.campfire.bookinfo.hardcover.graphql.MeData
+import app.campfire.bookinfo.hardcover.graphql.SeriesData
 import app.campfire.bookinfo.hardcover.graphql.UserBooksData
 import app.campfire.bookinfo.hardcover.graphql.bookByIdentifiersQuery
+import app.campfire.bookinfo.hardcover.graphql.canonicalizeSeries
+import app.campfire.bookinfo.hardcover.graphql.normalizedIdentifier
 import app.campfire.bookinfo.hardcover.graphql.parseCoverUrl
 import app.campfire.bookinfo.hardcover.graphql.parseRatingsDistribution
 import app.campfire.bookinfo.hardcover.graphql.parseUsername
+import app.campfire.bookinfo.hardcover.graphql.pickSeriesCandidate
+import app.campfire.bookinfo.hardcover.graphql.seriesByMembersQuery
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.session.UserSession
 import app.campfire.core.session.userId
 import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import kotlin.time.Clock
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import me.tatarka.inject.annotations.Inject
@@ -53,10 +65,11 @@ class HardcoverBookInfoProvider(
   override val displayName: String = "Hardcover"
   override val linkHelpUrl: String = "https://hardcover.app/account/api"
 
-  // Series capabilities stay false until the series contract lands in the api.
   override val capabilities: ProviderCapabilities = ProviderCapabilities(
     hasReviewText = true,
     hasAggregateRating = true,
+    hasSeriesOrdering = true,
+    hasUpcomingReleases = true,
     hasSupplementalMetadata = true,
     requiresAccountLink = true,
   )
@@ -127,6 +140,36 @@ class HardcoverBookInfoProvider(
       )
       else -> result.toBookInfoError()
     }
+  }
+
+  override suspend fun getSeries(match: SeriesMatch): BookInfoResult<ProviderSeries> {
+    val isbns = match.memberMatches.mapNotNull { it.isbn?.normalizedIdentifier() }.distinct()
+    val asins = match.memberMatches.mapNotNull { it.asin?.normalizedIdentifier() }.distinct()
+    if (isbns.isEmpty() && asins.isEmpty()) return BookInfoResult.NotFound
+
+    val document = seriesByMembersQuery(hasIsbns = isbns.isNotEmpty(), hasAsins = asins.isNotEmpty())
+    val variables = buildJsonObject {
+      if (isbns.isNotEmpty()) put("isbns", JsonArray(isbns.map { JsonPrimitive(it) }))
+      if (asins.isNotEmpty()) put("asins", JsonArray(asins.map { JsonPrimitive(it) }))
+    }
+
+    return when (val result = graphQl.execute(document, variables, SeriesData.serializer())) {
+      is HardcoverResult.Success -> {
+        val candidate = pickSeriesCandidate(result.data.series, match)
+          ?: return BookInfoResult.NotFound
+        BookInfoResult.Success(
+          canonicalizeSeries(candidate, nowIsoDate = todayIsoDate()),
+        )
+      }
+      else -> result.toBookInfoError()
+    }
+  }
+
+  private fun todayIsoDate(): String {
+    return Clock.System.now()
+      .toLocalDateTime(TimeZone.currentSystemDefault())
+      .date
+      .toString()
   }
 
   override suspend fun verifyAndLink(token: String): Result<LinkedAccount> {

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverSeries.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverSeries.kt
@@ -1,0 +1,217 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover.graphql
+
+import app.campfire.bookinfo.api.ProviderSeries
+import app.campfire.bookinfo.api.ProviderSeriesEntry
+import app.campfire.bookinfo.api.SeriesMatch
+import kotlin.math.floor
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Finds candidate series by member books rather than by name — Audiobookshelf
+ * series names don't reliably match Hardcover's, but the user's books do.
+ * GraphQL requires every declared variable to be used, so declarations and
+ * predicates are built together.
+ */
+internal fun seriesByMembersQuery(hasIsbns: Boolean, hasAsins: Boolean): String {
+  require(hasIsbns || hasAsins) { "At least one identifier list is required" }
+  val variables = buildList {
+    if (hasIsbns) add("${'$'}isbns: [String!]!")
+    if (hasAsins) add("${'$'}asins: [String!]!")
+  }.joinToString(", ")
+  val predicates = buildList {
+    if (hasIsbns) {
+      add("{isbn_13: {_in: ${'$'}isbns}}")
+      add("{isbn_10: {_in: ${'$'}isbns}}")
+    }
+    if (hasAsins) {
+      add("{asin: {_in: ${'$'}asins}}")
+    }
+  }.joinToString(", ")
+  return """
+  query SeriesByMembers($variables) {
+    series(
+      where: {book_series: {book: {editions: {_or: [$predicates]}}}}
+      order_by: {books_count: desc}
+      limit: 5
+    ) {
+      id
+      name
+      is_completed
+      books_count
+      book_series(order_by: {position: asc}) {
+        position
+        compilation
+        book {
+          id
+          slug
+          title
+          release_date
+          users_count
+          cached_image
+          editions(limit: 25) {
+            isbn_10
+            isbn_13
+            asin
+          }
+        }
+      }
+    }
+  }
+  """.trimIndent()
+}
+
+@Serializable
+internal data class SeriesData(
+  val series: List<HardcoverSeries> = emptyList(),
+)
+
+@Serializable
+internal data class HardcoverSeries(
+  val id: Long,
+  val name: String? = null,
+  @SerialName("is_completed") val isCompleted: Boolean? = null,
+  @SerialName("books_count") val booksCount: Int? = null,
+  @SerialName("book_series") val bookSeries: List<HardcoverBookSeries> = emptyList(),
+)
+
+@Serializable
+internal data class HardcoverBookSeries(
+  val position: Double? = null,
+  val compilation: Boolean? = null,
+  val book: HardcoverSeriesBook? = null,
+)
+
+@Serializable
+internal data class HardcoverSeriesBook(
+  val id: Long,
+  val slug: String? = null,
+  val title: String? = null,
+  @SerialName("release_date") val releaseDate: String? = null,
+  @SerialName("users_count") val usersCount: Int? = null,
+  @SerialName("cached_image") val cachedImage: JsonElement? = null,
+  val editions: List<HardcoverEdition> = emptyList(),
+)
+
+@Serializable
+internal data class HardcoverEdition(
+  @SerialName("isbn_10") val isbn10: String? = null,
+  @SerialName("isbn_13") val isbn13: String? = null,
+  val asin: String? = null,
+)
+
+/**
+ * Picks the series the user's books actually belong to: exact normalized name
+ * match first (a book can sit in several series, e.g. a saga and its parent
+ * universe), then the candidate overlapping the most member identifiers.
+ */
+internal fun pickSeriesCandidate(
+  candidates: List<HardcoverSeries>,
+  match: SeriesMatch,
+): HardcoverSeries? {
+  if (candidates.isEmpty()) return null
+  val targetName = match.seriesName.normalizedTitle()
+  candidates.firstOrNull { it.name?.normalizedTitle() == targetName }?.let { return it }
+
+  val memberIds = buildSet {
+    match.memberMatches.forEach { member ->
+      member.isbn?.normalizedIdentifier()?.let(::add)
+      member.asin?.normalizedIdentifier()?.let(::add)
+    }
+  }
+  return candidates.maxByOrNull { candidate -> candidate.memberOverlap(memberIds) }
+}
+
+private fun HardcoverSeries.memberOverlap(memberIds: Set<String>): Int {
+  return bookSeries.count { row ->
+    row.book?.editions.orEmpty().any { edition ->
+      edition.isbn13?.normalizedIdentifier() in memberIds ||
+        edition.isbn10?.normalizedIdentifier() in memberIds ||
+        edition.asin?.normalizedIdentifier() in memberIds
+    }
+  }
+}
+
+/**
+ * Reduces Hardcover's raw series rows — which mix translations, box sets, and
+ * split editions at overlapping positions — to one canonical entry per
+ * position:
+ *
+ * 1. compilations (box sets) are dropped
+ * 2. duplicate positions keep the most-shelved row (translations lose to the
+ *    canonical edition on `users_count`)
+ * 3. fractional positions that just re-title their base book (split parts,
+ *    dramatized adaptations) are dropped; genuine companion novellas survive
+ */
+internal fun canonicalizeSeries(
+  series: HardcoverSeries,
+  nowIsoDate: String,
+): ProviderSeries {
+  data class Row(val position: Double, val book: HardcoverSeriesBook)
+
+  val rows = series.bookSeries.mapNotNull { bookSeries ->
+    val position = bookSeries.position ?: return@mapNotNull null
+    if (bookSeries.compilation == true) return@mapNotNull null
+    val book = bookSeries.book ?: return@mapNotNull null
+    if (book.title.isNullOrBlank()) return@mapNotNull null
+    Row(position, book)
+  }
+
+  val byPosition = rows
+    .groupBy { it.position }
+    .mapValues { (_, group) -> group.maxBy { it.book.usersCount ?: 0 } }
+
+  val entries = byPosition.values
+    .filter { row ->
+      val isWholePosition = row.position == floor(row.position)
+      if (isWholePosition) return@filter true
+      val baseTitle = byPosition[floor(row.position)]?.book?.title?.normalizedTitle()
+      baseTitle == null || !row.book.title!!.normalizedTitle().startsWith(baseTitle)
+    }
+    .map { row ->
+      val book = row.book
+      ProviderSeriesEntry(
+        providerBookId = book.id.toString(),
+        position = row.position,
+        title = book.title!!,
+        releaseDate = book.releaseDate,
+        isReleased = isReleasedBy(book.releaseDate, nowIsoDate),
+        providerUrl = book.slug?.let { "https://hardcover.app/books/$it" },
+        coverUrl = parseCoverUrl(book.cachedImage),
+        isbns = book.editions
+          .mapNotNull { it.isbn13?.normalizedIdentifier() ?: it.isbn10?.normalizedIdentifier() }
+          .distinct(),
+        asins = book.editions
+          .mapNotNull { it.asin?.normalizedIdentifier() }
+          .distinct(),
+      )
+    }
+    .sortedBy { it.position }
+
+  return ProviderSeries(
+    providerSeriesId = series.id.toString(),
+    name = series.name.orEmpty(),
+    isCompleted = series.isCompleted,
+    entries = entries,
+  )
+}
+
+/** ISO dates compare lexicographically; a missing date means announced-only. */
+internal fun isReleasedBy(releaseDate: String?, nowIsoDate: String): Boolean {
+  val date = releaseDate?.take(10)?.takeUnless { it.isBlank() } ?: return false
+  return date <= nowIsoDate
+}
+
+internal fun String.normalizedTitle(): String {
+  return lowercase()
+    .filter { it.isLetterOrDigit() }
+    .removePrefix("the")
+}
+
+internal fun String.normalizedIdentifier(): String? {
+  return filter { it.isLetterOrDigit() }.uppercase().takeUnless { it.isEmpty() }
+}

--- a/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverSeries.kt
+++ b/data/bookinfo/hardcover/src/commonMain/kotlin/app/campfire/bookinfo/hardcover/graphql/HardcoverSeries.kt
@@ -12,12 +12,16 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Finds candidate series by member books rather than by name — Audiobookshelf
- * series names don't reliably match Hardcover's, but the user's books do.
- * GraphQL requires every declared variable to be used, so declarations and
- * predicates are built together.
+ * Step 1 of series resolution: look up the books the user owns and read the
+ * series Hardcover puts them in.
+ *
+ * This walks Hardcover's own book→series edges rather than reverse-searching
+ * the catalog for series containing those books. A reverse search ranks parent
+ * universes above the series you actually want (The Cosmere has more books than
+ * The Stormlight Archive, and contains every Sanderson book you own), so it
+ * reliably picks the wrong one.
  */
-internal fun seriesByMembersQuery(hasIsbns: Boolean, hasAsins: Boolean): String {
+internal fun seriesCandidatesQuery(hasIsbns: Boolean, hasAsins: Boolean): String {
   require(hasIsbns || hasAsins) { "At least one identifier list is required" }
   val variables = buildList {
     if (hasIsbns) add("${'$'}isbns: [String!]!")
@@ -33,16 +37,34 @@ internal fun seriesByMembersQuery(hasIsbns: Boolean, hasAsins: Boolean): String 
     }
   }.joinToString(", ")
   return """
-  query SeriesByMembers($variables) {
-    series(
-      where: {book_series: {book: {editions: {_or: [$predicates]}}}}
-      order_by: {books_count: desc}
-      limit: 5
-    ) {
+  query SeriesCandidates($variables) {
+    books(where: {editions: {_or: [$predicates]}}, limit: 10) {
+      id
+      book_series {
+        featured
+        position
+        series {
+          id
+          name
+          books_count
+          primary_books_count
+          is_completed
+        }
+      }
+    }
+  }
+  """.trimIndent()
+}
+
+/** Step 2: the chosen series' books, in reading order. */
+internal val SERIES_BOOKS_QUERY = """
+  query SeriesBooks(${'$'}seriesId: Int!) {
+    series(where: {id: {_eq: ${'$'}seriesId}}, limit: 1) {
       id
       name
       is_completed
       books_count
+      primary_books_count
       book_series(order_by: {position: asc}) {
         position
         compilation
@@ -62,8 +84,34 @@ internal fun seriesByMembersQuery(hasIsbns: Boolean, hasAsins: Boolean): String 
       }
     }
   }
-  """.trimIndent()
-}
+""".trimIndent()
+
+@Serializable
+internal data class SeriesCandidatesData(
+  val books: List<HardcoverCandidateBook> = emptyList(),
+)
+
+@Serializable
+internal data class HardcoverCandidateBook(
+  val id: Long,
+  @SerialName("book_series") val bookSeries: List<HardcoverCandidateSeriesRow> = emptyList(),
+)
+
+@Serializable
+internal data class HardcoverCandidateSeriesRow(
+  val featured: Boolean? = null,
+  val position: Double? = null,
+  val series: HardcoverSeriesSummary? = null,
+)
+
+@Serializable
+internal data class HardcoverSeriesSummary(
+  val id: Long,
+  val name: String? = null,
+  @SerialName("books_count") val booksCount: Int? = null,
+  @SerialName("primary_books_count") val primaryBooksCount: Int? = null,
+  @SerialName("is_completed") val isCompleted: Boolean? = null,
+)
 
 @Serializable
 internal data class SeriesData(
@@ -76,6 +124,7 @@ internal data class HardcoverSeries(
   val name: String? = null,
   @SerialName("is_completed") val isCompleted: Boolean? = null,
   @SerialName("books_count") val booksCount: Int? = null,
+  @SerialName("primary_books_count") val primaryBooksCount: Int? = null,
   @SerialName("book_series") val bookSeries: List<HardcoverBookSeries> = emptyList(),
 )
 
@@ -105,47 +154,58 @@ internal data class HardcoverEdition(
 )
 
 /**
- * Picks the series the user's books actually belong to: exact normalized name
- * match first (a book can sit in several series, e.g. a saga and its parent
- * universe), then the candidate overlapping the most member identifiers.
+ * Chooses which of the candidate series the user's shelf actually represents.
+ *
+ * A book commonly belongs to several series at once — a saga and the wider
+ * universe it sits in — so preference order is:
+ *
+ * 1. the series whose name matches the Audiobookshelf series name
+ * 2. the series shared by the most of the user's books
+ * 3. the series Hardcover marks as `featured` on those books (its primary one)
+ * 4. the most specific series, i.e. the fewest main books
  */
-internal fun pickSeriesCandidate(
-  candidates: List<HardcoverSeries>,
+internal fun pickSeriesId(
+  data: SeriesCandidatesData,
   match: SeriesMatch,
-): HardcoverSeries? {
-  if (candidates.isEmpty()) return null
+): HardcoverSeriesSummary? {
+  val rows = data.books.flatMap { book ->
+    book.bookSeries.mapNotNull { row -> row.series?.let { it to (row.featured == true) } }
+  }
+  if (rows.isEmpty()) return null
+
   val targetName = match.seriesName.normalizedTitle()
-  candidates.firstOrNull { it.name?.normalizedTitle() == targetName }?.let { return it }
+  rows.firstOrNull { (series, _) -> series.name?.normalizedTitle() == targetName }
+    ?.let { return it.first }
 
-  val memberIds = buildSet {
-    match.memberMatches.forEach { member ->
-      member.isbn?.normalizedIdentifier()?.let(::add)
-      member.asin?.normalizedIdentifier()?.let(::add)
-    }
-  }
-  return candidates.maxByOrNull { candidate -> candidate.memberOverlap(memberIds) }
-}
-
-private fun HardcoverSeries.memberOverlap(memberIds: Set<String>): Int {
-  return bookSeries.count { row ->
-    row.book?.editions.orEmpty().any { edition ->
-      edition.isbn13?.normalizedIdentifier() in memberIds ||
-        edition.isbn10?.normalizedIdentifier() in memberIds ||
-        edition.asin?.normalizedIdentifier() in memberIds
-    }
-  }
+  val grouped = rows.groupBy { it.first.id }
+  return grouped.values
+    .maxWithOrNull(
+      compareBy(
+        { group -> group.size },
+        { group -> group.count { it.second } },
+        { group -> -(group.first().first.primaryBooksCount ?: group.first().first.booksCount ?: 0) },
+      ),
+    )
+    ?.first()
+    ?.first
 }
 
 /**
- * Reduces Hardcover's raw series rows — which mix translations, box sets, and
- * split editions at overlapping positions — to one canonical entry per
- * position:
+ * Reduces a series' raw rows to its main books in reading order.
+ *
+ * Hardcover lists everything under a series: translations and box sets at the
+ * same position as the canonical edition, split audio editions at fractional
+ * positions, and companion novellas. `primary_books_count` is documented as
+ * "main series books (excluding companions)", and those main books are exactly
+ * the whole-numbered positions — so:
  *
  * 1. compilations (box sets) are dropped
- * 2. duplicate positions keep the most-shelved row (translations lose to the
- *    canonical edition on `users_count`)
- * 3. fractional positions that just re-title their base book (split parts,
- *    dramatized adaptations) are dropped; genuine companion novellas survive
+ * 2. fractional positions are dropped as companions/split editions
+ * 3. duplicates at one position keep the most-shelved row, so translations lose
+ *    to the canonical edition
+ *
+ * Companions the user actually owns are unaffected: the merge keeps owned books
+ * the provider listing doesn't mention.
  */
 internal fun canonicalizeSeries(
   series: HardcoverSeries,
@@ -153,25 +213,18 @@ internal fun canonicalizeSeries(
 ): ProviderSeries {
   data class Row(val position: Double, val book: HardcoverSeriesBook)
 
-  val rows = series.bookSeries.mapNotNull { bookSeries ->
+  val mainRows = series.bookSeries.mapNotNull { bookSeries ->
     val position = bookSeries.position ?: return@mapNotNull null
     if (bookSeries.compilation == true) return@mapNotNull null
+    if (position != floor(position)) return@mapNotNull null
     val book = bookSeries.book ?: return@mapNotNull null
     if (book.title.isNullOrBlank()) return@mapNotNull null
     Row(position, book)
   }
 
-  val byPosition = rows
+  val entries = mainRows
     .groupBy { it.position }
-    .mapValues { (_, group) -> group.maxBy { it.book.usersCount ?: 0 } }
-
-  val entries = byPosition.values
-    .filter { row ->
-      val isWholePosition = row.position == floor(row.position)
-      if (isWholePosition) return@filter true
-      val baseTitle = byPosition[floor(row.position)]?.book?.title?.normalizedTitle()
-      baseTitle == null || !row.book.title!!.normalizedTitle().startsWith(baseTitle)
-    }
+    .map { (_, group) -> group.maxBy { it.book.usersCount ?: 0 } }
     .map { row ->
       val book = row.book
       ProviderSeriesEntry(

--- a/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/CanonicalizeSeriesTest.kt
+++ b/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/CanonicalizeSeriesTest.kt
@@ -1,0 +1,220 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.hardcover
+
+import app.campfire.bookinfo.api.BookMatch
+import app.campfire.bookinfo.api.SeriesMatch
+import app.campfire.bookinfo.hardcover.graphql.HardcoverBookSeries
+import app.campfire.bookinfo.hardcover.graphql.HardcoverEdition
+import app.campfire.bookinfo.hardcover.graphql.HardcoverSeries
+import app.campfire.bookinfo.hardcover.graphql.HardcoverSeriesBook
+import app.campfire.bookinfo.hardcover.graphql.canonicalizeSeries
+import app.campfire.bookinfo.hardcover.graphql.isReleasedBy
+import app.campfire.bookinfo.hardcover.graphql.pickSeriesCandidate
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+/**
+ * Fixtures mirror the real shape of Hardcover's Stormlight Archive listing
+ * (see docs/research/book-metadata-providers.md): translations and box sets
+ * share positions with the canonical edition, split audio editions sit at
+ * fractional positions, and unreleased books carry placeholder future years.
+ */
+private const val TODAY = "2026-08-31"
+
+private var nextId = 1L
+
+private fun book(
+  title: String,
+  usersCount: Int = 0,
+  releaseDate: String? = "2010-08-31",
+  isbn13: String? = null,
+  asin: String? = null,
+  id: Long = nextId++,
+) = HardcoverSeriesBook(
+  id = id,
+  slug = title.lowercase().replace(" ", "-"),
+  title = title,
+  releaseDate = releaseDate,
+  usersCount = usersCount,
+  cachedImage = null,
+  editions = listOf(HardcoverEdition(isbn13 = isbn13, asin = asin)),
+)
+
+private fun row(position: Double, book: HardcoverSeriesBook, compilation: Boolean = false) =
+  HardcoverBookSeries(position = position, compilation = compilation, book = book)
+
+class CanonicalizeSeriesTest {
+
+  @Test
+  fun `box set compilations are dropped`() {
+    val series = HardcoverSeries(
+      id = 997,
+      name = "The Stormlight Archive",
+      bookSeries = listOf(
+        row(1.0, book("The Way of Kings", usersCount = 9505)),
+        row(1.0, book("The Stormlight Archive, Books 1-4"), compilation = true),
+      ),
+    )
+
+    val result = canonicalizeSeries(series, TODAY)
+
+    assertThat(result.entries.map { it.title }).isEqualTo(listOf("The Way of Kings"))
+  }
+
+  @Test
+  fun `translations lose to the most shelved edition at the same position`() {
+    val series = HardcoverSeries(
+      id = 997,
+      bookSeries = listOf(
+        row(1.0, book("Путь королей", usersCount = 0)),
+        row(1.0, book("The Way of Kings", usersCount = 9505)),
+        row(1.0, book("Der Weg der Könige", usersCount = 3)),
+      ),
+    )
+
+    val result = canonicalizeSeries(series, TODAY)
+
+    assertThat(result.entries.map { it.title }).isEqualTo(listOf("The Way of Kings"))
+  }
+
+  @Test
+  fun `split part editions are dropped but companion novellas survive`() {
+    val series = HardcoverSeries(
+      id = 997,
+      bookSeries = listOf(
+        row(1.0, book("The Way of Kings", usersCount = 9505)),
+        row(1.1, book("The Way of Kings, Part 1", usersCount = 437)),
+        row(1.2, book("The Way of Kings, Part 2", usersCount = 67)),
+        row(2.0, book("Words of Radiance", usersCount = 5971)),
+        row(2.5, book("Edgedancer", usersCount = 2000)),
+      ),
+    )
+
+    val result = canonicalizeSeries(series, TODAY)
+
+    assertThat(result.entries.map { it.title })
+      .isEqualTo(listOf("The Way of Kings", "Words of Radiance", "Edgedancer"))
+  }
+
+  @Test
+  fun `unreleased books are flagged and kept in order`() {
+    val series = HardcoverSeries(
+      id = 997,
+      isCompleted = false,
+      bookSeries = listOf(
+        row(4.0, book("Rhythm of War", usersCount = 4000, releaseDate = "2020-11-17")),
+        row(4.5, book("Horneater", usersCount = 120, releaseDate = "2027-01-01")),
+        row(6.0, book("Untitled Stormlight Archive #6", releaseDate = null)),
+      ),
+    )
+
+    val result = canonicalizeSeries(series, TODAY)
+
+    assertThat(result.entries.map { it.title to it.isReleased }).isEqualTo(
+      listOf(
+        "Rhythm of War" to true,
+        "Horneater" to false,
+        "Untitled Stormlight Archive #6" to false,
+      ),
+    )
+    assertThat(result.isCompleted).isEqualTo(false)
+  }
+
+  @Test
+  fun `entries are sorted by position and carry identifiers`() {
+    val series = HardcoverSeries(
+      id = 997,
+      bookSeries = listOf(
+        row(2.0, book("Words of Radiance", isbn13 = "9780765326379")),
+        row(1.0, book("The Way of Kings", isbn13 = "9780765393043", asin = "B003P2WO5E")),
+      ),
+    )
+
+    val result = canonicalizeSeries(series, TODAY)
+
+    assertThat(result.entries.map { it.position }).isEqualTo(listOf(1.0, 2.0))
+    assertThat(result.entries.first().isbns).isEqualTo(listOf("9780765393043"))
+    assertThat(result.entries.first().asins).isEqualTo(listOf("B003P2WO5E"))
+  }
+
+  @Test
+  fun `rows without a position or title are skipped`() {
+    val series = HardcoverSeries(
+      id = 997,
+      bookSeries = listOf(
+        row(1.0, book("The Way of Kings")),
+        HardcoverBookSeries(position = null, book = book("Positionless")),
+        row(3.0, book("")),
+      ),
+    )
+
+    val result = canonicalizeSeries(series, TODAY)
+
+    assertThat(result.entries.map { it.title }).isEqualTo(listOf("The Way of Kings"))
+  }
+
+  @Test
+  fun `release dates are compared against today`() {
+    assertThat(isReleasedBy("2010-08-31", TODAY)).isTrue()
+    assertThat(isReleasedBy("2027-01-01", TODAY)).isFalse()
+    assertThat(isReleasedBy(null, TODAY)).isFalse()
+    assertThat(isReleasedBy("2026-08-31T00:00:00Z", TODAY)).isTrue()
+  }
+
+  @Test
+  fun `candidate selection prefers an exact name match`() {
+    val match = SeriesMatch(
+      seriesName = "The Stormlight Archive",
+      memberMatches = listOf(BookMatch.Identifiers(isbn = "9780765393043", asin = null)),
+    )
+    val cosmere = HardcoverSeries(id = 5497, name = "The Cosmere")
+    val stormlight = HardcoverSeries(id = 997, name = "Stormlight Archive")
+
+    val picked = pickSeriesCandidate(listOf(cosmere, stormlight), match)
+
+    assertThat(picked).isNotNull()
+    assertThat(picked!!.id).isEqualTo(997L)
+  }
+
+  @Test
+  fun `candidate selection falls back to member overlap`() {
+    val match = SeriesMatch(
+      seriesName = "Completely Different Name",
+      memberMatches = listOf(
+        BookMatch.Identifiers(isbn = "978-0-7653-9304-3", asin = null),
+        BookMatch.Identifiers(isbn = "9780765326379", asin = null),
+      ),
+    )
+    val unrelated = HardcoverSeries(
+      id = 1,
+      name = "Unrelated",
+      bookSeries = listOf(row(1.0, book("Other", isbn13 = "9999999999999"))),
+    )
+    val stormlight = HardcoverSeries(
+      id = 997,
+      name = "Stormlight",
+      bookSeries = listOf(
+        row(1.0, book("The Way of Kings", isbn13 = "9780765393043")),
+        row(2.0, book("Words of Radiance", isbn13 = "9780765326379")),
+      ),
+    )
+
+    val picked = pickSeriesCandidate(listOf(unrelated, stormlight), match)
+
+    assertThat(picked!!.id).isEqualTo(997L)
+  }
+
+  @Test
+  fun `no candidates yields no series`() {
+    val match = SeriesMatch("Any", listOf(BookMatch.Identifiers(isbn = "1", asin = null)))
+
+    assertThat(pickSeriesCandidate(emptyList(), match)).isNull()
+  }
+}

--- a/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/CanonicalizeSeriesTest.kt
+++ b/data/bookinfo/hardcover/src/commonTest/kotlin/app/campfire/bookinfo/hardcover/CanonicalizeSeriesTest.kt
@@ -6,12 +6,16 @@ package app.campfire.bookinfo.hardcover
 import app.campfire.bookinfo.api.BookMatch
 import app.campfire.bookinfo.api.SeriesMatch
 import app.campfire.bookinfo.hardcover.graphql.HardcoverBookSeries
+import app.campfire.bookinfo.hardcover.graphql.HardcoverCandidateBook
+import app.campfire.bookinfo.hardcover.graphql.HardcoverCandidateSeriesRow
 import app.campfire.bookinfo.hardcover.graphql.HardcoverEdition
 import app.campfire.bookinfo.hardcover.graphql.HardcoverSeries
 import app.campfire.bookinfo.hardcover.graphql.HardcoverSeriesBook
+import app.campfire.bookinfo.hardcover.graphql.HardcoverSeriesSummary
+import app.campfire.bookinfo.hardcover.graphql.SeriesCandidatesData
 import app.campfire.bookinfo.hardcover.graphql.canonicalizeSeries
 import app.campfire.bookinfo.hardcover.graphql.isReleasedBy
-import app.campfire.bookinfo.hardcover.graphql.pickSeriesCandidate
+import app.campfire.bookinfo.hardcover.graphql.pickSeriesId
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
@@ -21,12 +25,29 @@ import assertk.assertions.isTrue
 import kotlin.test.Test
 
 /**
- * Fixtures mirror the real shape of Hardcover's Stormlight Archive listing
- * (see docs/research/book-metadata-providers.md): translations and box sets
- * share positions with the canonical edition, split audio editions sit at
- * fractional positions, and unreleased books carry placeholder future years.
+ * Fixtures mirror the real shape of Hardcover's Stormlight Archive data
+ * (verified live — see docs/research/book-metadata-providers.md): every book
+ * belongs to both the saga (997, primary_books_count 10) and the wider Cosmere
+ * (5497, primary_books_count 34), and the raw series listing mixes
+ * translations, box sets, split audio editions, and companion novellas.
  */
 private const val TODAY = "2026-08-31"
+
+private val STORMLIGHT = HardcoverSeriesSummary(
+  id = 997,
+  name = "The Stormlight Archive",
+  booksCount = 27,
+  primaryBooksCount = 10,
+  isCompleted = false,
+)
+
+private val COSMERE = HardcoverSeriesSummary(
+  id = 5497,
+  name = "The Cosmere",
+  booksCount = 37,
+  primaryBooksCount = 34,
+  isCompleted = null,
+)
 
 private var nextId = 1L
 
@@ -50,16 +71,106 @@ private fun book(
 private fun row(position: Double, book: HardcoverSeriesBook, compilation: Boolean = false) =
   HardcoverBookSeries(position = position, compilation = compilation, book = book)
 
+/** An owned book that Hardcover puts in both the saga and the universe. */
+private fun candidateBook(
+  stormlightPosition: Double,
+  cosmerePosition: Double,
+) = HardcoverCandidateBook(
+  id = nextId++,
+  bookSeries = listOf(
+    HardcoverCandidateSeriesRow(featured = true, position = stormlightPosition, series = STORMLIGHT),
+    HardcoverCandidateSeriesRow(featured = false, position = cosmerePosition, series = COSMERE),
+  ),
+)
+
+private fun match(name: String) = SeriesMatch(
+  seriesName = name,
+  memberMatches = listOf(BookMatch.Identifiers(isbn = "9780765393043", asin = null)),
+)
+
 class CanonicalizeSeriesTest {
+
+  @Test
+  fun `the series matching the library name wins over the wider universe`() {
+    val data = SeriesCandidatesData(
+      books = listOf(candidateBook(1.0, 7.0), candidateBook(3.0, 21.0)),
+    )
+
+    val picked = pickSeriesId(data, match("The Stormlight Archive"))
+
+    assertThat(picked).isNotNull()
+    assertThat(picked!!.id).isEqualTo(997L)
+  }
+
+  @Test
+  fun `an unrecognized library name still avoids the parent universe`() {
+    // Both series are shared by every book, so the featured flag breaks the tie
+    // rather than the book count — which is what previously picked The Cosmere.
+    val data = SeriesCandidatesData(
+      books = listOf(candidateBook(1.0, 7.0), candidateBook(3.0, 21.0)),
+    )
+
+    val picked = pickSeriesId(data, match("Stormlight (audio editions)"))
+
+    assertThat(picked!!.id).isEqualTo(997L)
+  }
+
+  @Test
+  fun `the series shared by the most books wins`() {
+    val shared = HardcoverSeriesSummary(id = 42, name = "Shared", primaryBooksCount = 5)
+    val onlyOne = HardcoverSeriesSummary(id = 43, name = "Fringe", primaryBooksCount = 2)
+    val data = SeriesCandidatesData(
+      books = listOf(
+        HardcoverCandidateBook(1, listOf(HardcoverCandidateSeriesRow(false, 1.0, shared))),
+        HardcoverCandidateBook(
+          2,
+          listOf(
+            HardcoverCandidateSeriesRow(false, 2.0, shared),
+            HardcoverCandidateSeriesRow(false, 1.0, onlyOne),
+          ),
+        ),
+      ),
+    )
+
+    val picked = pickSeriesId(data, match("Unknown Name"))
+
+    assertThat(picked!!.id).isEqualTo(42L)
+  }
+
+  @Test
+  fun `no candidates yields no series`() {
+    assertThat(pickSeriesId(SeriesCandidatesData(), match("Any"))).isNull()
+  }
+
+  @Test
+  fun `only main books are kept`() {
+    val series = HardcoverSeries(
+      id = 997,
+      name = "The Stormlight Archive",
+      primaryBooksCount = 10,
+      bookSeries = listOf(
+        row(0.1, book("The Way of Kings Prime", usersCount = 203)),
+        row(1.0, book("The Way of Kings", usersCount = 9505)),
+        row(1.1, book("The Way of Kings, Part 1", usersCount = 437)),
+        row(1.2, book("The Way of Kings, Part 2", usersCount = 67)),
+        row(2.0, book("Words of Radiance", usersCount = 5971)),
+        row(2.5, book("Edgedancer", usersCount = 2000)),
+      ),
+    )
+
+    val result = canonicalizeSeries(series, TODAY)
+
+    assertThat(result.entries.map { it.title })
+      .isEqualTo(listOf("The Way of Kings", "Words of Radiance"))
+  }
 
   @Test
   fun `box set compilations are dropped`() {
     val series = HardcoverSeries(
       id = 997,
-      name = "The Stormlight Archive",
       bookSeries = listOf(
         row(1.0, book("The Way of Kings", usersCount = 9505)),
-        row(1.0, book("The Stormlight Archive, Books 1-4"), compilation = true),
+        row(2.0, book("The Stormlight Archive, Books 1-4"), compilation = true),
       ),
     )
 
@@ -85,26 +196,7 @@ class CanonicalizeSeriesTest {
   }
 
   @Test
-  fun `split part editions are dropped but companion novellas survive`() {
-    val series = HardcoverSeries(
-      id = 997,
-      bookSeries = listOf(
-        row(1.0, book("The Way of Kings", usersCount = 9505)),
-        row(1.1, book("The Way of Kings, Part 1", usersCount = 437)),
-        row(1.2, book("The Way of Kings, Part 2", usersCount = 67)),
-        row(2.0, book("Words of Radiance", usersCount = 5971)),
-        row(2.5, book("Edgedancer", usersCount = 2000)),
-      ),
-    )
-
-    val result = canonicalizeSeries(series, TODAY)
-
-    assertThat(result.entries.map { it.title })
-      .isEqualTo(listOf("The Way of Kings", "Words of Radiance", "Edgedancer"))
-  }
-
-  @Test
-  fun `unreleased books are flagged and kept in order`() {
+  fun `unreleased main books are flagged and kept in order`() {
     val series = HardcoverSeries(
       id = 997,
       isCompleted = false,
@@ -117,10 +209,10 @@ class CanonicalizeSeriesTest {
 
     val result = canonicalizeSeries(series, TODAY)
 
+    // Horneater sits at 4.5 — a companion, not a main entry.
     assertThat(result.entries.map { it.title to it.isReleased }).isEqualTo(
       listOf(
         "Rhythm of War" to true,
-        "Horneater" to false,
         "Untitled Stormlight Archive #6" to false,
       ),
     )
@@ -161,60 +253,31 @@ class CanonicalizeSeriesTest {
   }
 
   @Test
+  fun `main book count lines up with hardcover's own primary count`() {
+    // Positions 1..10 are the main entries; everything else is noise.
+    val series = HardcoverSeries(
+      id = 997,
+      primaryBooksCount = 10,
+      bookSeries = buildList {
+        add(row(0.1, book("The Way of Kings Prime")))
+        (1..10).forEach { add(row(it.toDouble(), book("Main Book $it"))) }
+        add(row(2.5, book("Edgedancer")))
+        add(row(3.5, book("Dawnshard")))
+        add(row(4.5, book("Horneater")))
+        add(row(5.0, book("Box Set"), compilation = true))
+      },
+    )
+
+    val result = canonicalizeSeries(series, TODAY)
+
+    assertThat(result.entries.size).isEqualTo(series.primaryBooksCount)
+  }
+
+  @Test
   fun `release dates are compared against today`() {
     assertThat(isReleasedBy("2010-08-31", TODAY)).isTrue()
     assertThat(isReleasedBy("2027-01-01", TODAY)).isFalse()
     assertThat(isReleasedBy(null, TODAY)).isFalse()
     assertThat(isReleasedBy("2026-08-31T00:00:00Z", TODAY)).isTrue()
-  }
-
-  @Test
-  fun `candidate selection prefers an exact name match`() {
-    val match = SeriesMatch(
-      seriesName = "The Stormlight Archive",
-      memberMatches = listOf(BookMatch.Identifiers(isbn = "9780765393043", asin = null)),
-    )
-    val cosmere = HardcoverSeries(id = 5497, name = "The Cosmere")
-    val stormlight = HardcoverSeries(id = 997, name = "Stormlight Archive")
-
-    val picked = pickSeriesCandidate(listOf(cosmere, stormlight), match)
-
-    assertThat(picked).isNotNull()
-    assertThat(picked!!.id).isEqualTo(997L)
-  }
-
-  @Test
-  fun `candidate selection falls back to member overlap`() {
-    val match = SeriesMatch(
-      seriesName = "Completely Different Name",
-      memberMatches = listOf(
-        BookMatch.Identifiers(isbn = "978-0-7653-9304-3", asin = null),
-        BookMatch.Identifiers(isbn = "9780765326379", asin = null),
-      ),
-    )
-    val unrelated = HardcoverSeries(
-      id = 1,
-      name = "Unrelated",
-      bookSeries = listOf(row(1.0, book("Other", isbn13 = "9999999999999"))),
-    )
-    val stormlight = HardcoverSeries(
-      id = 997,
-      name = "Stormlight",
-      bookSeries = listOf(
-        row(1.0, book("The Way of Kings", isbn13 = "9780765393043")),
-        row(2.0, book("Words of Radiance", isbn13 = "9780765326379")),
-      ),
-    )
-
-    val picked = pickSeriesCandidate(listOf(unrelated, stormlight), match)
-
-    assertThat(picked!!.id).isEqualTo(997L)
-  }
-
-  @Test
-  fun `no candidates yields no series`() {
-    val match = SeriesMatch("Any", listOf(BookMatch.Identifiers(isbn = "1", asin = null)))
-
-    assertThat(pickSeriesCandidate(emptyList(), match)).isNull()
   }
 }

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -128,13 +128,14 @@ class DefaultBookInfoRegistry(
     ownedItems: List<LibraryItem>,
     ownedOnly: SeriesInfoState,
   ): Flow<LoadState<out SeriesInfoState>> = flow {
+    // The user's own books are already local. Provider entries decorate that
+    // list, so they must never gate it behind a network round-trip — show the
+    // owned books immediately and merge provider entries in when they arrive.
+    emit(LoadState.Loaded(ownedOnly))
+
     val cached = seriesStore.cached(key)
     val invalidLink = status.linkState is ProviderLinkState.Invalid
-
-    if (invalidLink && cached == null) {
-      emit(LoadState.Loaded(ownedOnly))
-      return@flow
-    }
+    if (invalidLink && cached == null) return@flow
 
     val refresh = !invalidLink &&
       (
@@ -145,27 +146,20 @@ class DefaultBookInfoRegistry(
           )
         )
 
-    var emittedData = false
     seriesStore.stream(key, refresh = refresh).collect { response ->
-      when (response) {
-        is StoreReadResponse.Loading -> if (!emittedData) emit(LoadState.Loading)
-        is StoreReadResponse.Data -> {
-          emittedData = true
-          val series = response.value.series
-          emit(
-            LoadState.Loaded(
-              SeriesInfoState(
-                providerId = series?.let { status.provider.id },
-                providerName = series?.let { status.provider.displayName },
-                isCompleted = series?.isCompleted,
-                entries = mergeSeriesEntries(ownedItems, series, status.provider.id),
-              ),
+      // Loading and Error keep the owned-only list on screen.
+      if (response is StoreReadResponse.Data) {
+        val series = response.value.series
+        emit(
+          LoadState.Loaded(
+            SeriesInfoState(
+              providerId = series?.let { status.provider.id },
+              providerName = series?.let { status.provider.displayName },
+              isCompleted = series?.isCompleted,
+              entries = mergeSeriesEntries(ownedItems, series, status.provider.id),
             ),
-          )
-        }
-        // Provider-sourced entries are additive; on failure show what's owned.
-        is StoreReadResponse.Error -> if (!emittedData) emit(LoadState.Loaded(ownedOnly))
-        else -> Unit
+          ),
+        )
       }
     }
   }

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -11,10 +11,14 @@ import app.campfire.bookinfo.api.CommunitySource
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
 import app.campfire.bookinfo.api.ProviderStatus
+import app.campfire.bookinfo.api.SeriesInfoState
 import app.campfire.bookinfo.api.bestMatch
+import app.campfire.bookinfo.api.seriesMatch
 import app.campfire.bookinfo.store.BookInfoStore
 import app.campfire.bookinfo.store.CachedBookInfo
+import app.campfire.bookinfo.store.SeriesInfoStore
 import app.campfire.bookinfo.store.isStale
+import app.campfire.bookinfo.store.mergeSeriesEntries
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
@@ -42,6 +46,7 @@ class DefaultBookInfoRegistry(
   private val providers: Set<BookInfoProvider>,
   private val settings: BookInfoProviderSettings,
   private val store: BookInfoStore,
+  private val seriesStore: SeriesInfoStore,
   private val userSession: UserSession,
 ) : BookInfoRegistry {
 
@@ -84,8 +89,90 @@ class DefaultBookInfoRegistry(
       }
   }
 
+  override fun observeSeriesEntries(
+    seriesName: String,
+    ownedItems: List<LibraryItem>,
+  ): Flow<LoadState<out SeriesInfoState>> {
+    val ownedOnly = SeriesInfoState(
+      providerId = null,
+      providerName = null,
+      isCompleted = null,
+      entries = mergeSeriesEntries(ownedItems, series = null, providerId = ProviderId.Hardcover),
+    )
+
+    val userId = userSession.userId ?: return flowOf(LoadState.Loaded(ownedOnly))
+    val match = seriesMatch(seriesName, ownedItems) ?: return flowOf(LoadState.Loaded(ownedOnly))
+
+    return observeProviders()
+      .map { statuses -> statuses.firstOrNull { it.canServeSeries } }
+      .distinctUntilChanged { old, new ->
+        old?.provider?.id == new?.provider?.id && old?.linkState == new?.linkState
+      }
+      .flatMapLatest { status ->
+        if (status == null) {
+          flowOf(LoadState.Loaded(ownedOnly))
+        } else {
+          streamSeriesFromStore(
+            status = status,
+            key = SeriesInfoStore.Key(userId, status.provider.id, match),
+            ownedItems = ownedItems,
+            ownedOnly = ownedOnly,
+          )
+        }
+      }
+  }
+
+  private fun streamSeriesFromStore(
+    status: ProviderStatus,
+    key: SeriesInfoStore.Key,
+    ownedItems: List<LibraryItem>,
+    ownedOnly: SeriesInfoState,
+  ): Flow<LoadState<out SeriesInfoState>> = flow {
+    val cached = seriesStore.cached(key)
+    val invalidLink = status.linkState is ProviderLinkState.Invalid
+
+    if (invalidLink && cached == null) {
+      emit(LoadState.Loaded(ownedOnly))
+      return@flow
+    }
+
+    val refresh = !invalidLink &&
+      (
+        cached == null ||
+          cached.isStale(
+            nowMillis = Clock.System.now().toEpochMilliseconds(),
+            currentMatchKey = key.match.cacheKey,
+          )
+        )
+
+    var emittedData = false
+    seriesStore.stream(key, refresh = refresh).collect { response ->
+      when (response) {
+        is StoreReadResponse.Loading -> if (!emittedData) emit(LoadState.Loading)
+        is StoreReadResponse.Data -> {
+          emittedData = true
+          val series = response.value.series
+          emit(
+            LoadState.Loaded(
+              SeriesInfoState(
+                providerId = series?.let { status.provider.id },
+                providerName = series?.let { status.provider.displayName },
+                isCompleted = series?.isCompleted,
+                entries = mergeSeriesEntries(ownedItems, series, status.provider.id),
+              ),
+            ),
+          )
+        }
+        // Provider-sourced entries are additive; on failure show what's owned.
+        is StoreReadResponse.Error -> if (!emittedData) emit(LoadState.Loaded(ownedOnly))
+        else -> Unit
+      }
+    }
+  }
+
   override suspend fun clearCache() {
     store.clearAll()
+    seriesStore.clearAll()
   }
 
   private fun streamFromStore(
@@ -144,5 +231,10 @@ class DefaultBookInfoRegistry(
   private val ProviderStatus.canServeBookInfo: Boolean
     get() = enabled &&
       provider.capabilities.hasAggregateRating &&
+      linkState !is ProviderLinkState.NotLinked
+
+  private val ProviderStatus.canServeSeries: Boolean
+    get() = enabled &&
+      provider.capabilities.hasSeriesOrdering &&
       linkState !is ProviderLinkState.NotLinked
 }

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/CachedSeriesInfo.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/CachedSeriesInfo.kt
@@ -1,0 +1,34 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.store
+
+import app.campfire.bookinfo.api.ProviderSeries
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlinx.serialization.Serializable
+
+/**
+ * The cached unit for one (user, provider, series). A null [series] is a cached
+ * "provider has no listing for this series" — kept on a short TTL like book
+ * misses, since a series may become matchable as identifiers improve.
+ *
+ * [matchKey] records the member identifiers that produced this row; adding a
+ * book to the series (or fixing its identifiers) changes the key and refetches
+ * immediately rather than waiting out the TTL.
+ */
+@Serializable
+data class CachedSeriesInfo(
+  val series: ProviderSeries? = null,
+  val fetchedAt: Long,
+  val matchKey: String? = null,
+)
+
+internal val SERIES_INFO_CACHE_TTL = 7.days
+internal val SERIES_INFO_MISS_TTL = 1.hours
+
+internal fun CachedSeriesInfo.isStale(nowMillis: Long, currentMatchKey: String): Boolean {
+  if (matchKey != currentMatchKey) return true
+  val ttl = if (series == null) SERIES_INFO_MISS_TTL else SERIES_INFO_CACHE_TTL
+  return nowMillis - fetchedAt > ttl.inWholeMilliseconds
+}

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/SeriesInfoStore.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/SeriesInfoStore.kt
@@ -1,0 +1,130 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.store
+
+import app.campfire.bookinfo.api.BookInfoProvider
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.SeriesMatch
+import app.campfire.bookinfo.db.BookInfoDatabase
+import app.campfire.core.coroutines.DispatcherProvider
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import app.campfire.core.model.UserId
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import kotlin.time.Clock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import me.tatarka.inject.annotations.Inject
+import org.mobilenativefoundation.store.store5.Fetcher
+import org.mobilenativefoundation.store.store5.FetcherResult
+import org.mobilenativefoundation.store.store5.SourceOfTruth
+import org.mobilenativefoundation.store.store5.Store
+import org.mobilenativefoundation.store.store5.StoreBuilder
+import org.mobilenativefoundation.store.store5.StoreReadRequest
+import org.mobilenativefoundation.store.store5.StoreReadResponse
+
+/**
+ * Store5 pipeline for a provider's canonical series listing, mirroring
+ * [BookInfoStore]. Series listings change rarely, so these rows carry a long
+ * TTL — the identifier-based [CachedSeriesInfo.matchKey] handles the case that
+ * actually matters (the user adding a book to the series).
+ */
+@SingleIn(UserScope::class)
+@Inject
+class SeriesInfoStore(
+  private val providers: Set<BookInfoProvider>,
+  private val db: BookInfoDatabase,
+  private val dispatcherProvider: DispatcherProvider,
+) {
+
+  data class Key(
+    val userId: UserId,
+    val providerId: ProviderId,
+    val match: SeriesMatch,
+  )
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private val store: Store<Key, CachedSeriesInfo> = StoreBuilder.from(
+    fetcher = Fetcher.ofResult { key: Key -> fetch(key) },
+    sourceOfTruth = SourceOfTruth.of<Key, CachedSeriesInfo, CachedSeriesInfo>(
+      reader = { key ->
+        db.seriesInfoCacheQueries
+          .select(key.userId, key.providerId.key, key.match.seriesName)
+          .asFlow()
+          .mapToOneOrNull(dispatcherProvider.io)
+          .map { row -> row?.let { decode(it.payload) } }
+      },
+      writer = { key, value ->
+        db.seriesInfoCacheQueries.upsert(
+          userId = key.userId,
+          providerId = key.providerId.key,
+          seriesName = key.match.seriesName,
+          payload = json.encodeToString(CachedSeriesInfo.serializer(), value),
+          fetchedAt = value.fetchedAt,
+        )
+      },
+      delete = { key ->
+        db.seriesInfoCacheQueries.delete(key.userId, key.providerId.key, key.match.seriesName)
+      },
+      deleteAll = {
+        db.seriesInfoCacheQueries.deleteAll()
+      },
+    ),
+  ).build()
+
+  fun stream(key: Key, refresh: Boolean): Flow<StoreReadResponse<CachedSeriesInfo>> {
+    return store.stream(StoreReadRequest.cached(key, refresh = refresh))
+  }
+
+  suspend fun clearAll() {
+    store.clear()
+  }
+
+  suspend fun cached(key: Key): CachedSeriesInfo? {
+    return db.seriesInfoCacheQueries
+      .select(key.userId, key.providerId.key, key.match.seriesName)
+      .awaitAsOneOrNull()
+      ?.let { decode(it.payload) }
+  }
+
+  private suspend fun fetch(key: Key): FetcherResult<CachedSeriesInfo> {
+    val provider = providers.firstOrNull { it.id == key.providerId }
+      ?: return FetcherResult.Error.Message("No provider installed for ${key.providerId.key}")
+
+    return when (val result = provider.getSeries(key.match)) {
+      is BookInfoResult.Success -> FetcherResult.Data(
+        CachedSeriesInfo(
+          series = result.data,
+          fetchedAt = nowMillis(),
+          matchKey = key.match.cacheKey,
+        ),
+      )
+
+      // Cache the miss so unmatched series aren't re-queried on every visit.
+      is BookInfoResult.NotFound -> FetcherResult.Data(
+        CachedSeriesInfo(series = null, fetchedAt = nowMillis(), matchKey = key.match.cacheKey),
+      )
+
+      is BookInfoResult.NotLinked -> FetcherResult.Error.Exception(BookInfoNotLinkedException())
+      is BookInfoResult.TokenInvalid -> FetcherResult.Error.Exception(BookInfoTokenInvalidException())
+      is BookInfoResult.RateLimited -> FetcherResult.Error.Exception(BookInfoRateLimitedException())
+      is BookInfoResult.Failure -> FetcherResult.Error.Exception(result.cause)
+    }
+  }
+
+  private fun decode(payload: String): CachedSeriesInfo? {
+    return try {
+      json.decodeFromString(CachedSeriesInfo.serializer(), payload)
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  private fun nowMillis(): Long = Clock.System.now().toEpochMilliseconds()
+}

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/SeriesMerge.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/store/SeriesMerge.kt
@@ -1,0 +1,84 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.store
+
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderSeries
+import app.campfire.bookinfo.api.SeriesEntry
+import app.campfire.core.model.LibraryItem
+
+/**
+ * Merges the books a user owns in a series with a provider's canonical listing.
+ *
+ * Owned books are matched to provider entries by identifier first (ISBN/ASIN,
+ * punctuation-insensitive) and normalized title second, so an owned book never
+ * also shows up as "missing". Provider entries with no owned match become
+ * [SeriesEntry.Missing] when released and [SeriesEntry.Upcoming] when not.
+ * Owned books the provider doesn't list are kept — the user's library is the
+ * source of truth for what they have — ordered by their Audiobookshelf series
+ * sequence, falling back to the end of the list.
+ */
+internal fun mergeSeriesEntries(
+  ownedItems: List<LibraryItem>,
+  series: ProviderSeries?,
+  providerId: ProviderId,
+): List<SeriesEntry> {
+  if (series == null) {
+    return ownedItems
+      .sortedBy { it.seriesSequenceOrNull() ?: Double.MAX_VALUE }
+      .map { SeriesEntry.Owned(it) }
+  }
+
+  val remaining = ownedItems.toMutableList()
+  val positioned = mutableListOf<Pair<Double, SeriesEntry>>()
+
+  for (entry in series.entries) {
+    val ownedIndex = remaining.indexOfFirst { it.matches(entry.isbns, entry.asins, entry.title) }
+    if (ownedIndex >= 0) {
+      val owned = remaining.removeAt(ownedIndex)
+      positioned += entry.position to SeriesEntry.Owned(owned)
+    } else if (entry.isReleased) {
+      positioned += entry.position to SeriesEntry.Missing(entry, providerId)
+    } else {
+      positioned += entry.position to SeriesEntry.Upcoming(entry, providerId)
+    }
+  }
+
+  // Owned books the provider doesn't list still belong to the user's series.
+  for (owned in remaining) {
+    positioned += (owned.seriesSequenceOrNull() ?: Double.MAX_VALUE) to SeriesEntry.Owned(owned)
+  }
+
+  return positioned
+    .sortedBy { it.first }
+    .map { it.second }
+}
+
+private fun LibraryItem.matches(
+  isbns: List<String>,
+  asins: List<String>,
+  title: String,
+): Boolean {
+  val metadata = media.metadata
+  val ownedIsbn = metadata.ISBN?.normalizedIdentifier()
+  if (ownedIsbn != null && isbns.any { it.normalizedIdentifier() == ownedIsbn }) return true
+  val ownedAsin = metadata.ASIN?.normalizedIdentifier()
+  if (ownedAsin != null && asins.any { it.normalizedIdentifier() == ownedAsin }) return true
+  val ownedTitle = metadata.title?.normalizedTitle()
+  return ownedTitle != null && ownedTitle.isNotEmpty() && ownedTitle == title.normalizedTitle()
+}
+
+private fun LibraryItem.seriesSequenceOrNull(): Double? {
+  return media.metadata.seriesSequence?.sequence
+}
+
+private fun String.normalizedIdentifier(): String? {
+  return filter { it.isLetterOrDigit() }.uppercase().takeUnless { it.isEmpty() }
+}
+
+private fun String.normalizedTitle(): String {
+  return lowercase()
+    .filter { it.isLetterOrDigit() }
+    .removePrefix("the")
+}

--- a/data/bookinfo/impl/src/commonMain/sqldelight/app/campfire/bookinfo/db/seriesInfoCache.sq
+++ b/data/bookinfo/impl/src/commonMain/sqldelight/app/campfire/bookinfo/db/seriesInfoCache.sq
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS seriesInfoCache (
+  userId TEXT NOT NULL,
+  providerId TEXT NOT NULL,
+  seriesName TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  fetchedAt INTEGER NOT NULL,
+  PRIMARY KEY (userId, providerId, seriesName)
+);
+
+select:
+SELECT * FROM seriesInfoCache
+WHERE userId = :userId AND providerId = :providerId AND seriesName = :seriesName;
+
+upsert:
+INSERT OR REPLACE INTO seriesInfoCache(userId, providerId, seriesName, payload, fetchedAt)
+VALUES (:userId, :providerId, :seriesName, :payload, :fetchedAt);
+
+delete:
+DELETE FROM seriesInfoCache
+WHERE userId = :userId AND providerId = :providerId AND seriesName = :seriesName;
+
+deleteAll:
+DELETE FROM seriesInfoCache;

--- a/data/bookinfo/impl/src/commonTest/kotlin/app/campfire/bookinfo/SeriesMergeTest.kt
+++ b/data/bookinfo/impl/src/commonTest/kotlin/app/campfire/bookinfo/SeriesMergeTest.kt
@@ -1,0 +1,200 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo
+
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderSeries
+import app.campfire.bookinfo.api.ProviderSeriesEntry
+import app.campfire.bookinfo.api.SeriesEntry
+import app.campfire.bookinfo.store.mergeSeriesEntries
+import app.campfire.core.model.LibraryItem
+import app.campfire.core.model.SeriesSequence
+import app.campfire.home.ui.libraryItem
+import app.campfire.home.ui.media
+import app.campfire.home.ui.mediaMetadata
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import kotlin.test.Test
+
+private fun owned(
+  title: String,
+  isbn: String? = null,
+  asin: String? = null,
+  sequence: Double? = null,
+  id: String = "item_$title",
+): LibraryItem = libraryItem(
+  id = id,
+  media = media(
+    metadata = mediaMetadata(
+      title = title,
+      ISBN = isbn,
+      ASIN = asin,
+      seriesSequence = sequence?.let { SeriesSequence(id = "s", name = "Series", sequence = it) },
+    ),
+  ),
+)
+
+private fun providerEntry(
+  title: String,
+  position: Double,
+  isReleased: Boolean = true,
+  isbns: List<String> = emptyList(),
+  asins: List<String> = emptyList(),
+) = ProviderSeriesEntry(
+  providerBookId = "hc_$title",
+  position = position,
+  title = title,
+  releaseDate = if (isReleased) "2010-08-31" else "2031-01-01",
+  isReleased = isReleased,
+  providerUrl = null,
+  coverUrl = null,
+  isbns = isbns,
+  asins = asins,
+)
+
+private fun series(vararg entries: ProviderSeriesEntry) = ProviderSeries(
+  providerSeriesId = "997",
+  name = "The Stormlight Archive",
+  isCompleted = false,
+  entries = entries.toList(),
+)
+
+class SeriesMergeTest {
+
+  @Test
+  fun `owned books match provider entries by isbn`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(owned("The Way of Kings", isbn = "978-0-7653-9304-3")),
+      series = series(providerEntry("The Way of Kings", 1.0, isbns = listOf("9780765393043"))),
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.size).isEqualTo(1)
+    assertThat(entries.single()).isInstanceOf<SeriesEntry.Owned>()
+  }
+
+  @Test
+  fun `owned books match provider entries by asin`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(owned("Some Title", asin = "b002ri9z9e")),
+      series = series(providerEntry("Different Title", 1.0, asins = listOf("B002RI9Z9E"))),
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.single()).isInstanceOf<SeriesEntry.Owned>()
+  }
+
+  @Test
+  fun `owned books match by normalized title when identifiers differ`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(owned("The Way of Kings")),
+      series = series(providerEntry("Way of Kings", 1.0, isbns = listOf("9780765393043"))),
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.single()).isInstanceOf<SeriesEntry.Owned>()
+  }
+
+  @Test
+  fun `unowned released entries are missing and unreleased are upcoming`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(owned("The Way of Kings", isbn = "9780765393043")),
+      series = series(
+        providerEntry("The Way of Kings", 1.0, isbns = listOf("9780765393043")),
+        providerEntry("Words of Radiance", 2.0),
+        providerEntry("Untitled #6", 6.0, isReleased = false),
+      ),
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.map { it::class.simpleName }).isEqualTo(
+      listOf("Owned", "Missing", "Upcoming"),
+    )
+  }
+
+  @Test
+  fun `entries are ordered by provider position`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(owned("Words of Radiance", isbn = "9780765326379")),
+      series = series(
+        providerEntry("Words of Radiance", 2.0, isbns = listOf("9780765326379")),
+        providerEntry("The Way of Kings", 1.0),
+        providerEntry("Edgedancer", 2.5),
+      ),
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.map { it.title() })
+      .isEqualTo(listOf("The Way of Kings", "Words of Radiance", "Edgedancer"))
+  }
+
+  @Test
+  fun `an owned book is never also listed as missing`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(owned("The Way of Kings", isbn = "9780765393043")),
+      series = series(
+        providerEntry("The Way of Kings", 1.0, isbns = listOf("9780765393043")),
+        providerEntry("The Way of Kings", 1.1),
+      ),
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.count { it is SeriesEntry.Owned }).isEqualTo(1)
+    // The duplicate provider row can't consume the same owned book twice.
+    assertThat(entries.count { it is SeriesEntry.Missing }).isEqualTo(1)
+  }
+
+  @Test
+  fun `owned books the provider does not list are kept`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(
+        owned("The Way of Kings", isbn = "9780765393043", sequence = 1.0),
+        owned("Fan Companion", sequence = 3.0),
+      ),
+      series = series(providerEntry("The Way of Kings", 1.0, isbns = listOf("9780765393043"))),
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.map { it.title() }).isEqualTo(listOf("The Way of Kings", "Fan Companion"))
+    assertThat(entries.all { it is SeriesEntry.Owned }).isEqualTo(true)
+  }
+
+  @Test
+  fun `without a provider series only owned books are listed in sequence order`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(
+        owned("Words of Radiance", sequence = 2.0),
+        owned("The Way of Kings", sequence = 1.0),
+      ),
+      series = null,
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.map { it.title() })
+      .isEqualTo(listOf("The Way of Kings", "Words of Radiance"))
+    assertThat(entries.all { it is SeriesEntry.Owned }).isEqualTo(true)
+  }
+
+  @Test
+  fun `entry keys are unique across the listing`() {
+    val entries = mergeSeriesEntries(
+      ownedItems = listOf(owned("The Way of Kings", isbn = "9780765393043")),
+      series = series(
+        providerEntry("The Way of Kings", 1.0, isbns = listOf("9780765393043")),
+        providerEntry("Words of Radiance", 2.0),
+        providerEntry("Untitled #6", 6.0, isReleased = false),
+      ),
+      providerId = ProviderId.Hardcover,
+    )
+
+    assertThat(entries.map { it.key }.toSet().size).isEqualTo(entries.size)
+  }
+}
+
+private fun SeriesEntry.title(): String? = when (this) {
+  is SeriesEntry.Owned -> item.media.metadata.title
+  is SeriesEntry.Missing -> entry.title
+  is SeriesEntry.Upcoming -> entry.title
+}

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -259,6 +259,25 @@ class DefaultBookInfoRegistryTest {
   }
 
   @Test
+  fun `owned books are emitted before the provider responds`() = runTest {
+    val provider = FakeBookInfoProvider()
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ISBN = "9780765393043")),
+    )
+    val registry = registry(provider)
+
+    // The very first loaded emission must already carry the user's own book —
+    // provider entries decorate the list, they never gate it.
+    val first = registry
+      .observeSeriesEntries("The Stormlight Archive", listOf(owned))
+      .first { it is LoadState.Loaded<*> }
+
+    val loaded = (first as LoadState.Loaded).data
+    assertThat(loaded.entries.map { it::class.simpleName }).isEqualTo(listOf("Owned"))
+    assertThat(loaded.providerId).isNull()
+  }
+
+  @Test
   fun `series degrades to owned entries when the provider has no listing`() = runTest {
     val provider = FakeBookInfoProvider()
     provider.seriesResult = BookInfoResult.NotFound

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -8,8 +8,11 @@ import app.campfire.bookinfo.api.BookInfoResult
 import app.campfire.bookinfo.api.CommunitySource
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.api.ProviderSeries
+import app.campfire.bookinfo.api.ProviderSeriesEntry
 import app.campfire.bookinfo.db.BookInfoDatabase
 import app.campfire.bookinfo.store.BookInfoStore
+import app.campfire.bookinfo.store.SeriesInfoStore
 import app.campfire.bookinfo.test.FakeBookInfoProvider
 import app.campfire.common.test.coroutines.TestDispatcherProvider
 import app.campfire.common.test.user
@@ -54,15 +57,13 @@ class DefaultBookInfoRegistryTest {
   ): DefaultBookInfoRegistry {
     val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     BookInfoDatabase.Schema.synchronous().create(driver)
-    val store = BookInfoStore(
-      providers = setOf(provider),
-      db = BookInfoDatabase(driver),
-      dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
-    )
+    val db = BookInfoDatabase(driver)
+    val dispatchers = TestDispatcherProvider(StandardTestDispatcher(testScheduler))
     return DefaultBookInfoRegistry(
       providers = setOf(provider),
       settings = settings,
-      store = store,
+      store = BookInfoStore(setOf(provider), db, dispatchers),
+      seriesStore = SeriesInfoStore(setOf(provider), db, dispatchers),
       userSession = session,
     )
   }
@@ -210,6 +211,85 @@ class DefaultBookInfoRegistryTest {
     }
 
     assertThat(provider.bookInfoRequests.size).isEqualTo(2)
+  }
+
+  @Test
+  fun `series entries merge owned books with provider entries`() = runTest {
+    val provider = FakeBookInfoProvider()
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ISBN = "9780765393043")),
+    )
+    provider.seriesResult = BookInfoResult.Success(
+      ProviderSeries(
+        providerSeriesId = "997",
+        name = "The Stormlight Archive",
+        isCompleted = false,
+        entries = listOf(
+          ProviderSeriesEntry(
+            providerBookId = "386446",
+            position = 1.0,
+            title = "The Way of Kings",
+            releaseDate = "2010-08-31",
+            isReleased = true,
+            providerUrl = null,
+            coverUrl = null,
+            isbns = listOf("9780765393043"),
+          ),
+          ProviderSeriesEntry(
+            providerBookId = "374131",
+            position = 2.0,
+            title = "Words of Radiance",
+            releaseDate = "2014-03-04",
+            isReleased = true,
+            providerUrl = null,
+            coverUrl = null,
+          ),
+        ),
+      ),
+    )
+    val registry = registry(provider)
+
+    val state = registry
+      .observeSeriesEntries("The Stormlight Archive", listOf(owned))
+      .first { it is LoadState.Loaded<*> && (it as LoadState.Loaded).data.providerId != null }
+
+    val loaded = (state as LoadState.Loaded).data
+    assertThat(loaded.providerName).isEqualTo("Fake Provider")
+    assertThat(loaded.entries.map { it::class.simpleName }).isEqualTo(listOf("Owned", "Missing"))
+  }
+
+  @Test
+  fun `series degrades to owned entries when the provider has no listing`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.seriesResult = BookInfoResult.NotFound
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ISBN = "9780765393043")),
+    )
+    val registry = registry(provider)
+
+    val state = registry
+      .observeSeriesEntries("The Stormlight Archive", listOf(owned))
+      .first { it is LoadState.Loaded<*> }
+
+    val loaded = (state as LoadState.Loaded).data
+    assertThat(loaded.providerId).isNull()
+    assertThat(loaded.entries.map { it::class.simpleName }).isEqualTo(listOf("Owned"))
+  }
+
+  @Test
+  fun `series without identifiable members never calls the provider`() = runTest {
+    val provider = FakeBookInfoProvider()
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "Untracked", ISBN = null, ASIN = null)),
+    )
+    val registry = registry(provider)
+
+    val state = registry
+      .observeSeriesEntries("Mystery Series", listOf(owned))
+      .first { it is LoadState.Loaded<*> }
+
+    assertThat((state as LoadState.Loaded).data.entries.size).isEqualTo(1)
+    assertThat(provider.seriesRequests.size).isEqualTo(0)
   }
 
   @Test

--- a/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoProvider.kt
+++ b/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoProvider.kt
@@ -11,6 +11,8 @@ import app.campfire.bookinfo.api.BookReview
 import app.campfire.bookinfo.api.ProviderCapabilities
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.api.ProviderSeries
+import app.campfire.bookinfo.api.SeriesMatch
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -42,5 +44,12 @@ class FakeBookInfoProvider(
   override suspend fun getReviews(match: BookMatch, limit: Int): BookInfoResult<List<BookReview>> {
     reviewsRequests += match
     return reviewsResult
+  }
+
+  var seriesResult: BookInfoResult<ProviderSeries> = BookInfoResult.NotFound
+  val seriesRequests = mutableListOf<SeriesMatch>()
+  override suspend fun getSeries(match: SeriesMatch): BookInfoResult<ProviderSeries> {
+    seriesRequests += match
+    return seriesResult
   }
 }

--- a/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoRegistry.kt
+++ b/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoRegistry.kt
@@ -7,6 +7,7 @@ import app.campfire.bookinfo.api.BookInfoRegistry
 import app.campfire.bookinfo.api.CommunityInfoState
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderStatus
+import app.campfire.bookinfo.api.SeriesInfoState
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.LibraryItem
 import kotlinx.coroutines.flow.Flow
@@ -25,6 +26,16 @@ class FakeBookInfoRegistry : BookInfoRegistry {
   ): Flow<LoadState<out CommunityInfoState?>> {
     communityInfoRequests += item to preferredProvider
     return communityInfoFlow
+  }
+
+  val seriesEntriesFlow = MutableSharedFlow<LoadState<out SeriesInfoState>>(replay = 1)
+  val seriesEntriesRequests = mutableListOf<Pair<String, List<LibraryItem>>>()
+  override fun observeSeriesEntries(
+    seriesName: String,
+    ownedItems: List<LibraryItem>,
+  ): Flow<LoadState<out SeriesInfoState>> {
+    seriesEntriesRequests += seriesName to ownedItems
+    return seriesEntriesFlow
   }
 
   var clearCacheCount = 0


### PR DESCRIPTION
## Summary

First of Phase 2 (stacked on #1021). Data layer for showing which books are missing from a series and which are still coming.

- **Provider contract**: `getSeries(SeriesMatch)` returning a canonical `ProviderSeries` with reading-order entries, including announced-but-unreleased ones. Default implementation reports no data, so keyless providers opt in when they gain the capability
- **Series matching**: Audiobookshelf series carry no external identifier, so a `SeriesMatch` is the series name plus the identifiers of the books the user owns in it — Hardcover queries candidate series *by member books* and verifies by identifier overlap, with an exact normalized-name match preferred (a book can belong to both a saga and its parent universe)
- **Canonical filtering**: Hardcover's raw listings mix translations, box sets, and split audio editions at overlapping positions. `canonicalizeSeries` drops compilations, keeps the most-shelved row per position (so translations lose to the canonical edition), and drops fractional positions that merely re-title their base book — while preserving genuine companion novellas like Edgedancer
- **Merge**: `observeSeriesEntries` produces one ordered list of `Owned` / `Missing` / `Upcoming` entries. Owned books match provider entries by identifier then normalized title (so an owned book is never also "missing"), owned books the provider doesn't list are kept, and the whole thing degrades to owned-only when no series-capable provider is linked — callers render the same shape either way
- **Cache**: 7-day TTL for listings (1h for misses) in the same disposable bookinfo database, invalidated when the series' member identifiers change

No UI yet — that's the next PR.

## Test plan
- `./gradlew :data:bookinfo:hardcover:jvmTest :data:bookinfo:impl:jvmTest` — 10 canonicalization/candidate-selection tests with fixtures mirroring the real Stormlight listing (box sets, translations at shared positions, 1.1/1.2 split editions, Horneater at 4.5/2027, untitled placeholders), 9 merge tests, and 3 registry-level series tests
- Desktop DI graph compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu