### PR TITLE
Add Audnexus ratings for audiobooks and a connect-for-reviews shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Community ratings and reviews from Hardcover on the book detail page, with attribution and a tap-through to the book on Hardcover
 - Social page in Settings to connect book info providers like Hardcover (paste an API token), toggle sources, and clear cached data
 - Open Library as a built-in ratings source — books with an ISBN show community ratings even without a Hardcover account
+- Audnexus as a built-in ratings source for audiobooks with an ASIN, showing the Audible rating without any account
+- A "Connect Hardcover to see reviews" shortcut on the Community section when ratings come from a source without written reviews
 
 ### Changed
 

--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
         api(projects.data.account.ui)
         api(projects.data.analytics.impl)
         api(projects.data.bookinfo.impl)
+        api(projects.data.bookinfo.audnexus)
         api(projects.data.bookinfo.hardcover)
         api(projects.data.bookinfo.openlibrary)
         api(projects.data.bookinfo.ui)

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
@@ -49,6 +49,9 @@ data class ProviderStatus(
  *
  * @param availableSources every provider currently able to serve community
  * info, for source-switcher UI; always contains the serving provider.
+ * @param reviewsLinkProviderName when the serving provider has no review text
+ * but linking another provider (e.g. Hardcover) would add reviews, the name of
+ * that provider — for a "connect for reviews" affordance.
  */
 data class CommunityInfoState(
   val providerId: ProviderId,
@@ -58,6 +61,7 @@ data class CommunityInfoState(
   val reviews: List<BookReview>,
   val needsRelink: Boolean = false,
   val availableSources: List<CommunitySource> = emptyList(),
+  val reviewsLinkProviderName: String? = null,
 )
 
 data class CommunitySource(

--- a/data/bookinfo/audnexus/build.gradle.kts
+++ b/data/bookinfo/audnexus/build.gradle.kts
@@ -1,0 +1,37 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import app.campfire.convention.addKspDependencyForCommon
+
+plugins {
+  id("app.campfire.android.library")
+  id("app.campfire.multiplatform")
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.ksp)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.data.bookinfo.api)
+
+        implementation(projects.core)
+        implementation(projects.data.network.api)
+        implementation(libs.ktor.client.core)
+        implementation(libs.kotlinx.serialization.json)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(libs.bundles.test.common)
+        implementation(libs.bundles.test.impl)
+        implementation(libs.ktor.client.mock)
+      }
+    }
+  }
+}
+
+addKspDependencyForCommon(libs.kimchi.compiler)

--- a/data/bookinfo/audnexus/src/commonMain/kotlin/app/campfire/bookinfo/audnexus/AudnexusBookInfoProvider.kt
+++ b/data/bookinfo/audnexus/src/commonMain/kotlin/app/campfire/bookinfo/audnexus/AudnexusBookInfoProvider.kt
@@ -1,0 +1,125 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.audnexus
+
+import app.campfire.bookinfo.api.BookCommunityInfo
+import app.campfire.bookinfo.api.BookInfoProvider
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.ProviderCapabilities
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.audnexus.di.AudnexusClient
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Keyless audiobook-native source backed by Audnexus (audnex.us), whose data
+ * is Audible-derived. Keys on ASIN — the identifier audiobooks most reliably
+ * carry — and supplies the Audible aggregate rating plus metadata. No rating
+ * distribution or count is available.
+ */
+@SingleIn(UserScope::class)
+@ContributesMultibinding(UserScope::class, boundType = BookInfoProvider::class)
+@Inject
+class AudnexusBookInfoProvider(
+  @AudnexusClient private val client: HttpClient,
+) : BookInfoProvider {
+
+  override val id: ProviderId = ProviderId.Audnexus
+  override val displayName: String = "Audnexus"
+
+  override val capabilities: ProviderCapabilities = ProviderCapabilities(
+    hasAggregateRating = true,
+    hasSupplementalMetadata = true,
+  )
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  override fun observeLinkState(): Flow<ProviderLinkState> =
+    flowOf(ProviderLinkState.Linked(accountName = null))
+
+  override fun canServe(match: BookMatch): Boolean =
+    match is BookMatch.Identifiers && !match.asin.isNullOrBlank()
+
+  override suspend fun getBookInfo(match: BookMatch): BookInfoResult<BookCommunityInfo> {
+    val asin = (match as? BookMatch.Identifiers)
+      ?.asin
+      ?.filter { it.isLetterOrDigit() }
+      ?.uppercase()
+      ?.takeUnless { it.isEmpty() }
+      ?: return BookInfoResult.NotFound
+
+    val response = try {
+      client.get("$BASE_URL/books/$asin")
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      return BookInfoResult.Failure(e)
+    }
+
+    return when {
+      response.status == HttpStatusCode.NotFound -> BookInfoResult.NotFound
+      // Audnexus reports an unparseable/unknown ASIN as a 400.
+      response.status == HttpStatusCode.BadRequest -> BookInfoResult.NotFound
+      !response.status.isSuccess() ->
+        BookInfoResult.Failure(AudnexusHttpException(response.status.value))
+      else -> try {
+        val book = json.decodeFromString(AudnexusBook.serializer(), response.bodyAsText())
+        val rating = book.rating?.toDoubleOrNull()?.takeIf { it > 0.0 }
+          ?: return BookInfoResult.NotFound
+        BookInfoResult.Success(
+          BookCommunityInfo(
+            providerBookId = book.asin ?: asin,
+            providerUrl = "https://www.audible.com/pd/${book.asin ?: asin}",
+            rating = rating,
+            ratingsCount = null,
+            ratingsDistribution = null,
+            reviewsCount = null,
+            releaseDate = book.releaseDate,
+            coverUrl = book.image,
+          ),
+        )
+      } catch (e: Exception) {
+        BookInfoResult.Failure(e)
+      }
+    }
+  }
+
+  override suspend fun getReviews(match: BookMatch, limit: Int): BookInfoResult<List<BookReview>> {
+    return BookInfoResult.Success(emptyList())
+  }
+
+  companion object {
+    private const val BASE_URL = "https://api.audnex.us"
+  }
+}
+
+class AudnexusHttpException(val status: Int) : Exception("Audnexus HTTP $status")
+
+@Serializable
+internal data class AudnexusBook(
+  val asin: String? = null,
+  val title: String? = null,
+  val rating: String? = null,
+  @SerialName("releaseDate") val releaseDate: String? = null,
+  val image: String? = null,
+)

--- a/data/bookinfo/audnexus/src/commonMain/kotlin/app/campfire/bookinfo/audnexus/di/AudnexusHttpClientModule.kt
+++ b/data/bookinfo/audnexus/src/commonMain/kotlin/app/campfire/bookinfo/audnexus/di/AudnexusHttpClientModule.kt
@@ -1,0 +1,30 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.audnexus.di
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.network.di.BaseClient
+import com.r0adkll.kimchi.annotations.ContributesTo
+import io.ktor.client.HttpClient
+import me.tatarka.inject.annotations.Provides
+import me.tatarka.inject.annotations.Qualifier
+
+/** Qualifies the [HttpClient] configured for the Audnexus REST API. */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AudnexusClient
+
+@ContributesTo(AppScope::class)
+interface AudnexusHttpClientModule {
+
+  @AudnexusClient
+  @SingleIn(AppScope::class)
+  @Provides
+  fun provideAudnexusHttpClient(
+    @BaseClient baseClient: HttpClient,
+  ): HttpClient = baseClient.config {
+    expectSuccess = false
+  }
+}

--- a/data/bookinfo/audnexus/src/commonTest/kotlin/app/campfire/bookinfo/audnexus/AudnexusBookInfoProviderTest.kt
+++ b/data/bookinfo/audnexus/src/commonTest/kotlin/app/campfire/bookinfo/audnexus/AudnexusBookInfoProviderTest.kt
@@ -1,0 +1,114 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.audnexus
+
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+private const val BOOK_RESPONSE = """
+{
+  "asin": "B002V0QK4C",
+  "title": "The Way of Kings",
+  "rating": "4.79",
+  "releaseDate": "2010-08-31T00:00:00.000Z",
+  "image": "https://m.media-amazon.com/images/I/91KzZWpgmyL.jpg",
+  "runtimeLengthMin": 2734,
+  "genres": [{"asin": "18580606011", "name": "Science Fiction & Fantasy", "type": "genre"}]
+}
+"""
+
+private const val UNRATED_RESPONSE = """
+{"asin": "B002V0QK4C", "title": "Obscure Book", "rating": "0"}
+"""
+
+class AudnexusBookInfoProviderTest {
+
+  private val requests = mutableListOf<String>()
+
+  private fun provider(
+    response: String = BOOK_RESPONSE,
+    status: HttpStatusCode = HttpStatusCode.OK,
+  ): AudnexusBookInfoProvider {
+    val client = HttpClient(
+      MockEngine { request ->
+        requests += request.url.toString()
+        respond(response, status)
+      },
+    )
+    return AudnexusBookInfoProvider(client)
+  }
+
+  @Test
+  fun `only asin bearing matches are servable`() {
+    val provider = provider()
+
+    assertThat(provider.canServe(BookMatch.Identifiers(isbn = null, asin = "B002V0QK4C"))).isTrue()
+    assertThat(provider.canServe(BookMatch.Identifiers(isbn = "9780765393043", asin = null))).isFalse()
+    assertThat(provider.canServe(BookMatch.TitleAuthor("Title", "Author"))).isFalse()
+  }
+
+  @Test
+  fun `the audible rating and metadata are mapped`() = runTest {
+    val result = provider().getBookInfo(BookMatch.Identifiers(isbn = null, asin = " b002v0qk4c "))
+
+    val info = (result as BookInfoResult.Success).data
+    assertThat(info.providerBookId).isEqualTo("B002V0QK4C")
+    assertThat(info.providerUrl).isEqualTo("https://www.audible.com/pd/B002V0QK4C")
+    assertThat(info.rating).isEqualTo(4.79)
+    assertThat(info.ratingsCount).isNull()
+    assertThat(info.ratingsDistribution).isNull()
+    assertThat(info.coverUrl).isEqualTo("https://m.media-amazon.com/images/I/91KzZWpgmyL.jpg")
+    // The ASIN is normalized (trimmed, uppercased) into the request path.
+    assertThat(requests.single().endsWith("/books/B002V0QK4C")).isTrue()
+  }
+
+  @Test
+  fun `an unrated book is a miss`() = runTest {
+    val result = provider(response = UNRATED_RESPONSE)
+      .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B002V0QK4C"))
+
+    assertThat(result).isEqualTo(BookInfoResult.NotFound)
+  }
+
+  @Test
+  fun `unknown asins are a miss for 404 and 400`() = runTest {
+    assertThat(
+      provider(response = "", status = HttpStatusCode.NotFound)
+        .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B000000000")),
+    ).isEqualTo(BookInfoResult.NotFound)
+
+    assertThat(
+      provider(response = "", status = HttpStatusCode.BadRequest)
+        .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "NOTANASIN1")),
+    ).isEqualTo(BookInfoResult.NotFound)
+  }
+
+  @Test
+  fun `server errors surface as failures`() = runTest {
+    val result = provider(response = "", status = HttpStatusCode.InternalServerError)
+      .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B002V0QK4C"))
+
+    assertThat(result).isInstanceOf(BookInfoResult.Failure::class)
+  }
+
+  @Test
+  fun `an isbn only match short circuits without a request`() = runTest {
+    val result = provider().getBookInfo(BookMatch.Identifiers(isbn = "9780765393043", asin = null))
+
+    assertThat(result).isEqualTo(BookInfoResult.NotFound)
+    assertThat(requests.size).isEqualTo(0)
+  }
+}

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -65,11 +65,23 @@ class DefaultBookInfoRegistry(
     val match = item.bestMatch() ?: return flowOf(LoadState.Loaded(null))
 
     return observeProviders()
-      .map { statuses -> statuses.filter { it.canServeBookInfo && it.provider.canServe(match) } }
-      .distinctUntilChanged { old, new ->
-        old.map { it.provider.id to it.linkState } == new.map { it.provider.id to it.linkState }
+      .map { statuses ->
+        val usable = statuses.filter { it.canServeBookInfo && it.provider.canServe(match) }
+        // An enabled-but-unlinked review-capable provider is worth advertising
+        // when whoever ends up serving has no review text of its own.
+        val reviewsVia = statuses.firstOrNull {
+          it.enabled &&
+            it.provider.capabilities.hasReviewText &&
+            it.linkState is ProviderLinkState.NotLinked
+        }?.provider?.displayName
+        usable to reviewsVia
       }
-      .flatMapLatest { usable ->
+      .distinctUntilChanged { (oldUsable, oldVia), (newUsable, newVia) ->
+        oldUsable.map { it.provider.id to it.linkState } ==
+          newUsable.map { it.provider.id to it.linkState } &&
+          oldVia == newVia
+      }
+      .flatMapLatest { (usable, reviewsVia) ->
         val status = usable.firstOrNull { it.provider.id == preferredProvider }
           ?: usable.firstOrNull()
         if (status == null) {
@@ -79,6 +91,8 @@ class DefaultBookInfoRegistry(
             status = status,
             key = BookInfoStore.Key(userId, status.provider.id, item.id, match),
             sources = usable.map { CommunitySource(it.provider.id, it.provider.displayName) },
+            reviewsLinkProviderName = reviewsVia
+              .takeUnless { status.provider.capabilities.hasReviewText },
           )
         }
       }
@@ -92,6 +106,7 @@ class DefaultBookInfoRegistry(
     status: ProviderStatus,
     key: BookInfoStore.Key,
     sources: List<CommunitySource>,
+    reviewsLinkProviderName: String?,
   ): Flow<LoadState<out CommunityInfoState?>> = flow {
     val cached = store.cached(key)
     val invalidLink = status.linkState is ProviderLinkState.Invalid
@@ -117,7 +132,7 @@ class DefaultBookInfoRegistry(
         is StoreReadResponse.Loading -> if (!emittedData) emit(LoadState.Loading)
         is StoreReadResponse.Data -> {
           emittedData = true
-          emit(LoadState.Loaded(response.value.toState(status, sources)))
+          emit(LoadState.Loaded(response.value.toState(status, sources, reviewsLinkProviderName)))
         }
         is StoreReadResponse.Error -> if (!emittedData) emit(LoadState.Loaded(null))
         else -> Unit
@@ -128,6 +143,7 @@ class DefaultBookInfoRegistry(
   private fun CachedBookInfo.toState(
     status: ProviderStatus,
     sources: List<CommunitySource>,
+    reviewsLinkProviderName: String?,
   ): CommunityInfoState? {
     val info = info ?: return null
     return CommunityInfoState(
@@ -138,6 +154,7 @@ class DefaultBookInfoRegistry(
       reviews = reviews,
       needsRelink = status.linkState is ProviderLinkState.Invalid,
       availableSources = sources,
+      reviewsLinkProviderName = reviewsLinkProviderName,
     )
   }
 

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -6,6 +6,7 @@ package app.campfire.bookinfo
 import app.campfire.bookinfo.api.BookCommunityInfo
 import app.campfire.bookinfo.api.BookInfoResult
 import app.campfire.bookinfo.api.CommunitySource
+import app.campfire.bookinfo.api.ProviderCapabilities
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
 import app.campfire.bookinfo.db.BookInfoDatabase
@@ -239,6 +240,48 @@ class DefaultBookInfoRegistryTest {
     assertThat(loaded!!.providerId).isEqualTo(ProviderId.Audnexus)
     assertThat(loaded.availableSources.map { it.id }).isEqualTo(listOf(ProviderId.Audnexus))
     assertThat(isbnOnly.bookInfoRequests.size).isEqualTo(0)
+  }
+
+  @Test
+  fun `a linkable review source is advertised when the serving provider lacks reviews`() = runTest {
+    val keyless = FakeBookInfoProvider(
+      id = ProviderId.OpenLibrary,
+      displayName = "Open Library",
+      capabilities = ProviderCapabilities(hasAggregateRating = true),
+    )
+    keyless.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val hardcover = FakeBookInfoProvider(id = ProviderId.Hardcover, displayName = "Hardcover")
+    hardcover.linkState.value = ProviderLinkState.NotLinked
+
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    BookInfoDatabase.Schema.synchronous().create(driver)
+    val db = BookInfoDatabase(driver)
+    val dispatchers = TestDispatcherProvider(StandardTestDispatcher(testScheduler))
+    val providers = setOf(hardcover, keyless)
+    val registry = DefaultBookInfoRegistry(
+      providers = providers,
+      settings = DefaultBookInfoProviderSettings(MapSettings(), session),
+      store = BookInfoStore(providers, db, dispatchers),
+      userSession = session,
+    )
+
+    val state = registry.observeCommunityInfo(item)
+      .first { it is LoadState.Loaded<*> && (it as LoadState.Loaded).data != null }
+
+    val loaded = (state as LoadState.Loaded).data!!
+    assertThat(loaded.providerId).isEqualTo(ProviderId.OpenLibrary)
+    assertThat(loaded.reviewsLinkProviderName).isEqualTo("Hardcover")
+  }
+
+  @Test
+  fun `no review link is advertised when the serving provider has review text`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    assertThat((state as LoadState.Loaded).data!!.reviewsLinkProviderName).isNull()
   }
 
   @Test

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -146,5 +146,6 @@
   <string name="community_review_spoiler_warning">Contains spoilers</string>
   <string name="community_review_show_spoiler">Show review</string>
   <string name="community_relink_provider">Reconnect %1$s to refresh</string>
+  <string name="community_connect_for_reviews">Connect %1$s to see reviews</string>
   <string name="community_open_on_provider">Open on %1$s</string>
 </resources>

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
@@ -57,6 +57,7 @@ import app.campfire.libraries.ui.detail.composables.ReviewBottomSheet
 import app.campfire.libraries.ui.detail.composables.ReviewerAvatar
 import app.campfire.libraries.ui.detail.composables.ReviewerBadge
 import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.community_connect_for_reviews
 import campfire.features.libraries.ui.generated.resources.community_rating_attribution
 import campfire.features.libraries.ui.generated.resources.community_rating_count
 import campfire.features.libraries.ui.generated.resources.community_relink_provider
@@ -185,6 +186,16 @@ class CommunitySlot(
               onClick = { expandedReview = review },
             )
           }
+        }
+      }
+
+      // Serving source has no review text, but linking another provider adds it.
+      state.reviewsLinkProviderName?.takeIf { state.reviews.isEmpty() }?.let { linkName ->
+        TextButton(
+          onClick = { eventSink(LibraryItemUiEvent.RelinkProvider) },
+          modifier = Modifier.padding(horizontal = 8.dp),
+        ) {
+          Text(stringResource(Res.string.community_connect_for_reviews, linkName))
         }
       }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -144,6 +144,7 @@ include(
 )
 include(
   ":data:bookinfo:api",
+  ":data:bookinfo:audnexus",
   ":data:bookinfo:hardcover",
   ":data:bookinfo:impl",
   ":data:bookinfo:openlibrary",


### PR DESCRIPTION
## Summary

Completes Phase 3 (stacked on #1025).

- **`:data:bookinfo:audnexus`**: keyless provider serving the Audible aggregate rating (plus cover/release metadata) from `api.audnex.us/books/{asin}` for any audiobook with an ASIN — the identifier audiobooks most reliably carry, covering exactly the books Open Library can't. `canServe` declares ISBN-only matches unservable; unrated books and unknown ASINs (404/400) are misses on the short TTL. No distribution or ratings count exists in this source, and the UI already renders rating-only states gracefully.
- **Connect-for-reviews shortcut**: when the serving source has no written reviews but a review-capable provider (Hardcover) is enabled and unlinked, the registry surfaces its name and the Community section shows "Connect Hardcover to see reviews" routing to the Social settings page — the richer tier becomes discoverable exactly where its absence is felt. Attribution already switches per provider automatically.

With both fallback providers in, the source-switcher pill gets real choices for the first time: a book with ISBN + ASIN and a linked Hardcover account offers all three sources.

## Test plan
- `./gradlew :data:bookinfo:audnexus:jvmTest` — rating/metadata mapping with ASIN normalization, unrated → miss, 404/400 → miss, 5xx → failure, ISBN-only short-circuit
- `./gradlew :data:bookinfo:impl:jvmTest` — reviews-link name surfaced when serving provider lacks review text, absent when it has it
- Desktop DI graph compiles with all four providers registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu