### PR TITLE
Show missing and upcoming books on the series page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sound equalizer on the playing screen (Android and desktop) with presets, 10-band adjustment, loudness and bass boost, and per-book profiles
 - Community ratings and reviews from Hardcover on the book detail page, with attribution and a tap-through to the book on Hardcover
 - Social page in Settings to connect book info providers like Hardcover (paste an API token), toggle sources, and clear cached data
+- Missing and upcoming books in a series, shown alongside the ones you own on the series page
 
 ### Changed
 

--- a/features/series/ui/build.gradle.kts
+++ b/features/series/ui/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        implementation(projects.data.bookinfo.api)
         implementation(projects.features.series.api)
         implementation(projects.features.filters.api)
         implementation(projects.features.user.api)
@@ -21,6 +22,18 @@ kotlin {
         implementation(libs.androidx.paging.compose)
         // Need encodeUrlParameter() ext function
         implementation(libs.ktor.http)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(projects.common.test)
+        implementation(projects.data.analytics.test)
+        implementation(projects.data.bookinfo.test)
+        implementation(projects.features.series.test)
+        implementation(projects.infra.audioplayer.test)
+        implementation(libs.bundles.test.common)
+        implementation(libs.bundles.test.ui)
       }
     }
   }

--- a/features/series/ui/src/commonMain/composeResources/values/series_ui_strings.xml
+++ b/features/series/ui/src/commonMain/composeResources/values/series_ui_strings.xml
@@ -9,4 +9,9 @@
   </plurals>
 
   <string name="action_back">Back</string>
+
+  <string name="series_entry_missing">Not in your library</string>
+  <string name="series_entry_upcoming">Not yet released</string>
+  <string name="series_entry_upcoming_year">Expected %1$s</string>
+  <string name="series_source_attribution">Series details from %1$s</string>
 </resources>

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailPresenter.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailPresenter.kt
@@ -10,14 +10,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import app.campfire.analytics.Analytics
+import app.campfire.analytics.events.ActionEvent
+import app.campfire.analytics.events.Click
 import app.campfire.analytics.events.ContentSelected
 import app.campfire.analytics.events.ContentType
 import app.campfire.audioplayer.offline.OfflineDownloadManager
+import app.campfire.bookinfo.api.BookInfoRegistry
+import app.campfire.bookinfo.api.SeriesEntry
+import app.campfire.bookinfo.api.SeriesInfoState
 import app.campfire.common.screens.SeriesDetailScreen
+import app.campfire.common.screens.UrlScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.logging.bark
-import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.loggableId
 import app.campfire.libraries.api.screen.LibraryItemScreen
 import app.campfire.series.api.SeriesRepository
@@ -38,6 +43,7 @@ class SeriesDetailPresenter(
   @Assisted private val screen: SeriesDetailScreen,
   @Assisted private val navigator: Navigator,
   private val repository: SeriesRepository,
+  private val bookInfoRegistry: BookInfoRegistry,
   private val offlineDownloadManager: OfflineDownloadManager,
   private val analytics: Analytics,
 ) : NonPausablePresenter<SeriesDetailUiState> {
@@ -48,12 +54,17 @@ class SeriesDetailPresenter(
   override fun present(): SeriesDetailUiState {
     val seriesContentState by remember {
       repository.observeSeriesLibraryItems(seriesId = screen.seriesId)
-        .map { LoadState.Loaded(it) as LoadState<List<LibraryItem>> }
-        .catch { emit(LoadState.Error as LoadState<List<LibraryItem>>) }
+        .flatMapLatest { items ->
+          bookInfoRegistry.observeSeriesEntries(screen.seriesName, items)
+        }
+        .catch { emit(LoadState.Error as LoadState<SeriesInfoState>) }
     }.collectAsState(LoadState.Loading)
 
     LaunchedEffect(seriesContentState) {
       val groupedBooks = seriesContentState.dataOrNull
+        ?.entries
+        ?.filterIsInstance<SeriesEntry.Owned>()
+        ?.map { it.item }
         ?.groupBy { item -> item.id }
         ?: emptyMap()
 
@@ -72,8 +83,10 @@ class SeriesDetailPresenter(
     val offlineDownloads by remember {
       snapshotFlow { seriesContentState.dataOrNull }
         .filterNotNull()
-        .flatMapLatest { items ->
-          offlineDownloadManager.observeForItems(items)
+        .flatMapLatest { info ->
+          offlineDownloadManager.observeForItems(
+            info.entries.filterIsInstance<SeriesEntry.Owned>().map { it.item },
+          )
         }
     }.collectAsState(emptyMap())
 
@@ -91,6 +104,11 @@ class SeriesDetailPresenter(
               sharedTransitionKey = event.libraryItem.id + screen.seriesName,
             ),
           )
+        }
+
+        is SeriesDetailUiEvent.ProviderEntryClick -> {
+          analytics.send(ActionEvent("series_provider_entry", Click))
+          event.entry.providerUrl?.let { navigator.goTo(UrlScreen(it)) }
         }
       }
     }

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUi.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUi.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -20,14 +22,19 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app.campfire.audioplayer.offline.asWidgetStatus
+import app.campfire.bookinfo.api.ProviderSeriesEntry
+import app.campfire.bookinfo.api.SeriesEntry
+import app.campfire.bookinfo.api.SeriesInfoState
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.extensions.plus
 import app.campfire.common.compose.widgets.CampfireTopAppBar
@@ -43,9 +50,11 @@ import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.offline.OfflineStatus
+import app.campfire.series.ui.detail.composables.ProviderEntryCard
 import campfire.features.series.ui.generated.resources.Res
 import campfire.features.series.ui.generated.resources.action_back
 import campfire.features.series.ui.generated.resources.error_series_detail_message
+import campfire.features.series.ui.generated.resources.series_source_attribution
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.slack.circuit.sharedelements.SharedElementTransitionScope
 import org.jetbrains.compose.resources.stringResource
@@ -102,9 +111,10 @@ fun SeriesDetail(
 
       is LoadState.Loaded -> LoadedState(
         seriesName = screen.seriesName,
-        items = state.seriesContentState.data,
+        info = state.seriesContentState.data,
         offlineStatus = { state.offlineStates[it].asWidgetStatus() },
         onLibraryItemClick = { state.eventSink(SeriesDetailUiEvent.LibraryItemClick(it)) },
+        onProviderEntryClick = { state.eventSink(SeriesDetailUiEvent.ProviderEntryClick(it)) },
         contentPadding = paddingValues,
       )
     }
@@ -114,13 +124,15 @@ fun SeriesDetail(
 @Composable
 private fun LoadedState(
   seriesName: String,
-  items: List<LibraryItem>,
+  info: SeriesInfoState,
   offlineStatus: (LibraryItemId) -> OfflineStatus,
   onLibraryItemClick: (LibraryItem) -> Unit,
+  onProviderEntryClick: (ProviderSeriesEntry) -> Unit,
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = PaddingValues(),
   gridState: LazyGridState = rememberLazyGridState(),
 ) {
+  val entries = info.entries
   LazyVerticalGrid(
     columns = GridCells.Fixed(2),
     state = gridState,
@@ -130,16 +142,44 @@ private fun LoadedState(
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
     itemsIndexed(
-      items = items,
-      key = { _, item -> item.id },
-    ) { index, item ->
-      LibraryItemCard(
-        item = item,
-        sharedTransitionKey = item.id + seriesName,
-        sharedTransitionZIndex = (items.size - index) + 1f,
-        offlineStatus = offlineStatus(item.id),
-        onClick = { onLibraryItemClick(item) },
-      )
+      items = entries,
+      key = { _, entry -> entry.key },
+    ) { index, entry ->
+      when (entry) {
+        is SeriesEntry.Owned -> LibraryItemCard(
+          item = entry.item,
+          sharedTransitionKey = entry.item.id + seriesName,
+          sharedTransitionZIndex = (entries.size - index) + 1f,
+          offlineStatus = offlineStatus(entry.item.id),
+          onClick = { onLibraryItemClick(entry.item) },
+        )
+
+        is SeriesEntry.Missing -> ProviderEntryCard(
+          entry = entry.entry,
+          isUpcoming = false,
+          onClick = { onProviderEntryClick(entry.entry) },
+        )
+
+        is SeriesEntry.Upcoming -> ProviderEntryCard(
+          entry = entry.entry,
+          isUpcoming = true,
+          onClick = { onProviderEntryClick(entry.entry) },
+        )
+      }
+    }
+
+    info.providerName?.let { providerName ->
+      item(key = "series_source_attribution", span = { GridItemSpan(maxLineSpan) }) {
+        Text(
+          text = stringResource(Res.string.series_source_attribution, providerName),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          textAlign = TextAlign.Center,
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp),
+        )
+      }
     }
   }
 }

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUiState.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUiState.kt
@@ -4,6 +4,8 @@
 package app.campfire.series.ui.detail
 
 import app.campfire.audioplayer.offline.OfflineDownload
+import app.campfire.bookinfo.api.ProviderSeriesEntry
+import app.campfire.bookinfo.api.SeriesInfoState
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
@@ -11,7 +13,7 @@ import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 
 data class SeriesDetailUiState(
-  val seriesContentState: LoadState<out List<LibraryItem>>,
+  val seriesContentState: LoadState<out SeriesInfoState>,
   val offlineStates: Map<LibraryItemId, OfflineDownload>,
   val eventSink: (SeriesDetailUiEvent) -> Unit,
 ) : CircuitUiState
@@ -19,4 +21,7 @@ data class SeriesDetailUiState(
 sealed interface SeriesDetailUiEvent : CircuitUiEvent {
   data object Back : SeriesDetailUiEvent
   data class LibraryItemClick(val libraryItem: LibraryItem) : SeriesDetailUiEvent
+
+  /** A book the user doesn't own — opens it on the provider that listed it. */
+  data class ProviderEntryClick(val entry: ProviderSeriesEntry) : SeriesDetailUiEvent
 }

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/composables/ProviderEntryCard.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/composables/ProviderEntryCard.kt
@@ -1,0 +1,100 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.series.ui.detail.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.campfire.bookinfo.api.ProviderSeriesEntry
+import app.campfire.common.compose.widgets.CoverImage
+import campfire.features.series.ui.generated.resources.Res
+import campfire.features.series.ui.generated.resources.series_entry_missing
+import campfire.features.series.ui.generated.resources.series_entry_upcoming
+import campfire.features.series.ui.generated.resources.series_entry_upcoming_year
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * A book in the series the user doesn't have, rendered as a dimmed "ghost" of a
+ * [app.campfire.common.compose.widgets.LibraryItemCard] so it reads as absent
+ * without competing with owned books. Deliberately does not register shared
+ * element bounds — there's no detail screen to transition into.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun ProviderEntryCard(
+  entry: ProviderSeriesEntry,
+  isUpcoming: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  ElevatedCard(
+    onClick = onClick,
+    shape = MaterialTheme.shapes.largeIncreased,
+    colors = CardDefaults.elevatedCardColors(
+      containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    ),
+    modifier = modifier,
+  ) {
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .aspectRatio(1f)
+        .padding(8.dp),
+    ) {
+      CoverImage(
+        imageUrl = entry.coverUrl,
+        contentDescription = entry.title,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier
+          .fillMaxWidth()
+          .alpha(0.45f),
+      )
+    }
+
+    Column(
+      modifier = Modifier.padding(horizontal = 12.dp),
+    ) {
+      Text(
+        text = entry.title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+      )
+      Spacer(Modifier.height(2.dp))
+      Text(
+        text = when {
+          !isUpcoming -> stringResource(Res.string.series_entry_missing)
+          entry.releaseYear() != null ->
+            stringResource(Res.string.series_entry_upcoming_year, entry.releaseYear()!!)
+          else -> stringResource(Res.string.series_entry_upcoming)
+        },
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Start,
+        maxLines = 1,
+      )
+      Spacer(Modifier.height(12.dp))
+    }
+  }
+}
+
+private fun ProviderSeriesEntry.releaseYear(): String? {
+  return releaseDate?.take(4)?.takeIf { it.length == 4 && it.all(Char::isDigit) }
+}

--- a/features/series/ui/src/commonTest/kotlin/app/campfire/series/ui/detail/SeriesDetailPresenterTest.kt
+++ b/features/series/ui/src/commonTest/kotlin/app/campfire/series/ui/detail/SeriesDetailPresenterTest.kt
@@ -1,0 +1,194 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.series.ui.detail
+
+import app.campfire.analytics.test.FakeAnalytics
+import app.campfire.audioplayer.test.offline.FakeOfflineDownloadManager
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderSeriesEntry
+import app.campfire.bookinfo.api.SeriesEntry
+import app.campfire.bookinfo.api.SeriesInfoState
+import app.campfire.bookinfo.test.FakeBookInfoRegistry
+import app.campfire.common.screens.SeriesDetailScreen
+import app.campfire.common.screens.UrlScreen
+import app.campfire.core.coroutines.LoadState
+import app.campfire.core.model.preview.libraryItem
+import app.campfire.libraries.api.screen.LibraryItemScreen
+import app.campfire.series.test.FakeSeriesRepository
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class SeriesDetailPresenterTest {
+
+  private val screen = SeriesDetailScreen("series_id", "The Stormlight Archive")
+  private val navigator = FakeNavigator(screen)
+  private val repository = FakeSeriesRepository()
+  private val bookInfoRegistry = FakeBookInfoRegistry()
+  private val offlineDownloadManager = FakeOfflineDownloadManager()
+  private val analytics = FakeAnalytics()
+
+  private val presenter = SeriesDetailPresenter(
+    screen = screen,
+    navigator = navigator,
+    repository = repository,
+    bookInfoRegistry = bookInfoRegistry,
+    offlineDownloadManager = offlineDownloadManager,
+    analytics = analytics,
+  )
+
+  private val ownedItem = libraryItem(id = "owned_1")
+
+  private val missingEntry = ProviderSeriesEntry(
+    providerBookId = "374131",
+    position = 2.0,
+    title = "Words of Radiance",
+    releaseDate = "2014-03-04",
+    isReleased = true,
+    providerUrl = "https://hardcover.app/books/words-of-radiance",
+    coverUrl = null,
+  )
+
+  private val upcomingEntry = ProviderSeriesEntry(
+    providerBookId = "999",
+    position = 6.0,
+    title = "Untitled Stormlight Archive #6",
+    releaseDate = "2031-01-01",
+    isReleased = false,
+    providerUrl = null,
+    coverUrl = null,
+  )
+
+  private suspend fun emitSeries(
+    entries: List<SeriesEntry>,
+    providerName: String? = "Hardcover",
+  ) {
+    repository.seriesLibraryItemsFlow.emit(listOf(ownedItem))
+    bookInfoRegistry.seriesEntriesFlow.emit(
+      LoadState.Loaded(
+        SeriesInfoState(
+          providerId = providerName?.let { ProviderId.Hardcover },
+          providerName = providerName,
+          isCompleted = false,
+          entries = entries,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun present_Default_IsLoading() = runTest {
+    presenter.test {
+      assertThat(awaitItem().seriesContentState).isInstanceOf<LoadState.Loading>()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_MergedEntries_AreExposedInOrder() = runTest {
+    emitSeries(
+      listOf(
+        SeriesEntry.Owned(ownedItem),
+        SeriesEntry.Missing(missingEntry, ProviderId.Hardcover),
+        SeriesEntry.Upcoming(upcomingEntry, ProviderId.Hardcover),
+      ),
+    )
+
+    presenter.test {
+      val state = awaitItemMatching { it.seriesContentState is LoadState.Loaded<*> }
+      val info = (state.seriesContentState as LoadState.Loaded).data
+
+      assertThat(info.entries.map { it::class.simpleName })
+        .isEqualTo(listOf("Owned", "Missing", "Upcoming"))
+      assertThat(info.providerName).isEqualTo("Hardcover")
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_WithoutProvider_ShowsOnlyOwnedEntries() = runTest {
+    emitSeries(listOf(SeriesEntry.Owned(ownedItem)), providerName = null)
+
+    presenter.test {
+      val state = awaitItemMatching { it.seriesContentState is LoadState.Loaded<*> }
+      val info = (state.seriesContentState as LoadState.Loaded).data
+
+      assertThat(info.providerName).isEqualTo(null)
+      assertThat(info.entries.single()).isInstanceOf<SeriesEntry.Owned>()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_LibraryItemClick_NavigatesToDetail() = runTest {
+    emitSeries(listOf(SeriesEntry.Owned(ownedItem)))
+
+    presenter.test {
+      val state = awaitItemMatching { it.seriesContentState is LoadState.Loaded<*> }
+      state.eventSink(SeriesDetailUiEvent.LibraryItemClick(ownedItem))
+
+      assertThat(navigator.awaitNextScreen()).isEqualTo(
+        LibraryItemScreen(
+          libraryItemId = ownedItem.id,
+          sharedTransitionKey = ownedItem.id + screen.seriesName,
+        ),
+      )
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_ProviderEntryClick_OpensProviderPage() = runTest {
+    emitSeries(listOf(SeriesEntry.Missing(missingEntry, ProviderId.Hardcover)))
+
+    presenter.test {
+      val state = awaitItemMatching { it.seriesContentState is LoadState.Loaded<*> }
+      state.eventSink(SeriesDetailUiEvent.ProviderEntryClick(missingEntry))
+
+      assertThat(navigator.awaitNextScreen())
+        .isEqualTo(UrlScreen("https://hardcover.app/books/words-of-radiance"))
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_ProviderEntryClickWithoutUrl_DoesNotNavigate() = runTest {
+    emitSeries(listOf(SeriesEntry.Upcoming(upcomingEntry, ProviderId.Hardcover)))
+
+    presenter.test {
+      val state = awaitItemMatching { it.seriesContentState is LoadState.Loaded<*> }
+      state.eventSink(SeriesDetailUiEvent.ProviderEntryClick(upcomingEntry))
+
+      expectNoEvents()
+      cancelAndIgnoreRemainingEvents()
+    }
+    navigator.assertGoToIsEmpty()
+  }
+
+  @Test
+  fun present_Back_PopsNavigator() = runTest {
+    emitSeries(listOf(SeriesEntry.Owned(ownedItem)))
+
+    presenter.test {
+      val state = awaitItemMatching { it.seriesContentState is LoadState.Loaded<*> }
+      state.eventSink(SeriesDetailUiEvent.Back)
+
+      navigator.awaitPop()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+}
+
+private suspend inline fun app.cash.turbine.ReceiveTurbine<SeriesDetailUiState>.awaitItemMatching(
+  predicate: (SeriesDetailUiState) -> Boolean,
+): SeriesDetailUiState {
+  while (true) {
+    val item = awaitItem()
+    if (predicate(item)) return item
+  }
+}


### PR DESCRIPTION
## Summary

Completes Phase 2 (stacked on #1023). Surfaces the merged series listing in the UI.

- `SeriesDetailUiState` widens from `List<LibraryItem>` to the registry's `SeriesInfoState`, and the grid keys on `SeriesEntry.key` instead of `item.id` so owned and provider-sourced rows coexist
- Owned books render exactly as before — same `LibraryItemCard`, same shared-element transition key — so nothing regresses for users without a linked provider
- Missing/upcoming books render as dimmed ghost cards (45% cover, "Not in your library" / "Expected 2027"). They deliberately register **no** shared element bounds, since there's no detail screen to transition into; tapping one opens the book on the provider
- Provider attribution renders as a full-width footer under the grid
- When no series-capable provider is linked, the registry returns owned-only entries and the page is unchanged

## Test plan
- `./gradlew :features:series:ui:jvmTest` — new presenter test suite (7 tests): merged entry ordering, owned-only degradation, item navigation, provider link-out, no-URL no-navigation, back
- Desktop and Android alpha-debug graphs compile

Screenshots to follow once I've linked a live token against a series with real gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu