### PR TITLE
Add Open Library as a keyless ratings fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sound equalizer on the playing screen (Android and desktop) with presets, 10-band adjustment, loudness and bass boost, and per-book profiles
 - Community ratings and reviews from Hardcover on the book detail page, with attribution and a tap-through to the book on Hardcover
 - Book Info page in Settings to connect sources like Hardcover (paste an API token), toggle them, and clear cached data
+- Open Library as a built-in ratings source — books with an ISBN show community ratings even without a Hardcover account
 
 ### Changed
 

--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
         api(projects.data.analytics.impl)
         api(projects.data.bookinfo.impl)
         api(projects.data.bookinfo.hardcover)
+        api(projects.data.bookinfo.openlibrary)
         api(projects.data.bookinfo.ui)
         api(projects.data.crashreporting.impl)
 

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoProvider.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoProvider.kt
@@ -26,6 +26,13 @@ interface BookInfoProvider {
 
   fun observeLinkState(): Flow<ProviderLinkState>
 
+  /**
+   * Whether this provider can even attempt [match] — e.g. a catalog keyed
+   * solely by ISBN can't serve an ASIN-only item. The registry skips providers
+   * that can't serve a match so another source gets the chance.
+   */
+  fun canServe(match: BookMatch): Boolean = true
+
   suspend fun getBookInfo(match: BookMatch): BookInfoResult<BookCommunityInfo>
 
   suspend fun getReviews(match: BookMatch, limit: Int = 10): BookInfoResult<List<BookReview>>

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -65,7 +65,7 @@ class DefaultBookInfoRegistry(
     val match = item.bestMatch() ?: return flowOf(LoadState.Loaded(null))
 
     return observeProviders()
-      .map { statuses -> statuses.filter { it.canServeBookInfo } }
+      .map { statuses -> statuses.filter { it.canServeBookInfo && it.provider.canServe(match) } }
       .distinctUntilChanged { old, new ->
         old.map { it.provider.id to it.linkState } == new.map { it.provider.id to it.linkState }
       }

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -213,6 +213,35 @@ class DefaultBookInfoRegistryTest {
   }
 
   @Test
+  fun `a provider that cannot serve the match is skipped for one that can`() = runTest {
+    // Mimics an ASIN-only audiobook: the first-priority provider is ISBN-keyed
+    // and declares itself unservable, so the lower-priority one serves.
+    val isbnOnly = FakeBookInfoProvider(id = ProviderId.OpenLibrary, displayName = "ISBN Only")
+    isbnOnly.canServeResult = false
+    val asinCapable = FakeBookInfoProvider(id = ProviderId.Audnexus, displayName = "ASIN Capable")
+    asinCapable.bookInfoResult = BookInfoResult.Success(communityInfo)
+
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    BookInfoDatabase.Schema.synchronous().create(driver)
+    val db = BookInfoDatabase(driver)
+    val dispatchers = TestDispatcherProvider(StandardTestDispatcher(testScheduler))
+    val providers = setOf(isbnOnly, asinCapable)
+    val registry = DefaultBookInfoRegistry(
+      providers = providers,
+      settings = DefaultBookInfoProviderSettings(MapSettings(), session),
+      store = BookInfoStore(providers, db, dispatchers),
+      userSession = session,
+    )
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    val loaded = (state as LoadState.Loaded).data
+    assertThat(loaded!!.providerId).isEqualTo(ProviderId.Audnexus)
+    assertThat(loaded.availableSources.map { it.id }).isEqualTo(listOf(ProviderId.Audnexus))
+    assertThat(isbnOnly.bookInfoRequests.size).isEqualTo(0)
+  }
+
+  @Test
   fun `clearing the cache forces a refetch`() = runTest {
     val provider = FakeBookInfoProvider()
     provider.bookInfoResult = BookInfoResult.Success(communityInfo)

--- a/data/bookinfo/openlibrary/build.gradle.kts
+++ b/data/bookinfo/openlibrary/build.gradle.kts
@@ -1,0 +1,37 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import app.campfire.convention.addKspDependencyForCommon
+
+plugins {
+  id("app.campfire.android.library")
+  id("app.campfire.multiplatform")
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.ksp)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.data.bookinfo.api)
+
+        implementation(projects.core)
+        implementation(projects.data.network.api)
+        implementation(libs.ktor.client.core)
+        implementation(libs.kotlinx.serialization.json)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(libs.bundles.test.common)
+        implementation(libs.bundles.test.impl)
+        implementation(libs.ktor.client.mock)
+      }
+    }
+  }
+}
+
+addKspDependencyForCommon(libs.kimchi.compiler)

--- a/data/bookinfo/openlibrary/src/commonMain/kotlin/app/campfire/bookinfo/openlibrary/OpenLibraryBookInfoProvider.kt
+++ b/data/bookinfo/openlibrary/src/commonMain/kotlin/app/campfire/bookinfo/openlibrary/OpenLibraryBookInfoProvider.kt
@@ -1,0 +1,176 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.openlibrary
+
+import app.campfire.bookinfo.api.BookCommunityInfo
+import app.campfire.bookinfo.api.BookInfoProvider
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.ProviderCapabilities
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.openlibrary.di.OpenLibraryClient
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Keyless aggregate-rating and metadata source backed by Open Library
+ * (openlibrary.org). No account, no token — always available as a fallback
+ * when no account-linked provider is connected. Open Library keys on ISBN, so
+ * ASIN-only audiobooks are declared unservable and left to other providers.
+ */
+@SingleIn(UserScope::class)
+@ContributesMultibinding(UserScope::class, boundType = BookInfoProvider::class)
+@Inject
+class OpenLibraryBookInfoProvider(
+  @OpenLibraryClient private val client: HttpClient,
+) : BookInfoProvider {
+
+  override val id: ProviderId = ProviderId.OpenLibrary
+  override val displayName: String = "Open Library"
+
+  override val capabilities: ProviderCapabilities = ProviderCapabilities(
+    hasAggregateRating = true,
+    hasSupplementalMetadata = true,
+  )
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  private val throttle = RequestThrottle()
+
+  override fun observeLinkState(): Flow<ProviderLinkState> =
+    flowOf(ProviderLinkState.Linked(accountName = null))
+
+  override fun canServe(match: BookMatch): Boolean =
+    match is BookMatch.Identifiers && !match.isbn.isNullOrBlank()
+
+  override suspend fun getBookInfo(match: BookMatch): BookInfoResult<BookCommunityInfo> {
+    val isbn = (match as? BookMatch.Identifiers)
+      ?.isbn
+      ?.filter { it.isLetterOrDigit() }
+      ?.takeUnless { it.isEmpty() }
+      ?: return BookInfoResult.NotFound
+
+    // Two hops: the edition resolves the ISBN to a work, and ratings hang off
+    // the work. Covers are referenced by cover id, which dodges Open Library's
+    // tight per-IP limit on ISBN-keyed cover lookups.
+    val edition = when (val result = fetch("$BASE_URL/isbn/$isbn.json", OpenLibraryEdition.serializer())) {
+      is Fetched.Success -> result.value
+      Fetched.NotFound -> return BookInfoResult.NotFound
+      is Fetched.Failure -> return BookInfoResult.Failure(result.cause)
+    }
+    val workKey = edition.works.firstOrNull()?.key
+      ?.takeIf { it.startsWith("/works/") }
+      ?: return BookInfoResult.NotFound
+
+    val ratings = when (val result = fetch("$BASE_URL$workKey/ratings.json", OpenLibraryRatings.serializer())) {
+      is Fetched.Success -> result.value
+      Fetched.NotFound -> return BookInfoResult.NotFound
+      is Fetched.Failure -> return BookInfoResult.Failure(result.cause)
+    }
+
+    // No ratings is treated as a miss: the aggregate rating is what this
+    // provider exists to supply, and misses retry on the short TTL.
+    val average = ratings.summary.average ?: return BookInfoResult.NotFound
+    if ((ratings.summary.count ?: 0) <= 0) return BookInfoResult.NotFound
+
+    return BookInfoResult.Success(
+      BookCommunityInfo(
+        providerBookId = workKey,
+        providerUrl = "$BASE_URL$workKey",
+        rating = average,
+        ratingsCount = ratings.summary.count,
+        ratingsDistribution = ratings.counts
+          .mapNotNull { (star, count) -> star.toIntOrNull()?.let { it to count } }
+          .toMap()
+          .ifEmpty { null },
+        reviewsCount = null,
+        releaseDate = edition.publishDate,
+        coverUrl = edition.covers.firstOrNull { it > 0 }
+          ?.let { "https://covers.openlibrary.org/b/id/$it-L.jpg" },
+      ),
+    )
+  }
+
+  override suspend fun getReviews(match: BookMatch, limit: Int): BookInfoResult<List<BookReview>> {
+    return BookInfoResult.Success(emptyList())
+  }
+
+  private sealed interface Fetched<out T> {
+    data class Success<T>(val value: T) : Fetched<T>
+    data object NotFound : Fetched<Nothing>
+    data class Failure(val cause: Throwable) : Fetched<Nothing>
+  }
+
+  private suspend fun <T> fetch(
+    url: String,
+    deserializer: kotlinx.serialization.DeserializationStrategy<T>,
+  ): Fetched<T> {
+    val response: HttpResponse = try {
+      throttle.withThrottle { client.get(url) }
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      return Fetched.Failure(e)
+    }
+
+    return when {
+      response.status == HttpStatusCode.NotFound -> Fetched.NotFound
+      !response.status.isSuccess() -> Fetched.Failure(OpenLibraryHttpException(response.status.value))
+      else -> try {
+        Fetched.Success(json.decodeFromString(deserializer, response.bodyAsText()))
+      } catch (e: Exception) {
+        Fetched.Failure(e)
+      }
+    }
+  }
+
+  companion object {
+    private const val BASE_URL = "https://openlibrary.org"
+  }
+}
+
+class OpenLibraryHttpException(val status: Int) : Exception("Open Library HTTP $status")
+
+@Serializable
+internal data class OpenLibraryEdition(
+  val works: List<OpenLibraryWorkRef> = emptyList(),
+  val covers: List<Long> = emptyList(),
+  @SerialName("publish_date") val publishDate: String? = null,
+)
+
+@Serializable
+internal data class OpenLibraryWorkRef(
+  val key: String? = null,
+)
+
+@Serializable
+internal data class OpenLibraryRatings(
+  val summary: OpenLibraryRatingsSummary = OpenLibraryRatingsSummary(),
+  val counts: Map<String, Int> = emptyMap(),
+)
+
+@Serializable
+internal data class OpenLibraryRatingsSummary(
+  val average: Double? = null,
+  val count: Int? = null,
+)

--- a/data/bookinfo/openlibrary/src/commonMain/kotlin/app/campfire/bookinfo/openlibrary/RequestThrottle.kt
+++ b/data/bookinfo/openlibrary/src/commonMain/kotlin/app/campfire/bookinfo/openlibrary/RequestThrottle.kt
@@ -1,0 +1,36 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.openlibrary
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Serializes requests and spaces them at least [minInterval] apart. Open
+ * Library asks unauthenticated clients to stay around one request per second.
+ */
+internal class RequestThrottle(
+  private val minInterval: Duration = 1.seconds,
+  private val timeSource: TimeSource = TimeSource.Monotonic,
+) {
+  private val mutex = Mutex()
+  private var lastRequestAt: TimeMark? = null
+
+  suspend fun <T> withThrottle(block: suspend () -> T): T = mutex.withLock {
+    lastRequestAt?.let { last ->
+      val wait = minInterval - last.elapsedNow()
+      if (wait.isPositive()) delay(wait)
+    }
+    try {
+      block()
+    } finally {
+      lastRequestAt = timeSource.markNow()
+    }
+  }
+}

--- a/data/bookinfo/openlibrary/src/commonMain/kotlin/app/campfire/bookinfo/openlibrary/di/OpenLibraryHttpClientModule.kt
+++ b/data/bookinfo/openlibrary/src/commonMain/kotlin/app/campfire/bookinfo/openlibrary/di/OpenLibraryHttpClientModule.kt
@@ -1,0 +1,32 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.openlibrary.di
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.network.di.BaseClient
+import com.r0adkll.kimchi.annotations.ContributesTo
+import io.ktor.client.HttpClient
+import me.tatarka.inject.annotations.Provides
+import me.tatarka.inject.annotations.Qualifier
+
+/** Qualifies the [HttpClient] configured for the Open Library REST API. */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class OpenLibraryClient
+
+@ContributesTo(AppScope::class)
+interface OpenLibraryHttpClientModule {
+
+  // The base client already sends the identifying app User-Agent that Open
+  // Library's API policy asks for.
+  @OpenLibraryClient
+  @SingleIn(AppScope::class)
+  @Provides
+  fun provideOpenLibraryHttpClient(
+    @BaseClient baseClient: HttpClient,
+  ): HttpClient = baseClient.config {
+    expectSuccess = false
+  }
+}

--- a/data/bookinfo/openlibrary/src/commonTest/kotlin/app/campfire/bookinfo/openlibrary/OpenLibraryBookInfoProviderTest.kt
+++ b/data/bookinfo/openlibrary/src/commonTest/kotlin/app/campfire/bookinfo/openlibrary/OpenLibraryBookInfoProviderTest.kt
@@ -1,0 +1,124 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.openlibrary
+
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+private const val EDITION_RESPONSE = """
+{
+  "works": [{"key": "/works/OL8479867W"}],
+  "covers": [-1, 8739161],
+  "publish_date": "Aug 31, 2010"
+}
+"""
+
+private const val RATINGS_RESPONSE = """
+{
+  "summary": {"average": 4.35, "count": 132},
+  "counts": {"1": 2, "2": 4, "3": 16, "4": 34, "5": 76}
+}
+"""
+
+private const val EMPTY_RATINGS_RESPONSE = """
+{
+  "summary": {"average": null, "count": 0},
+  "counts": {"1": 0, "2": 0, "3": 0, "4": 0, "5": 0}
+}
+"""
+
+class OpenLibraryBookInfoProviderTest {
+
+  private val requests = mutableListOf<String>()
+
+  private fun provider(
+    ratingsResponse: String = RATINGS_RESPONSE,
+    editionStatus: HttpStatusCode = HttpStatusCode.OK,
+  ): OpenLibraryBookInfoProvider {
+    val client = HttpClient(
+      MockEngine { request ->
+        val url = request.url.toString()
+        requests += url
+        when {
+          "/isbn/" in url -> respond(EDITION_RESPONSE, editionStatus)
+          "/ratings.json" in url -> respond(ratingsResponse)
+          else -> respond("", HttpStatusCode.NotFound)
+        }
+      },
+    )
+    return OpenLibraryBookInfoProvider(client)
+  }
+
+  @Test
+  fun `only isbn bearing matches are servable`() {
+    val provider = provider()
+
+    assertThat(provider.canServe(BookMatch.Identifiers(isbn = "9780765393043", asin = null))).isTrue()
+    assertThat(provider.canServe(BookMatch.Identifiers(isbn = null, asin = "B002RI9Z9E"))).isFalse()
+    assertThat(provider.canServe(BookMatch.TitleAuthor("Title", "Author"))).isFalse()
+  }
+
+  @Test
+  fun `ratings resolve through the edition's work`() = runTest {
+    val result = provider().getBookInfo(BookMatch.Identifiers(isbn = "978-0-7653-9304-3", asin = null))
+
+    val info = (result as BookInfoResult.Success).data
+    assertThat(info.providerBookId).isEqualTo("/works/OL8479867W")
+    assertThat(info.providerUrl).isEqualTo("https://openlibrary.org/works/OL8479867W")
+    assertThat(info.rating).isEqualTo(4.35)
+    assertThat(info.ratingsCount).isEqualTo(132)
+    assertThat(info.ratingsDistribution).isEqualTo(mapOf(1 to 2, 2 to 4, 3 to 16, 4 to 34, 5 to 76))
+    assertThat(info.reviewsCount).isNull()
+    // Cover uses the first real cover id, skipping the -1 placeholder.
+    assertThat(info.coverUrl).isEqualTo("https://covers.openlibrary.org/b/id/8739161-L.jpg")
+
+    // The ISBN is normalized into the edition path.
+    assertThat(requests.first().contains("/isbn/9780765393043.json")).isTrue()
+  }
+
+  @Test
+  fun `a work without ratings is a miss`() = runTest {
+    val result = provider(ratingsResponse = EMPTY_RATINGS_RESPONSE)
+      .getBookInfo(BookMatch.Identifiers(isbn = "9780765393043", asin = null))
+
+    assertThat(result).isEqualTo(BookInfoResult.NotFound)
+  }
+
+  @Test
+  fun `an unknown isbn is a miss`() = runTest {
+    val result = provider(editionStatus = HttpStatusCode.NotFound)
+      .getBookInfo(BookMatch.Identifiers(isbn = "9999999999999", asin = null))
+
+    assertThat(result).isEqualTo(BookInfoResult.NotFound)
+    assertThat(requests.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `server errors surface as failures`() = runTest {
+    val result = provider(editionStatus = HttpStatusCode.InternalServerError)
+      .getBookInfo(BookMatch.Identifiers(isbn = "9780765393043", asin = null))
+
+    assertThat(result).isInstanceOf(BookInfoResult.Failure::class)
+  }
+
+  @Test
+  fun `an asin only match short circuits without a request`() = runTest {
+    val result = provider().getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B002RI9Z9E"))
+
+    assertThat(result).isEqualTo(BookInfoResult.NotFound)
+    assertThat(requests.size).isEqualTo(0)
+  }
+}

--- a/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoProvider.kt
+++ b/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoProvider.kt
@@ -30,6 +30,9 @@ class FakeBookInfoProvider(
   val linkState = MutableStateFlow<ProviderLinkState>(ProviderLinkState.Linked(accountName = null))
   override fun observeLinkState(): Flow<ProviderLinkState> = linkState
 
+  var canServeResult: Boolean = true
+  override fun canServe(match: BookMatch): Boolean = canServeResult
+
   var bookInfoResult: BookInfoResult<BookCommunityInfo> = BookInfoResult.NotFound
   val bookInfoRequests = mutableListOf<BookMatch>()
   override suspend fun getBookInfo(match: BookMatch): BookInfoResult<BookCommunityInfo> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -146,6 +146,7 @@ include(
   ":data:bookinfo:api",
   ":data:bookinfo:hardcover",
   ":data:bookinfo:impl",
+  ":data:bookinfo:openlibrary",
   ":data:bookinfo:test",
   ":data:bookinfo:ui",
 )


### PR DESCRIPTION
## Summary

First of Phase 3 (stacked on #1021): the anonymous fallback tier, so community ratings degrade gracefully for users without a Hardcover account.

- **`:data:bookinfo:openlibrary`**: keyless provider resolving ISBN → edition → work → `ratings.json` for average, count, and the per-star distribution. Covers referenced by cover id (Open Library rate-limits ISBN-keyed cover lookups hard); requests spaced ~1/s per their API policy via a small mutex throttle; identifying app User-Agent inherited from the base client. A work with zero ratings is treated as a miss (short TTL) since the aggregate rating is what this provider exists to supply.
- **Identifier-aware selection**: new `BookInfoProvider.canServe(match)` (default true) lets a catalog declare a match unservable — Open Library can't do ASIN-only audiobooks — and the registry skips to a provider that can, keeping unservable sources out of the source-switcher pill too. Without this, an ASIN-only book would route to Open Library and dead-end.
- Zero UI changes: the Social settings screen and the source pill are registry-driven, so Open Library appears in both automatically. It ranks below Hardcover, so linked users see no behavior change.

## Test plan
- `./gradlew :data:bookinfo:openlibrary:jvmTest` — edition→work→ratings mapping (distribution, cover id skip of -1 placeholders, ISBN normalization into the path), 404 → miss, zero ratings → miss, server error → failure, ASIN-only short-circuit
- `./gradlew :data:bookinfo:impl:jvmTest` — unservable provider skipped for one that can serve, and excluded from available sources
- Desktop DI graph compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu