### PR TITLE
Add Audible ratings for audiobooks and a connect-for-reviews shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Community ratings and reviews from Hardcover on the book detail page, with attribution and a tap-through to the book on Hardcover
 - Book Info page in Settings to connect sources like Hardcover (paste an API token), toggle them, and clear cached data
 - Open Library as a built-in ratings source — books with an ISBN show community ratings even without a Hardcover account
+- Audible as a built-in ratings source for audiobooks with an ASIN, showing the Audible rating and star distribution without any account
+- A "Connect Hardcover to see reviews" shortcut on the Community section when ratings come from a source without written reviews
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Community ratings and reviews from Hardcover on the book detail page, with attribution and a tap-through to the book on Hardcover
 - Book Info page in Settings to connect sources like Hardcover (paste an API token), toggle them, and clear cached data
 - Open Library as a built-in ratings source — books with an ISBN show community ratings even without a Hardcover account
-- Audible as a built-in ratings source for audiobooks with an ASIN, showing the Audible rating and star distribution without any account
+- Audible as a built-in source for audiobooks with an ASIN, showing the Audible rating, star distribution, and written reviews without any account
 - A "Connect Hardcover to see reviews" shortcut on the Community section when ratings come from a source without written reviews
 
 ### Changed

--- a/app/common/build.gradle.kts
+++ b/app/common/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
         api(projects.data.account.ui)
         api(projects.data.analytics.impl)
         api(projects.data.bookinfo.impl)
+        api(projects.data.bookinfo.audible)
         api(projects.data.bookinfo.hardcover)
         api(projects.data.bookinfo.openlibrary)
         api(projects.data.bookinfo.ui)

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/Audible.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/Audible.kt
@@ -1,0 +1,101 @@
+package app.campfire.common.compose.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Audible's provider brand mark: an open-source book glyph carrying the brand
+ * orange, since brand marks render untinted. Not a general-purpose icon — it
+ * lives outside the tintable packs on purpose.
+ */
+val CampfireIcons.Audible: ImageVector by lazy(LazyThreadSafetyMode.NONE) {
+  ImageVector.Builder(
+    name = "Audible",
+    defaultWidth = 24.dp,
+    defaultHeight = 24.dp,
+    viewportWidth = 960f,
+    viewportHeight = 960f,
+  ).apply {
+    path(fill = SolidColor(Color(0xFFF8991C))) {
+      moveTo(560f, 396f)
+      verticalLineToRelative(-68f)
+      quadToRelative(33f, -14f, 67.5f, -21f)
+      reflectiveQuadToRelative(72.5f, -7f)
+      quadToRelative(26f, 0f, 51f, 4f)
+      reflectiveQuadToRelative(49f, 10f)
+      verticalLineToRelative(64f)
+      quadToRelative(-24f, -9f, -48.5f, -13.5f)
+      reflectiveQuadTo(700f, 360f)
+      quadToRelative(-38f, 0f, -73f, 9.5f)
+      reflectiveQuadTo(560f, 396f)
+      close()
+      moveTo(560f, 616f)
+      verticalLineToRelative(-68f)
+      quadToRelative(33f, -14f, 67.5f, -21f)
+      reflectiveQuadToRelative(72.5f, -7f)
+      quadToRelative(26f, 0f, 51f, 4f)
+      reflectiveQuadToRelative(49f, 10f)
+      verticalLineToRelative(64f)
+      quadToRelative(-24f, -9f, -48.5f, -13.5f)
+      reflectiveQuadTo(700f, 580f)
+      quadToRelative(-38f, 0f, -73f, 9f)
+      reflectiveQuadToRelative(-67f, 27f)
+      close()
+      moveTo(560f, 506f)
+      verticalLineToRelative(-68f)
+      quadToRelative(33f, -14f, 67.5f, -21f)
+      reflectiveQuadToRelative(72.5f, -7f)
+      quadToRelative(26f, 0f, 51f, 4f)
+      reflectiveQuadToRelative(49f, 10f)
+      verticalLineToRelative(64f)
+      quadToRelative(-24f, -9f, -48.5f, -13.5f)
+      reflectiveQuadTo(700f, 470f)
+      quadToRelative(-38f, 0f, -73f, 9.5f)
+      reflectiveQuadTo(560f, 506f)
+      close()
+      moveTo(520f, 682f)
+      quadToRelative(44f, -21f, 88.5f, -31.5f)
+      reflectiveQuadTo(700f, 640f)
+      quadToRelative(36f, 0f, 70.5f, 6f)
+      reflectiveQuadToRelative(69.5f, 18f)
+      verticalLineToRelative(-396f)
+      quadToRelative(-33f, -14f, -68.5f, -21f)
+      reflectiveQuadToRelative(-71.5f, -7f)
+      quadToRelative(-47f, 0f, -93f, 12f)
+      reflectiveQuadToRelative(-87f, 36f)
+      verticalLineToRelative(394f)
+      close()
+      moveTo(480f, 800f)
+      quadToRelative(-48f, -38f, -104f, -59f)
+      reflectiveQuadToRelative(-116f, -21f)
+      quadToRelative(-42f, 0f, -82.5f, 11f)
+      reflectiveQuadTo(100f, 762f)
+      quadToRelative(-21f, 11f, -40.5f, -1f)
+      reflectiveQuadTo(40f, 726f)
+      verticalLineToRelative(-482f)
+      quadToRelative(0f, -11f, 5.5f, -21f)
+      reflectiveQuadTo(62f, 208f)
+      quadToRelative(47f, -23f, 96.5f, -35.5f)
+      reflectiveQuadTo(260f, 160f)
+      quadToRelative(58f, 0f, 113.5f, 15f)
+      reflectiveQuadTo(480f, 220f)
+      quadToRelative(51f, -30f, 106.5f, -45f)
+      reflectiveQuadTo(700f, 160f)
+      quadToRelative(52f, 0f, 101.5f, 12.5f)
+      reflectiveQuadTo(898f, 208f)
+      quadToRelative(11f, 5f, 16.5f, 15f)
+      reflectiveQuadToRelative(5.5f, 21f)
+      verticalLineToRelative(482f)
+      quadToRelative(0f, 23f, -19.5f, 35f)
+      reflectiveQuadToRelative(-40.5f, 1f)
+      quadToRelative(-37f, -20f, -77.5f, -31f)
+      reflectiveQuadTo(700f, 720f)
+      quadToRelative(-60f, 0f, -116f, 21f)
+      reflectiveQuadToRelative(-104f, 59f)
+      close()
+    }
+  }.build()
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/ProviderBranding.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/ProviderBranding.kt
@@ -13,26 +13,38 @@ import androidx.compose.ui.graphics.vector.ImageVector
  * `tint = Color.Unspecified`) so the brand colors survive.
  */
 private const val HARDCOVER = "hardcover"
+private const val AUDIBLE = "audible"
 
 fun providerBrandIcon(providerKey: String): ImageVector? = when (providerKey) {
   HARDCOVER -> CampfireIcons.Hardcover
+  AUDIBLE -> CampfireIcons.Audible
   else -> null
 }
 
-/** The provider's primary brand color (Hardcover declares #6366F1 as its theme color). */
+/**
+ * The provider's primary brand color (Hardcover declares #6366F1 as its theme
+ * color; Audible's is its signature orange, #F8991C).
+ */
 fun providerBrandColor(providerKey: String): Color? = when (providerKey) {
   HARDCOVER -> Color(0xFF6366F1)
+  AUDIBLE -> Color(0xFFF8991C)
   else -> null
 }
 
-/** The provider's primary brand color (Hardcover declares #6366F1 as its theme color). */
+/** A deep shade of the brand hue, mirroring [providerBrandColor]'s scale. */
 fun providerBrandSecondaryColor(providerKey: String): Color? = when (providerKey) {
   HARDCOVER -> Color(0xFF312E81)
+  AUDIBLE -> Color(0xFF78350F)
   else -> null
 }
 
-/** Content color that stays legible on top of [providerBrandColor]. */
+/**
+ * Content color that stays legible on top of [providerBrandColor]. Audible's
+ * orange is light enough that white fails contrast — black is also the
+ * pairing Audible itself uses.
+ */
 fun providerOnBrandColor(providerKey: String): Color? = when (providerKey) {
   HARDCOVER -> Color.White
+  AUDIBLE -> Color.Black
   else -> null
 }

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookCommunityInfo.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookCommunityInfo.kt
@@ -29,6 +29,7 @@ data class BookCommunityInfo(
  * A single written community review.
  *
  * @param author the reviewer's display name (or username when no name is set)
+ * @param title the reviewer's own headline for the review, when the provider has one
  * @param avatarUrl the reviewer's profile image, when the provider exposes one
  * @param badge provider-issued profile badge text (e.g. Hardcover's "Supporter" flair)
  */
@@ -40,4 +41,5 @@ data class BookReview(
   val hasSpoilers: Boolean,
   val avatarUrl: String? = null,
   val badge: String? = null,
+  val title: String? = null,
 )

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
@@ -49,6 +49,9 @@ data class ProviderStatus(
  *
  * @param availableSources every provider currently able to serve community
  * info, for source-switcher UI; always contains the serving provider.
+ * @param reviewsLinkProviderName when the serving provider has no review text
+ * but linking another provider (e.g. Hardcover) would add reviews, the name of
+ * that provider — for a "connect for reviews" affordance.
  */
 data class CommunityInfoState(
   val providerId: ProviderId,
@@ -58,6 +61,7 @@ data class CommunityInfoState(
   val reviews: List<BookReview>,
   val needsRelink: Boolean = false,
   val availableSources: List<CommunitySource> = emptyList(),
+  val reviewsLinkProviderName: String? = null,
 )
 
 data class CommunitySource(

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
@@ -3,7 +3,6 @@
 
 package app.campfire.bookinfo.api
 
-import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.LibraryItem
 import kotlinx.coroutines.flow.Flow
 
@@ -20,14 +19,18 @@ interface BookInfoRegistry {
    * Community rating and reviews for [item]. By default the best available
    * provider is chosen automatically; pass [preferredProvider] to pin a
    * specific source (falls back to the automatic pick when the pinned provider
-   * is disabled, unlinked, or not installed). Emits `Loaded(null)` when no
-   * enabled provider can serve the item (no match identifiers, provider not
-   * linked, or nothing found).
+   * is disabled, unlinked, or not installed).
+   *
+   * Emits null only when nothing could ever serve the item — no identifiers,
+   * or no enabled provider can match it. Otherwise the emitted state always
+   * carries the serving provider and switchable sources, with the fetch phase
+   * expressed in [CommunityInfoState.content] — so a section rendered from
+   * this state stays put across loads and source switches.
    */
   fun observeCommunityInfo(
     item: LibraryItem,
     preferredProvider: ProviderId? = null,
-  ): Flow<LoadState<out CommunityInfoState?>>
+  ): Flow<CommunityInfoState?>
 
   /**
    * Drops all locally cached provider data (for every provider and user).
@@ -43,12 +46,13 @@ data class ProviderStatus(
 )
 
 /**
- * Presentation-ready community info. [providerName] and [providerUrl] must be
- * shown alongside any aggregate rating — attribution is a terms-of-service
- * requirement for some providers (e.g. Hardcover).
+ * Presentation-ready community info from one serving provider. The provider
+ * identity doubles as the required attribution for aggregate data (a
+ * terms-of-service requirement for some providers, e.g. Hardcover) and must
+ * render wherever [CommunityContent.Available] data does.
  *
- * @param availableSources every provider currently able to serve community
- * info, for source-switcher UI; always contains the serving provider.
+ * @param availableSources every provider currently able to serve the item,
+ * for source-switcher UI; always contains the serving provider.
  * @param reviewsLinkProviderName when the serving provider has no review text
  * but linking another provider (e.g. Hardcover) would add reviews, the name of
  * that provider — for a "connect for reviews" affordance.
@@ -56,13 +60,24 @@ data class ProviderStatus(
 data class CommunityInfoState(
   val providerId: ProviderId,
   val providerName: String,
-  val providerUrl: String?,
-  val info: BookCommunityInfo,
-  val reviews: List<BookReview>,
-  val needsRelink: Boolean = false,
   val availableSources: List<CommunitySource> = emptyList(),
+  val needsRelink: Boolean = false,
   val reviewsLinkProviderName: String? = null,
+  val content: CommunityContent = CommunityContent.Loading,
 )
+
+sealed interface CommunityContent {
+  /** The serving provider is being fetched with nothing cached yet. */
+  data object Loading : CommunityContent
+
+  /** The serving provider has nothing for this book. */
+  data object Unavailable : CommunityContent
+
+  data class Available(
+    val info: BookCommunityInfo,
+    val reviews: List<BookReview>,
+  ) : CommunityContent
+}
 
 data class CommunitySource(
   val id: ProviderId,

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/ProviderId.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/ProviderId.kt
@@ -9,6 +9,6 @@ package app.campfire.bookinfo.api
  */
 enum class ProviderId(val key: String) {
   Hardcover("hardcover"),
+  Audible("audible"),
   OpenLibrary("openlibrary"),
-  Audnexus("audnexus"),
 }

--- a/data/bookinfo/audible/build.gradle.kts
+++ b/data/bookinfo/audible/build.gradle.kts
@@ -1,0 +1,37 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import app.campfire.convention.addKspDependencyForCommon
+
+plugins {
+  id("app.campfire.android.library")
+  id("app.campfire.multiplatform")
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.ksp)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.data.bookinfo.api)
+
+        implementation(projects.core)
+        implementation(projects.data.network.api)
+        implementation(libs.ktor.client.core)
+        implementation(libs.kotlinx.serialization.json)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(libs.bundles.test.common)
+        implementation(libs.bundles.test.impl)
+        implementation(libs.ktor.client.mock)
+      }
+    }
+  }
+}
+
+addKspDependencyForCommon(libs.kimchi.compiler)

--- a/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/AudibleBookInfoProvider.kt
+++ b/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/AudibleBookInfoProvider.kt
@@ -42,6 +42,7 @@ class AudibleBookInfoProvider(
   override val displayName: String = "Audible"
 
   override val capabilities: ProviderCapabilities = ProviderCapabilities(
+    hasReviewText = true,
     hasAggregateRating = true,
     hasSupplementalMetadata = true,
   )
@@ -82,12 +83,54 @@ class AudibleBookInfoProvider(
   }
 
   override suspend fun getReviews(match: BookMatch, limit: Int): BookInfoResult<List<BookReview>> {
-    return BookInfoResult.Success(emptyList())
+    val asin = (match as? BookMatch.Identifiers)?.asin.normalizedAsin()
+      ?: return BookInfoResult.NotFound
+
+    return when (val result = catalog.reviews(asin, limit)) {
+      is BookInfoResult.Success -> BookInfoResult.Success(
+        result.data.mapNotNull { review ->
+          // Bodies arrive entity-escaped; one decode pass yields the HTML the
+          // review cards already render (real <br/> tags and so on). Audible
+          // has no spoiler flag.
+          val text = review.body?.decodeHtmlEntities()?.takeUnless { it.isBlank() }
+            ?: return@mapNotNull null
+          BookReview(
+            author = review.authorName?.decodeHtmlEntities()?.takeUnless { it.isBlank() },
+            rating = review.ratings?.overallRating?.takeIf { it > 0.0 },
+            text = text,
+            hasSpoilers = false,
+            title = review.title?.decodeHtmlEntities()?.takeUnless { it.isBlank() },
+          )
+        },
+      )
+      is BookInfoResult.Failure -> result
+      else -> BookInfoResult.Success(emptyList())
+    }
   }
 }
 
 internal fun String?.normalizedAsin(): String? {
   return this?.filter { it.isLetterOrDigit() }?.uppercase()?.takeUnless { it.isEmpty() }
+}
+
+/**
+ * Undoes one level of HTML entity escaping. Audible delivers review text
+ * double-encoded: `&lt;br/&gt;` decodes to a real `<br/>` tag for the HTML
+ * renderer. `&amp;` is decoded last so it can't create new entities.
+ */
+internal fun String.decodeHtmlEntities(): String {
+  return replace("&lt;", "<")
+    .replace("&gt;", ">")
+    .replace("&quot;", "\"")
+    .replace("&apos;", "'")
+    .replace("&#39;", "'")
+    .replace(Regex("&#(\\d+);")) { match ->
+      match.groupValues[1].toIntOrNull()?.toChar()?.toString() ?: match.value
+    }
+    .replace(Regex("&#x([0-9a-fA-F]+);")) { match ->
+      match.groupValues[1].toIntOrNull(16)?.toChar()?.toString() ?: match.value
+    }
+    .replace("&amp;", "&")
 }
 
 internal fun audibleProductUrl(asin: String): String = "https://www.audible.com/pd/$asin"

--- a/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/AudibleBookInfoProvider.kt
+++ b/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/AudibleBookInfoProvider.kt
@@ -1,0 +1,104 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.audible
+
+import app.campfire.bookinfo.api.BookCommunityInfo
+import app.campfire.bookinfo.api.BookInfoProvider
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.ProviderCapabilities
+import app.campfire.bookinfo.api.ProviderId
+import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.audible.di.AudibleClient
+import app.campfire.core.di.SingleIn
+import app.campfire.core.di.UserScope
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Keyless audiobook-native source backed by Audible's public catalog API — the
+ * same anonymous endpoints the Audiobookshelf server's own Audible metadata
+ * provider uses. Keys on ASIN, the identifier audiobooks most reliably carry,
+ * and supplies the Audible aggregate rating with its full star distribution.
+ *
+ * Currently pinned to the US marketplace (api.audible.com); other marketplaces
+ * live on per-region hosts and can become a setting later.
+ */
+@SingleIn(UserScope::class)
+@ContributesMultibinding(UserScope::class, boundType = BookInfoProvider::class)
+@Inject
+class AudibleBookInfoProvider(
+  @AudibleClient private val client: HttpClient,
+) : BookInfoProvider {
+
+  private val catalog = AudibleCatalog(client)
+
+  override val id: ProviderId = ProviderId.Audible
+  override val displayName: String = "Audible"
+
+  override val capabilities: ProviderCapabilities = ProviderCapabilities(
+    hasAggregateRating = true,
+    hasSupplementalMetadata = true,
+  )
+
+  override fun observeLinkState(): Flow<ProviderLinkState> =
+    flowOf(ProviderLinkState.Linked(accountName = null))
+
+  override fun canServe(match: BookMatch): Boolean =
+    match is BookMatch.Identifiers && !match.asin.isNullOrBlank()
+
+  override suspend fun getBookInfo(match: BookMatch): BookInfoResult<BookCommunityInfo> {
+    val asin = (match as? BookMatch.Identifiers)?.asin.normalizedAsin()
+      ?: return BookInfoResult.NotFound
+
+    val product = when (val result = catalog.product(asin, AudibleCatalog.BOOK_RESPONSE_GROUPS)) {
+      is BookInfoResult.Success -> result.data
+      is BookInfoResult.Failure -> return result
+      else -> return BookInfoResult.NotFound
+    }
+
+    val overall = product.rating?.overallDistribution
+    val average = overall?.averageRating?.takeIf { it > 0.0 }
+      ?: return BookInfoResult.NotFound
+    if ((overall.numRatings ?: 0) <= 0) return BookInfoResult.NotFound
+
+    return BookInfoResult.Success(
+      BookCommunityInfo(
+        providerBookId = product.asin ?: asin,
+        providerUrl = audibleProductUrl(product.asin ?: asin),
+        rating = average,
+        ratingsCount = overall.numRatings,
+        ratingsDistribution = overall.toDistribution(),
+        reviewsCount = product.rating.numReviews,
+        releaseDate = product.releaseDate,
+        coverUrl = product.coverUrl(),
+      ),
+    )
+  }
+
+  override suspend fun getReviews(match: BookMatch, limit: Int): BookInfoResult<List<BookReview>> {
+    return BookInfoResult.Success(emptyList())
+  }
+}
+
+internal fun String?.normalizedAsin(): String? {
+  return this?.filter { it.isLetterOrDigit() }?.uppercase()?.takeUnless { it.isEmpty() }
+}
+
+internal fun audibleProductUrl(asin: String): String = "https://www.audible.com/pd/$asin"
+
+internal fun AudibleRatingDistribution.toDistribution(): Map<Int, Int>? {
+  val counts = mapOf(
+    1 to (numOneStarRatings ?: 0),
+    2 to (numTwoStarRatings ?: 0),
+    3 to (numThreeStarRatings ?: 0),
+    4 to (numFourStarRatings ?: 0),
+    5 to (numFiveStarRatings ?: 0),
+  )
+  return counts.takeIf { it.values.any { count -> count > 0 } }
+}

--- a/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/AudibleCatalog.kt
+++ b/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/AudibleCatalog.kt
@@ -58,6 +58,16 @@ internal class AudibleCatalog(
     return BookInfoResult.Success(all)
   }
 
+  suspend fun reviews(
+    asin: String,
+    limit: Int,
+  ): BookInfoResult<List<AudibleReview>> {
+    return fetch(
+      url = "$BASE_URL/catalog/products/$asin/reviews?num_results=$limit&sort_by=MostHelpful",
+      deserializer = AudibleReviewsEnvelope.serializer(),
+    ).mapNotNull { it.customerReviews }
+  }
+
   private suspend fun <T> fetch(
     url: String,
     deserializer: DeserializationStrategy<T>,
@@ -148,6 +158,24 @@ internal data class AudibleRatingDistribution(
   @SerialName("num_three_star_ratings") val numThreeStarRatings: Int? = null,
   @SerialName("num_four_star_ratings") val numFourStarRatings: Int? = null,
   @SerialName("num_five_star_ratings") val numFiveStarRatings: Int? = null,
+)
+
+@Serializable
+internal data class AudibleReviewsEnvelope(
+  @SerialName("customer_reviews") val customerReviews: List<AudibleReview> = emptyList(),
+)
+
+@Serializable
+internal data class AudibleReview(
+  val title: String? = null,
+  @SerialName("author_name") val authorName: String? = null,
+  val body: String? = null,
+  val ratings: AudibleReviewRatings? = null,
+)
+
+@Serializable
+internal data class AudibleReviewRatings(
+  @SerialName("overall_rating") val overallRating: Double? = null,
 )
 
 @Serializable

--- a/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/AudibleCatalog.kt
+++ b/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/AudibleCatalog.kt
@@ -1,0 +1,166 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.audible
+
+import app.campfire.bookinfo.api.BookInfoResult
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Thin wrapper over Audible's anonymous catalog endpoints. Single products come
+ * back as `{product: {...}}`, batch lookups as `{products: [...]}`.
+ */
+internal class AudibleCatalog(
+  private val client: HttpClient,
+) {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  suspend fun product(
+    asin: String,
+    responseGroups: String,
+  ): BookInfoResult<AudibleProduct> {
+    return fetch(
+      url = "$BASE_URL/catalog/products/$asin?response_groups=$responseGroups&image_sizes=$IMAGE_SIZE",
+      deserializer = AudibleProductEnvelope.serializer(),
+    ).mapNotNull { it.product }
+  }
+
+  suspend fun products(
+    asins: List<String>,
+    responseGroups: String,
+  ): BookInfoResult<List<AudibleProduct>> {
+    if (asins.isEmpty()) return BookInfoResult.Success(emptyList())
+    val all = mutableListOf<AudibleProduct>()
+    // The batch endpoint caps around 50 ASINs per request.
+    asins.chunked(BATCH_SIZE).forEach { chunk ->
+      val url = "$BASE_URL/catalog/products" +
+        "?asins=${chunk.joinToString(",")}" +
+        "&response_groups=$responseGroups&image_sizes=$IMAGE_SIZE"
+      when (val result = fetch(url, AudibleProductsEnvelope.serializer())) {
+        is BookInfoResult.Success -> all += result.data.products
+        is BookInfoResult.Failure -> return result
+        else -> Unit
+      }
+    }
+    return BookInfoResult.Success(all)
+  }
+
+  private suspend fun <T> fetch(
+    url: String,
+    deserializer: DeserializationStrategy<T>,
+  ): BookInfoResult<T> {
+    val response = try {
+      client.get(url)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      return BookInfoResult.Failure(e)
+    }
+
+    return when {
+      response.status == HttpStatusCode.NotFound -> BookInfoResult.NotFound
+      // Audible reports an unparseable/unknown ASIN as a 400.
+      response.status == HttpStatusCode.BadRequest -> BookInfoResult.NotFound
+      !response.status.isSuccess() ->
+        BookInfoResult.Failure(AudibleHttpException(response.status.value))
+      else -> try {
+        BookInfoResult.Success(json.decodeFromString(deserializer, response.bodyAsText()))
+      } catch (e: Exception) {
+        BookInfoResult.Failure(e)
+      }
+    }
+  }
+
+  companion object {
+    private const val BASE_URL = "https://api.audible.com/1.0"
+    private const val IMAGE_SIZE = 500
+    private const val BATCH_SIZE = 50
+
+    const val BOOK_RESPONSE_GROUPS = "product_attrs,rating,media"
+    const val SERIES_MEMBERSHIP_RESPONSE_GROUPS = "series"
+    const val SERIES_CHILDREN_RESPONSE_GROUPS = "relationships,product_attrs"
+  }
+}
+
+internal inline fun <T, R> BookInfoResult<T>.mapNotNull(
+  transform: (T) -> R?,
+): BookInfoResult<R> = when (this) {
+  is BookInfoResult.Success -> transform(data)?.let { BookInfoResult.Success(it) }
+    ?: BookInfoResult.NotFound
+  is BookInfoResult.NotFound -> this
+  is BookInfoResult.NotLinked -> this
+  is BookInfoResult.TokenInvalid -> this
+  is BookInfoResult.RateLimited -> this
+  is BookInfoResult.Failure -> this
+}
+
+class AudibleHttpException(val status: Int) : Exception("Audible HTTP $status")
+
+@Serializable
+internal data class AudibleProductEnvelope(
+  val product: AudibleProduct? = null,
+)
+
+@Serializable
+internal data class AudibleProductsEnvelope(
+  val products: List<AudibleProduct> = emptyList(),
+)
+
+@Serializable
+internal data class AudibleProduct(
+  val asin: String? = null,
+  val title: String? = null,
+  @SerialName("release_date") val releaseDate: String? = null,
+  @SerialName("content_delivery_type") val contentDeliveryType: String? = null,
+  val rating: AudibleRating? = null,
+  @SerialName("product_images") val productImages: Map<String, String> = emptyMap(),
+  val series: List<AudibleSeriesMembership> = emptyList(),
+  val relationships: List<AudibleRelationship> = emptyList(),
+) {
+  fun coverUrl(): String? = productImages.values.firstOrNull()
+}
+
+@Serializable
+internal data class AudibleRating(
+  @SerialName("num_reviews") val numReviews: Int? = null,
+  @SerialName("overall_distribution") val overallDistribution: AudibleRatingDistribution? = null,
+)
+
+@Serializable
+internal data class AudibleRatingDistribution(
+  @SerialName("average_rating") val averageRating: Double? = null,
+  @SerialName("num_ratings") val numRatings: Int? = null,
+  @SerialName("num_one_star_ratings") val numOneStarRatings: Int? = null,
+  @SerialName("num_two_star_ratings") val numTwoStarRatings: Int? = null,
+  @SerialName("num_three_star_ratings") val numThreeStarRatings: Int? = null,
+  @SerialName("num_four_star_ratings") val numFourStarRatings: Int? = null,
+  @SerialName("num_five_star_ratings") val numFiveStarRatings: Int? = null,
+)
+
+@Serializable
+internal data class AudibleSeriesMembership(
+  val asin: String? = null,
+  val title: String? = null,
+  val sequence: String? = null,
+)
+
+@Serializable
+internal data class AudibleRelationship(
+  val asin: String? = null,
+  @SerialName("relationship_type") val relationshipType: String? = null,
+  @SerialName("relationship_to_product") val relationshipToProduct: String? = null,
+  val sequence: String? = null,
+)

--- a/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/di/AudibleHttpClientModule.kt
+++ b/data/bookinfo/audible/src/commonMain/kotlin/app/campfire/bookinfo/audible/di/AudibleHttpClientModule.kt
@@ -1,0 +1,30 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.audible.di
+
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.SingleIn
+import app.campfire.network.di.BaseClient
+import com.r0adkll.kimchi.annotations.ContributesTo
+import io.ktor.client.HttpClient
+import me.tatarka.inject.annotations.Provides
+import me.tatarka.inject.annotations.Qualifier
+
+/** Qualifies the [HttpClient] configured for the Audible catalog API. */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AudibleClient
+
+@ContributesTo(AppScope::class)
+interface AudibleHttpClientModule {
+
+  @AudibleClient
+  @SingleIn(AppScope::class)
+  @Provides
+  fun provideAudibleHttpClient(
+    @BaseClient baseClient: HttpClient,
+  ): HttpClient = baseClient.config {
+    expectSuccess = false
+  }
+}

--- a/data/bookinfo/audible/src/commonTest/kotlin/app/campfire/bookinfo/audible/AudibleBookInfoProviderTest.kt
+++ b/data/bookinfo/audible/src/commonTest/kotlin/app/campfire/bookinfo/audible/AudibleBookInfoProviderTest.kt
@@ -103,6 +103,53 @@ class AudibleBookInfoProviderTest {
   }
 
   @Test
+  fun `reviews are decoded and mapped`() = runTest {
+    val reviewsResponse = """
+    {
+      "customer_reviews": [
+        {
+          "title": "This book is a blast",
+          "author_name": "Jim &quot;The Impatient&quot;",
+          "body": "Great listen.&lt;br/&gt;Loved Dick Hill &amp; the story.",
+          "ratings": {"overall_rating": 5, "performance_rating": 5, "story_rating": 4}
+        },
+        {"title": "Empty", "author_name": "Quiet", "body": "  ", "ratings": {"overall_rating": 3}}
+      ]
+    }
+    """
+    val client = HttpClient(
+      MockEngine { request ->
+        requests += request.url.toString()
+        respond(reviewsResponse)
+      },
+    )
+
+    val result = AudibleBookInfoProvider(client)
+      .getReviews(BookMatch.Identifiers(isbn = null, asin = "b002v0qk4c"), limit = 5)
+
+    val reviews = (result as BookInfoResult.Success).data
+    // The blank-bodied review is dropped.
+    assertThat(reviews.size).isEqualTo(1)
+    val review = reviews.single()
+    assertThat(review.title).isEqualTo("This book is a blast")
+    assertThat(review.author).isEqualTo("Jim \"The Impatient\"")
+    assertThat(review.text).isEqualTo("Great listen.<br/>Loved Dick Hill & the story.")
+    assertThat(review.rating).isEqualTo(5.0)
+    assertThat(review.hasSpoilers).isFalse()
+    assertThat(
+      requests.single().endsWith("/reviews?num_results=5&sort_by=MostHelpful"),
+    ).isTrue()
+  }
+
+  @Test
+  fun `entity decoding is single pass`() {
+    // Double-escaped input decodes one level only: &amp;lt; becomes the
+    // literal text "&lt;", never a tag.
+    assertThat("5 &amp;lt; 10 &#8212; &#x27;quoted&#x27;".decodeHtmlEntities())
+      .isEqualTo("5 &lt; 10 — 'quoted'")
+  }
+
+  @Test
   fun `an unrated book is a miss`() = runTest {
     val result = provider(response = UNRATED_RESPONSE)
       .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B002V0QK4C"))

--- a/data/bookinfo/audible/src/commonTest/kotlin/app/campfire/bookinfo/audible/AudibleBookInfoProviderTest.kt
+++ b/data/bookinfo/audible/src/commonTest/kotlin/app/campfire/bookinfo/audible/AudibleBookInfoProviderTest.kt
@@ -1,0 +1,141 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.bookinfo.audible
+
+import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.BookMatch
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isTrue
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+// Mirrors the live shape of api.audible.com/1.0/catalog/products/{asin},
+// verified 2026-08-31.
+private const val PRODUCT_RESPONSE = """
+{
+  "product": {
+    "asin": "B002V0QK4C",
+    "title": "Wizard's First Rule",
+    "release_date": "2008-10-15",
+    "content_delivery_type": "SinglePartBook",
+    "rating": {
+      "num_reviews": 1762,
+      "overall_distribution": {
+        "average_rating": 4.510169568993098,
+        "display_average_rating": "4.5",
+        "num_ratings": 21879,
+        "num_one_star_ratings": 564,
+        "num_two_star_ratings": 605,
+        "num_three_star_ratings": 1373,
+        "num_four_star_ratings": 3900,
+        "num_five_star_ratings": 15437
+      }
+    },
+    "product_images": {"500": "https://m.media-amazon.com/images/I/519zdwHG3GL._SL500_.jpg"}
+  }
+}
+"""
+
+private const val UNRATED_RESPONSE = """
+{
+  "product": {
+    "asin": "B002V0QK4C",
+    "title": "Obscure Book",
+    "rating": {
+      "num_reviews": 0,
+      "overall_distribution": {"average_rating": 0.0, "num_ratings": 0}
+    }
+  }
+}
+"""
+
+class AudibleBookInfoProviderTest {
+
+  private val requests = mutableListOf<String>()
+
+  private fun provider(
+    response: String = PRODUCT_RESPONSE,
+    status: HttpStatusCode = HttpStatusCode.OK,
+  ): AudibleBookInfoProvider {
+    val client = HttpClient(
+      MockEngine { request ->
+        requests += request.url.toString()
+        respond(response, status)
+      },
+    )
+    return AudibleBookInfoProvider(client)
+  }
+
+  @Test
+  fun `only asin bearing matches are servable`() {
+    val provider = provider()
+
+    assertThat(provider.canServe(BookMatch.Identifiers(isbn = null, asin = "B002V0QK4C"))).isTrue()
+    assertThat(provider.canServe(BookMatch.Identifiers(isbn = "9780765393043", asin = null))).isFalse()
+    assertThat(provider.canServe(BookMatch.TitleAuthor("Title", "Author"))).isFalse()
+  }
+
+  @Test
+  fun `the rating distribution and metadata are mapped`() = runTest {
+    val result = provider().getBookInfo(BookMatch.Identifiers(isbn = null, asin = " b002v0qk4c "))
+
+    val info = (result as BookInfoResult.Success).data
+    assertThat(info.providerBookId).isEqualTo("B002V0QK4C")
+    assertThat(info.providerUrl).isEqualTo("https://www.audible.com/pd/B002V0QK4C")
+    assertThat(info.rating).isEqualTo(4.510169568993098)
+    assertThat(info.ratingsCount).isEqualTo(21879)
+    assertThat(info.ratingsDistribution).isEqualTo(
+      mapOf(1 to 564, 2 to 605, 3 to 1373, 4 to 3900, 5 to 15437),
+    )
+    assertThat(info.reviewsCount).isEqualTo(1762)
+    assertThat(info.coverUrl)
+      .isEqualTo("https://m.media-amazon.com/images/I/519zdwHG3GL._SL500_.jpg")
+    // The ASIN is normalized (trimmed, uppercased) into the request path.
+    assertThat(requests.single().contains("/catalog/products/B002V0QK4C?")).isTrue()
+  }
+
+  @Test
+  fun `an unrated book is a miss`() = runTest {
+    val result = provider(response = UNRATED_RESPONSE)
+      .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B002V0QK4C"))
+
+    assertThat(result).isEqualTo(BookInfoResult.NotFound)
+  }
+
+  @Test
+  fun `unknown asins are a miss for 404 and 400`() = runTest {
+    assertThat(
+      provider(response = "", status = HttpStatusCode.NotFound)
+        .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B000000000")),
+    ).isEqualTo(BookInfoResult.NotFound)
+
+    assertThat(
+      provider(response = "", status = HttpStatusCode.BadRequest)
+        .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "NOTANASIN1")),
+    ).isEqualTo(BookInfoResult.NotFound)
+  }
+
+  @Test
+  fun `server errors surface as failures`() = runTest {
+    val result = provider(response = "", status = HttpStatusCode.InternalServerError)
+      .getBookInfo(BookMatch.Identifiers(isbn = null, asin = "B002V0QK4C"))
+
+    assertThat(result).isInstanceOf(BookInfoResult.Failure::class)
+  }
+
+  @Test
+  fun `an isbn only match short circuits without a request`() = runTest {
+    val result = provider().getBookInfo(BookMatch.Identifiers(isbn = "9780765393043", asin = null))
+
+    assertThat(result).isEqualTo(BookInfoResult.NotFound)
+    assertThat(requests.size).isEqualTo(0)
+  }
+}

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -65,11 +65,23 @@ class DefaultBookInfoRegistry(
     val match = item.bestMatch() ?: return flowOf(LoadState.Loaded(null))
 
     return observeProviders()
-      .map { statuses -> statuses.filter { it.canServeBookInfo && it.provider.canServe(match) } }
-      .distinctUntilChanged { old, new ->
-        old.map { it.provider.id to it.linkState } == new.map { it.provider.id to it.linkState }
+      .map { statuses ->
+        val usable = statuses.filter { it.canServeBookInfo && it.provider.canServe(match) }
+        // An enabled-but-unlinked review-capable provider is worth advertising
+        // when whoever ends up serving has no review text of its own.
+        val reviewsVia = statuses.firstOrNull {
+          it.enabled &&
+            it.provider.capabilities.hasReviewText &&
+            it.linkState is ProviderLinkState.NotLinked
+        }?.provider?.displayName
+        usable to reviewsVia
       }
-      .flatMapLatest { usable ->
+      .distinctUntilChanged { (oldUsable, oldVia), (newUsable, newVia) ->
+        oldUsable.map { it.provider.id to it.linkState } ==
+          newUsable.map { it.provider.id to it.linkState } &&
+          oldVia == newVia
+      }
+      .flatMapLatest { (usable, reviewsVia) ->
         val status = usable.firstOrNull { it.provider.id == preferredProvider }
           ?: usable.firstOrNull()
         if (status == null) {
@@ -79,6 +91,8 @@ class DefaultBookInfoRegistry(
             status = status,
             key = BookInfoStore.Key(userId, status.provider.id, item.id, match),
             sources = usable.map { CommunitySource(it.provider.id, it.provider.displayName) },
+            reviewsLinkProviderName = reviewsVia
+              .takeUnless { status.provider.capabilities.hasReviewText },
           )
         }
       }
@@ -92,6 +106,7 @@ class DefaultBookInfoRegistry(
     status: ProviderStatus,
     key: BookInfoStore.Key,
     sources: List<CommunitySource>,
+    reviewsLinkProviderName: String?,
   ): Flow<LoadState<out CommunityInfoState?>> = flow {
     val cached = store.cached(key)
     val invalidLink = status.linkState is ProviderLinkState.Invalid
@@ -117,7 +132,7 @@ class DefaultBookInfoRegistry(
         is StoreReadResponse.Loading -> if (!emittedData) emit(LoadState.Loading)
         is StoreReadResponse.Data -> {
           emittedData = true
-          emit(LoadState.Loaded(response.value.toState(status, sources)))
+          emit(LoadState.Loaded(response.value.toState(status, sources, reviewsLinkProviderName)))
         }
         is StoreReadResponse.Error -> if (!emittedData) emit(LoadState.Loaded(null))
         else -> Unit
@@ -128,6 +143,7 @@ class DefaultBookInfoRegistry(
   private fun CachedBookInfo.toState(
     status: ProviderStatus,
     sources: List<CommunitySource>,
+    reviewsLinkProviderName: String?,
   ): CommunityInfoState? {
     val info = info ?: return null
     return CommunityInfoState(
@@ -138,6 +154,7 @@ class DefaultBookInfoRegistry(
       reviews = reviews,
       needsRelink = status.linkState is ProviderLinkState.Invalid,
       availableSources = sources,
+      reviewsLinkProviderName = reviewsLinkProviderName,
     )
   }
 

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -6,6 +6,7 @@ package app.campfire.bookinfo
 import app.campfire.bookinfo.api.BookInfoProvider
 import app.campfire.bookinfo.api.BookInfoProviderSettings
 import app.campfire.bookinfo.api.BookInfoRegistry
+import app.campfire.bookinfo.api.CommunityContent
 import app.campfire.bookinfo.api.CommunityInfoState
 import app.campfire.bookinfo.api.CommunitySource
 import app.campfire.bookinfo.api.ProviderId
@@ -15,7 +16,6 @@ import app.campfire.bookinfo.api.bestMatch
 import app.campfire.bookinfo.store.BookInfoStore
 import app.campfire.bookinfo.store.CachedBookInfo
 import app.campfire.bookinfo.store.isStale
-import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryItem
@@ -60,9 +60,9 @@ class DefaultBookInfoRegistry(
   override fun observeCommunityInfo(
     item: LibraryItem,
     preferredProvider: ProviderId?,
-  ): Flow<LoadState<out CommunityInfoState?>> {
-    val userId = userSession.userId ?: return flowOf(LoadState.Loaded(null))
-    val match = item.bestMatch() ?: return flowOf(LoadState.Loaded(null))
+  ): Flow<CommunityInfoState?> {
+    val userId = userSession.userId ?: return flowOf(null)
+    val match = item.bestMatch() ?: return flowOf(null)
 
     return observeProviders()
       .map { statuses ->
@@ -85,7 +85,7 @@ class DefaultBookInfoRegistry(
         val status = usable.firstOrNull { it.provider.id == preferredProvider }
           ?: usable.firstOrNull()
         if (status == null) {
-          flowOf(LoadState.Loaded(null))
+          flowOf(null)
         } else {
           streamFromStore(
             status = status,
@@ -107,13 +107,20 @@ class DefaultBookInfoRegistry(
     key: BookInfoStore.Key,
     sources: List<CommunitySource>,
     reviewsLinkProviderName: String?,
-  ): Flow<LoadState<out CommunityInfoState?>> = flow {
+  ): Flow<CommunityInfoState?> = flow {
+    val base = CommunityInfoState(
+      providerId = status.provider.id,
+      providerName = status.provider.displayName,
+      availableSources = sources,
+      needsRelink = status.linkState is ProviderLinkState.Invalid,
+      reviewsLinkProviderName = reviewsLinkProviderName,
+    )
     val cached = store.cached(key)
     val invalidLink = status.linkState is ProviderLinkState.Invalid
 
     // A rejected token means fetches would just 401; serve whatever is cached.
     if (invalidLink && cached == null) {
-      emit(LoadState.Loaded(null))
+      emit(base.copy(content = CommunityContent.Unavailable))
       return@flow
     }
 
@@ -129,33 +136,24 @@ class DefaultBookInfoRegistry(
     var emittedData = false
     store.stream(key, refresh = refresh).collect { response ->
       when (response) {
-        is StoreReadResponse.Loading -> if (!emittedData) emit(LoadState.Loading)
+        is StoreReadResponse.Loading -> if (!emittedData) emit(base)
         is StoreReadResponse.Data -> {
           emittedData = true
-          emit(LoadState.Loaded(response.value.toState(status, sources, reviewsLinkProviderName)))
+          emit(base.copy(content = response.value.toContent()))
         }
-        is StoreReadResponse.Error -> if (!emittedData) emit(LoadState.Loaded(null))
+        is StoreReadResponse.Error -> if (!emittedData) {
+          emit(base.copy(content = CommunityContent.Unavailable))
+        }
         else -> Unit
       }
     }
   }
 
-  private fun CachedBookInfo.toState(
-    status: ProviderStatus,
-    sources: List<CommunitySource>,
-    reviewsLinkProviderName: String?,
-  ): CommunityInfoState? {
-    val info = info ?: return null
-    return CommunityInfoState(
-      providerId = status.provider.id,
-      providerName = status.provider.displayName,
-      providerUrl = info.providerUrl,
-      info = info,
-      reviews = reviews,
-      needsRelink = status.linkState is ProviderLinkState.Invalid,
-      availableSources = sources,
-      reviewsLinkProviderName = reviewsLinkProviderName,
-    )
+  private fun CachedBookInfo.toContent(): CommunityContent {
+    return info
+      ?.takeIf { it.rating != null }
+      ?.let { CommunityContent.Available(it, reviews) }
+      ?: CommunityContent.Unavailable
   }
 
   private val ProviderStatus.canServeBookInfo: Boolean

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -6,6 +6,7 @@ package app.campfire.bookinfo
 import app.campfire.bookinfo.api.BookCommunityInfo
 import app.campfire.bookinfo.api.BookInfoResult
 import app.campfire.bookinfo.api.CommunitySource
+import app.campfire.bookinfo.api.ProviderCapabilities
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
 import app.campfire.bookinfo.db.BookInfoDatabase
@@ -218,7 +219,7 @@ class DefaultBookInfoRegistryTest {
     // and declares itself unservable, so the lower-priority one serves.
     val isbnOnly = FakeBookInfoProvider(id = ProviderId.OpenLibrary, displayName = "ISBN Only")
     isbnOnly.canServeResult = false
-    val asinCapable = FakeBookInfoProvider(id = ProviderId.Audnexus, displayName = "ASIN Capable")
+    val asinCapable = FakeBookInfoProvider(id = ProviderId.Audible, displayName = "ASIN Capable")
     asinCapable.bookInfoResult = BookInfoResult.Success(communityInfo)
 
     val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
@@ -236,9 +237,51 @@ class DefaultBookInfoRegistryTest {
     val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
 
     val loaded = (state as LoadState.Loaded).data
-    assertThat(loaded!!.providerId).isEqualTo(ProviderId.Audnexus)
-    assertThat(loaded.availableSources.map { it.id }).isEqualTo(listOf(ProviderId.Audnexus))
+    assertThat(loaded!!.providerId).isEqualTo(ProviderId.Audible)
+    assertThat(loaded.availableSources.map { it.id }).isEqualTo(listOf(ProviderId.Audible))
     assertThat(isbnOnly.bookInfoRequests.size).isEqualTo(0)
+  }
+
+  @Test
+  fun `a linkable review source is advertised when the serving provider lacks reviews`() = runTest {
+    val keyless = FakeBookInfoProvider(
+      id = ProviderId.OpenLibrary,
+      displayName = "Open Library",
+      capabilities = ProviderCapabilities(hasAggregateRating = true),
+    )
+    keyless.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val hardcover = FakeBookInfoProvider(id = ProviderId.Hardcover, displayName = "Hardcover")
+    hardcover.linkState.value = ProviderLinkState.NotLinked
+
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    BookInfoDatabase.Schema.synchronous().create(driver)
+    val db = BookInfoDatabase(driver)
+    val dispatchers = TestDispatcherProvider(StandardTestDispatcher(testScheduler))
+    val providers = setOf(hardcover, keyless)
+    val registry = DefaultBookInfoRegistry(
+      providers = providers,
+      settings = DefaultBookInfoProviderSettings(MapSettings(), session),
+      store = BookInfoStore(providers, db, dispatchers),
+      userSession = session,
+    )
+
+    val state = registry.observeCommunityInfo(item)
+      .first { it is LoadState.Loaded<*> && (it as LoadState.Loaded).data != null }
+
+    val loaded = (state as LoadState.Loaded).data!!
+    assertThat(loaded.providerId).isEqualTo(ProviderId.OpenLibrary)
+    assertThat(loaded.reviewsLinkProviderName).isEqualTo("Hardcover")
+  }
+
+  @Test
+  fun `no review link is advertised when the serving provider has review text`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+
+    assertThat((state as LoadState.Loaded).data!!.reviewsLinkProviderName).isNull()
   }
 
   @Test

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -5,6 +5,8 @@ package app.campfire.bookinfo
 
 import app.campfire.bookinfo.api.BookCommunityInfo
 import app.campfire.bookinfo.api.BookInfoResult
+import app.campfire.bookinfo.api.CommunityContent
+import app.campfire.bookinfo.api.CommunityInfoState
 import app.campfire.bookinfo.api.CommunitySource
 import app.campfire.bookinfo.api.ProviderCapabilities
 import app.campfire.bookinfo.api.ProviderId
@@ -14,7 +16,6 @@ import app.campfire.bookinfo.store.BookInfoStore
 import app.campfire.bookinfo.test.FakeBookInfoProvider
 import app.campfire.common.test.coroutines.TestDispatcherProvider
 import app.campfire.common.test.user
-import app.campfire.core.coroutines.LoadState
 import app.campfire.core.session.UserSession
 import app.campfire.home.ui.libraryItem
 import app.campfire.home.ui.media
@@ -23,11 +24,12 @@ import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNotNull
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import com.russhwolf.settings.MapSettings
 import kotlin.test.Test
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -50,28 +52,29 @@ class DefaultBookInfoRegistryTest {
   )
 
   private fun TestScope.registry(
-    provider: FakeBookInfoProvider,
+    vararg providers: FakeBookInfoProvider,
     settings: DefaultBookInfoProviderSettings = DefaultBookInfoProviderSettings(MapSettings(), session),
   ): DefaultBookInfoRegistry {
     val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     BookInfoDatabase.Schema.synchronous().create(driver)
-    val store = BookInfoStore(
-      providers = setOf(provider),
-      db = BookInfoDatabase(driver),
-      dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
-    )
+    val db = BookInfoDatabase(driver)
+    val dispatchers = TestDispatcherProvider(StandardTestDispatcher(testScheduler))
+    val providerSet = providers.toSet<app.campfire.bookinfo.api.BookInfoProvider>()
     return DefaultBookInfoRegistry(
-      providers = setOf(provider),
+      providers = providerSet,
       settings = settings,
-      store = store,
+      store = BookInfoStore(providerSet, db, dispatchers),
       userSession = session,
     )
   }
 
+  private suspend fun Flow<CommunityInfoState?>.awaitAvailable(): CommunityInfoState {
+    return first { it?.content is CommunityContent.Available }!!
+  }
+
   @Test
   fun `providers are reported with enablement and link state`() = runTest {
-    val provider = FakeBookInfoProvider()
-    val registry = registry(provider)
+    val registry = registry(FakeBookInfoProvider())
 
     val statuses = registry.observeProviders().first()
 
@@ -86,14 +89,27 @@ class DefaultBookInfoRegistryTest {
     provider.bookInfoResult = BookInfoResult.Success(communityInfo)
     val registry = registry(provider)
 
-    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    val state = registry.observeCommunityInfo(item).awaitAvailable()
 
-    val loaded = (state as LoadState.Loaded).data
-    assertThat(loaded).isNotNull()
-    assertThat(loaded!!.providerId).isEqualTo(ProviderId.Hardcover)
-    assertThat(loaded.providerName).isEqualTo("Fake Provider")
-    assertThat(loaded.info.rating).isEqualTo(4.63)
+    assertThat(state.providerId).isEqualTo(ProviderId.Hardcover)
+    assertThat(state.providerName).isEqualTo("Fake Provider")
+    assertThat((state.content as CommunityContent.Available).info.rating).isEqualTo(4.63)
     assertThat(provider.bookInfoRequests.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `an uncached fetch reports its loading phase with provider context`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(provider)
+
+    // The first emission already names the serving provider and sources, so a
+    // section rendered from it never disappears while the fetch runs.
+    val first = registry.observeCommunityInfo(item).first()!!
+
+    assertThat(first.content).isInstanceOf(CommunityContent.Loading::class)
+    assertThat(first.providerName).isEqualTo("Fake Provider")
+    assertThat(first.availableSources.map { it.id }).isEqualTo(listOf(ProviderId.Hardcover))
   }
 
   @Test
@@ -102,8 +118,8 @@ class DefaultBookInfoRegistryTest {
     provider.bookInfoResult = BookInfoResult.Success(communityInfo)
     val registry = registry(provider)
 
-    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
-    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    registry.observeCommunityInfo(item).awaitAvailable()
+    registry.observeCommunityInfo(item).awaitAvailable()
 
     assertThat(provider.bookInfoRequests.size).isEqualTo(1)
   }
@@ -114,9 +130,7 @@ class DefaultBookInfoRegistryTest {
     provider.linkState.value = ProviderLinkState.NotLinked
     val registry = registry(provider)
 
-    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
-
-    assertThat((state as LoadState.Loaded).data).isNull()
+    assertThat(registry.observeCommunityInfo(item).first()).isNull()
   }
 
   @Test
@@ -125,11 +139,9 @@ class DefaultBookInfoRegistryTest {
     provider.bookInfoResult = BookInfoResult.Success(communityInfo)
     val settings = DefaultBookInfoProviderSettings(MapSettings(), session)
     settings.setEnabled(ProviderId.Hardcover, false)
-    val registry = registry(provider, settings)
+    val registry = registry(provider, settings = settings)
 
-    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
-
-    assertThat((state as LoadState.Loaded).data).isNull()
+    assertThat(registry.observeCommunityInfo(item).first()).isNull()
     assertThat(provider.bookInfoRequests.size).isEqualTo(0)
   }
 
@@ -139,14 +151,12 @@ class DefaultBookInfoRegistryTest {
     provider.bookInfoResult = BookInfoResult.Success(communityInfo)
     val registry = registry(provider)
 
-    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    registry.observeCommunityInfo(item).awaitAvailable()
     provider.linkState.value = ProviderLinkState.Invalid
 
-    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    val state = registry.observeCommunityInfo(item).awaitAvailable()
 
-    val loaded = (state as LoadState.Loaded).data
-    assertThat(loaded).isNotNull()
-    assertThat(loaded!!.needsRelink).isTrue()
+    assertThat(state.needsRelink).isTrue()
     assertThat(provider.bookInfoRequests.size).isEqualTo(1)
   }
 
@@ -156,10 +166,9 @@ class DefaultBookInfoRegistryTest {
     provider.bookInfoResult = BookInfoResult.Success(communityInfo)
     val registry = registry(provider)
 
-    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    val state = registry.observeCommunityInfo(item).awaitAvailable()
 
-    val loaded = (state as LoadState.Loaded).data
-    assertThat(loaded!!.availableSources)
+    assertThat(state.availableSources)
       .isEqualTo(listOf(CommunitySource(ProviderId.Hardcover, "Fake Provider")))
   }
 
@@ -171,9 +180,9 @@ class DefaultBookInfoRegistryTest {
 
     val state = registry
       .observeCommunityInfo(item, preferredProvider = ProviderId.Hardcover)
-      .first { it is LoadState.Loaded<*> }
+      .awaitAvailable()
 
-    assertThat((state as LoadState.Loaded).data!!.providerId).isEqualTo(ProviderId.Hardcover)
+    assertThat(state.providerId).isEqualTo(ProviderId.Hardcover)
   }
 
   @Test
@@ -184,9 +193,9 @@ class DefaultBookInfoRegistryTest {
 
     val state = registry
       .observeCommunityInfo(item, preferredProvider = ProviderId.OpenLibrary)
-      .first { it is LoadState.Loaded<*> }
+      .awaitAvailable()
 
-    assertThat((state as LoadState.Loaded).data!!.providerId).isEqualTo(ProviderId.Hardcover)
+    assertThat(state.providerId).isEqualTo(ProviderId.Hardcover)
   }
 
   @Test
@@ -203,11 +212,11 @@ class DefaultBookInfoRegistryTest {
       media = media(metadata = mediaMetadata(ISBN = "9780765393043", ASIN = "B002RI9Z9E")),
     )
 
-    registry.observeCommunityInfo(asinOnly).first { it is LoadState.Loaded<*> }
+    registry.observeCommunityInfo(asinOnly).awaitAvailable()
     // The store serves the stale row first, then refetches with the new
     // identifiers — wait for the refetch to land.
     registry.observeCommunityInfo(withIsbn).first {
-      it is LoadState.Loaded<*> && provider.bookInfoRequests.size == 2
+      it?.content is CommunityContent.Available && provider.bookInfoRequests.size == 2
     }
 
     assertThat(provider.bookInfoRequests.size).isEqualTo(2)
@@ -221,24 +230,12 @@ class DefaultBookInfoRegistryTest {
     isbnOnly.canServeResult = false
     val asinCapable = FakeBookInfoProvider(id = ProviderId.Audible, displayName = "ASIN Capable")
     asinCapable.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val registry = registry(isbnOnly, asinCapable)
 
-    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-    BookInfoDatabase.Schema.synchronous().create(driver)
-    val db = BookInfoDatabase(driver)
-    val dispatchers = TestDispatcherProvider(StandardTestDispatcher(testScheduler))
-    val providers = setOf(isbnOnly, asinCapable)
-    val registry = DefaultBookInfoRegistry(
-      providers = providers,
-      settings = DefaultBookInfoProviderSettings(MapSettings(), session),
-      store = BookInfoStore(providers, db, dispatchers),
-      userSession = session,
-    )
+    val state = registry.observeCommunityInfo(item).awaitAvailable()
 
-    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
-
-    val loaded = (state as LoadState.Loaded).data
-    assertThat(loaded!!.providerId).isEqualTo(ProviderId.Audible)
-    assertThat(loaded.availableSources.map { it.id }).isEqualTo(listOf(ProviderId.Audible))
+    assertThat(state.providerId).isEqualTo(ProviderId.Audible)
+    assertThat(state.availableSources.map { it.id }).isEqualTo(listOf(ProviderId.Audible))
     assertThat(isbnOnly.bookInfoRequests.size).isEqualTo(0)
   }
 
@@ -252,25 +249,12 @@ class DefaultBookInfoRegistryTest {
     keyless.bookInfoResult = BookInfoResult.Success(communityInfo)
     val hardcover = FakeBookInfoProvider(id = ProviderId.Hardcover, displayName = "Hardcover")
     hardcover.linkState.value = ProviderLinkState.NotLinked
+    val registry = registry(hardcover, keyless)
 
-    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-    BookInfoDatabase.Schema.synchronous().create(driver)
-    val db = BookInfoDatabase(driver)
-    val dispatchers = TestDispatcherProvider(StandardTestDispatcher(testScheduler))
-    val providers = setOf(hardcover, keyless)
-    val registry = DefaultBookInfoRegistry(
-      providers = providers,
-      settings = DefaultBookInfoProviderSettings(MapSettings(), session),
-      store = BookInfoStore(providers, db, dispatchers),
-      userSession = session,
-    )
+    val state = registry.observeCommunityInfo(item).awaitAvailable()
 
-    val state = registry.observeCommunityInfo(item)
-      .first { it is LoadState.Loaded<*> && (it as LoadState.Loaded).data != null }
-
-    val loaded = (state as LoadState.Loaded).data!!
-    assertThat(loaded.providerId).isEqualTo(ProviderId.OpenLibrary)
-    assertThat(loaded.reviewsLinkProviderName).isEqualTo("Hardcover")
+    assertThat(state.providerId).isEqualTo(ProviderId.OpenLibrary)
+    assertThat(state.reviewsLinkProviderName).isEqualTo("Hardcover")
   }
 
   @Test
@@ -279,9 +263,9 @@ class DefaultBookInfoRegistryTest {
     provider.bookInfoResult = BookInfoResult.Success(communityInfo)
     val registry = registry(provider)
 
-    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    val state = registry.observeCommunityInfo(item).awaitAvailable()
 
-    assertThat((state as LoadState.Loaded).data!!.reviewsLinkProviderName).isNull()
+    assertThat(state.reviewsLinkProviderName).isNull()
   }
 
   @Test
@@ -290,23 +274,25 @@ class DefaultBookInfoRegistryTest {
     provider.bookInfoResult = BookInfoResult.Success(communityInfo)
     val registry = registry(provider)
 
-    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    registry.observeCommunityInfo(item).awaitAvailable()
     registry.clearCache()
-    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    registry.observeCommunityInfo(item).awaitAvailable()
 
     assertThat(provider.bookInfoRequests.size).isEqualTo(2)
   }
 
   @Test
-  fun `a provider miss is cached as no info`() = runTest {
+  fun `a provider miss keeps the section with empty content`() = runTest {
     val provider = FakeBookInfoProvider()
     provider.bookInfoResult = BookInfoResult.NotFound
     val registry = registry(provider)
 
-    val state = registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
-    registry.observeCommunityInfo(item).first { it is LoadState.Loaded<*> }
+    val state = registry.observeCommunityInfo(item)
+      .first { it?.content is CommunityContent.Unavailable }!!
+    registry.observeCommunityInfo(item).first { it?.content is CommunityContent.Unavailable }
 
-    assertThat((state as LoadState.Loaded).data).isNull()
+    // The miss keeps the provider context (pill, sources) and is cached.
+    assertThat(state.providerName).isEqualTo("Fake Provider")
     assertThat(provider.bookInfoRequests.size).isEqualTo(1)
   }
 }

--- a/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoRegistry.kt
+++ b/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoRegistry.kt
@@ -7,7 +7,6 @@ import app.campfire.bookinfo.api.BookInfoRegistry
 import app.campfire.bookinfo.api.CommunityInfoState
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderStatus
-import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.LibraryItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -17,12 +16,12 @@ class FakeBookInfoRegistry : BookInfoRegistry {
   val providersFlow = MutableSharedFlow<List<ProviderStatus>>(replay = 1)
   override fun observeProviders(): Flow<List<ProviderStatus>> = providersFlow
 
-  val communityInfoFlow = MutableSharedFlow<LoadState<out CommunityInfoState?>>(replay = 1)
+  val communityInfoFlow = MutableSharedFlow<CommunityInfoState?>(replay = 1)
   val communityInfoRequests = mutableListOf<Pair<LibraryItem, ProviderId?>>()
   override fun observeCommunityInfo(
     item: LibraryItem,
     preferredProvider: ProviderId?,
-  ): Flow<LoadState<out CommunityInfoState?>> {
+  ): Flow<CommunityInfoState?> {
     communityInfoRequests += item to preferredProvider
     return communityInfoFlow
   }

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -146,5 +146,6 @@
   <string name="community_review_spoiler_warning">Contains spoilers</string>
   <string name="community_review_show_spoiler">Show review</string>
   <string name="community_relink_provider">Reconnect %1$s to refresh</string>
+  <string name="community_connect_for_reviews">Connect %1$s to see reviews</string>
   <string name="community_open_on_provider">Open on %1$s</string>
 </resources>

--- a/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
+++ b/features/libraries/ui/src/commonMain/composeResources/values/libraries_ui_strings.xml
@@ -135,17 +135,17 @@
   <string name="podcast_downloads_banner_one">%1$d episode downloading on server</string>
   <string name="podcast_downloads_banner_other">%1$d episodes downloading on server</string>
 
-  <string name="community_title">Community</string>
+  <string name="community_title">Ratings &amp; Reviews</string>
   <string name="community_rating_title">Community rating</string>
   <string name="community_rating_attribution">%1$s rating</string>
   <string name="community_rating_count">%1$s ratings</string>
-  <string name="community_reviews_title">Reviews</string>
   <string name="community_reviews_from">From %1$s members</string>
   <string name="community_review_sheet_title">Review</string>
   <string name="community_review_by_author">by %1$s</string>
   <string name="community_review_spoiler_warning">Contains spoilers</string>
   <string name="community_review_show_spoiler">Show review</string>
   <string name="community_relink_provider">Reconnect %1$s to refresh</string>
+  <string name="community_empty_source">%1$s doesn't have anything for this book yet</string>
   <string name="community_connect_for_reviews">Connect %1$s to see reviews</string>
   <string name="community_open_on_provider">Open on %1$s</string>
 </resources>

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/book/BookPresenter.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/book/BookPresenter.kt
@@ -4,6 +4,7 @@
 package app.campfire.libraries.ui.detail.book
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -163,13 +164,18 @@ class BookPresenter(
     // Session-local community source override; null lets the registry pick.
     var communitySource by remember { mutableStateOf<ProviderId?>(null) }
 
-    // Keyed on the match identifiers so the flow rebuilds when the expanded
-    // metadata (carrying ISBN/ASIN) loads in after the initial minified item.
+    // Held in plain state (not re-collected from an initial value) so the
+    // section keeps its last content while a source switch or expanded-metadata
+    // reload re-subscribes — the state carries its own loading phase. Keyed on
+    // the match identifiers so the flow rebuilds when the expanded metadata
+    // (carrying ISBN/ASIN) loads in after the initial minified item.
     val bookMatch = libraryItem.bestMatch()
-    val communityInfoState by remember(bookMatch, communitySource) {
+    var communityInfoState by remember { mutableStateOf<CommunityInfoState?>(null) }
+    LaunchedEffect(bookMatch, communitySource) {
       bookInfoRegistry.observeCommunityInfo(libraryItem, communitySource)
-        .catch { emit(LoadState.Loaded(null)) }
-    }.collectAsState(LoadState.Loading)
+        .catch { emit(null) }
+        .collect { communityInfoState = it }
+    }
 
     val itemValidation by remember {
       flow { emit(validator.validate(libraryItem)) }
@@ -414,7 +420,7 @@ private fun buildSlots(
   mediaProgressState: LoadState<out MediaProgress?>,
   offlineDownloadState: OfflineDownload?,
   seriesContentState: LoadState<out List<SeriesWithBooks>>,
-  communityInfoState: LoadState<out CommunityInfoState?>,
+  communityInfoState: CommunityInfoState?,
   showTimeInBook: Boolean,
   showConfirmDownloadDialog: Boolean,
   hasSession: Boolean,
@@ -505,11 +511,11 @@ private fun buildSlots(
       )
     }
 
-    communityInfoState.onLoaded { communityInfo ->
-      if (communityInfo != null && communityInfo.info.rating != null) {
-        this += SpacerSlot.medium("community_spacer")
-        this += CommunitySlot(communityInfo)
-      }
+    // Present whenever any provider can serve — the slot renders its own
+    // loading and empty phases so the section never blinks between them.
+    communityInfoState?.let { communityInfo ->
+      this += SpacerSlot.medium("community_spacer")
+      this += CommunitySlot(communityInfo)
     }
 
     seriesContentState.onLoaded { seriesWithBooks ->

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ReviewBottomSheet.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/ReviewBottomSheet.kt
@@ -134,6 +134,16 @@ internal fun ReviewBottomSheet(
 
       Spacer(Modifier.height(16.dp))
 
+      review.title?.let { title ->
+        Text(
+          text = title,
+          style = MaterialTheme.typography.titleMedium,
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(Modifier.height(8.dp))
+      }
+
       Box(
         modifier = Modifier.weight(1f, fill = false),
       ) {

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
@@ -322,14 +322,25 @@ private fun ReviewCard(
       ) {
         ReviewHeader(review = review, providerKey = providerKey)
         Spacer(Modifier.height(8.dp))
-        // minLines == maxLines keeps every card in the row the same height
-        // regardless of how long the review is.
+        // Every card measures five text lines tall regardless of review
+        // length; a titled review trades one body line for its headline.
+        review.title?.let { title ->
+          Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = if (obscured) Modifier.blur(12.dp) else Modifier,
+          )
+        }
+        val bodyLines = if (review.title != null) 4 else 5
         RichText(
           state = rememberHtmlRichTextState(review.text),
           style = MaterialTheme.typography.bodyMedium,
           color = MaterialTheme.colorScheme.onSurfaceVariant,
-          minLines = 5,
-          maxLines = 5,
+          minLines = bodyLines,
+          maxLines = bodyLines,
           overflow = TextOverflow.Ellipsis,
           modifier = if (obscured) Modifier.blur(12.dp) else Modifier,
         )

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
@@ -57,6 +57,7 @@ import app.campfire.libraries.ui.detail.composables.ReviewBottomSheet
 import app.campfire.libraries.ui.detail.composables.ReviewerAvatar
 import app.campfire.libraries.ui.detail.composables.ReviewerBadge
 import campfire.features.libraries.ui.generated.resources.Res
+import campfire.features.libraries.ui.generated.resources.community_connect_for_reviews
 import campfire.features.libraries.ui.generated.resources.community_rating_attribution
 import campfire.features.libraries.ui.generated.resources.community_rating_count
 import campfire.features.libraries.ui.generated.resources.community_relink_provider
@@ -185,6 +186,16 @@ class CommunitySlot(
               onClick = { expandedReview = review },
             )
           }
+        }
+      }
+
+      // Serving source has no review text, but linking another provider adds it.
+      state.reviewsLinkProviderName?.takeIf { state.reviews.isEmpty() }?.let { linkName ->
+        TextButton(
+          onClick = { eventSink(LibraryItemUiEvent.RelinkProvider) },
+          modifier = Modifier.padding(horizontal = 8.dp),
+        ) {
+          Text(stringResource(Res.string.community_connect_for_reviews, linkName))
         }
       }
     }

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -42,10 +43,12 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.CommunityContent
 import app.campfire.bookinfo.api.CommunityInfoState
 import app.campfire.common.compose.extensions.rememberHtmlRichTextState
 import app.campfire.common.compose.extensions.roundToSingleDecimal
@@ -58,12 +61,11 @@ import app.campfire.libraries.ui.detail.composables.ReviewerAvatar
 import app.campfire.libraries.ui.detail.composables.ReviewerBadge
 import campfire.features.libraries.ui.generated.resources.Res
 import campfire.features.libraries.ui.generated.resources.community_connect_for_reviews
-import campfire.features.libraries.ui.generated.resources.community_rating_attribution
+import campfire.features.libraries.ui.generated.resources.community_empty_source
 import campfire.features.libraries.ui.generated.resources.community_rating_count
 import campfire.features.libraries.ui.generated.resources.community_relink_provider
 import campfire.features.libraries.ui.generated.resources.community_review_show_spoiler
 import campfire.features.libraries.ui.generated.resources.community_review_spoiler_warning
-import campfire.features.libraries.ui.generated.resources.community_reviews_title
 import campfire.features.libraries.ui.generated.resources.community_title
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.ui.material.RichText
@@ -82,12 +84,13 @@ class CommunitySlot(
 
   @Composable
   override fun Content(modifier: Modifier, eventSink: (LibraryItemUiEvent) -> Unit) {
-    val rating = state.info.rating ?: return
     var expandedReview by remember { mutableStateOf<BookReview?>(null) }
 
     Column(
       modifier = modifier,
     ) {
+      // The header (and its source pill) renders in every phase so the section
+      // stays put while a source switch or first fetch resolves.
       Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -104,59 +107,24 @@ class CommunitySlot(
         SourcePill(state = state, eventSink = eventSink)
       }
 
-      Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-          .fillMaxWidth()
-          .thenIf(state.providerUrl != null) {
-            clickable {
-              eventSink(LibraryItemUiEvent.OpenProviderPage(state.providerUrl!!))
-            }
-          },
-      ) {
-        Spacer(Modifier.width(16.dp))
-
-        Text(
-          text = rating.roundToSingleDecimal(),
-          style = MaterialTheme.typography.headlineLarge,
-          color = MaterialTheme.colorScheme.onSurface,
-        )
-
-        Spacer(Modifier.width(16.dp))
-
-        Column(
-          modifier = Modifier
-            .padding(vertical = 12.dp),
-        ) {
-          StarRow(rating = rating)
-
-          Spacer(Modifier.height(2.dp))
-
-          Row(
-            verticalAlignment = Alignment.CenterVertically,
-          ) {
-            providerBrandIcon(state.providerId.key)?.let { brandIcon ->
-              Image(
-                imageVector = brandIcon,
-                contentDescription = state.providerName,
-                modifier = Modifier.size(16.dp),
-              )
-              Spacer(Modifier.width(4.dp))
-            }
-            Text(
-              text = buildString {
-                append(stringResource(Res.string.community_rating_attribution, state.providerName))
-                state.info.ratingsCount?.let { count ->
-                  append(" · ")
-                  append(stringResource(Res.string.community_rating_count, count.toString()))
-                }
-              },
-              style = MaterialTheme.typography.bodySmall,
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-          }
+      when (val content = state.content) {
+        CommunityContent.Loading -> PhaseBox {
+          CircularProgressIndicator(modifier = Modifier.size(28.dp))
         }
-        Spacer(Modifier.width(16.dp))
+
+        CommunityContent.Unavailable -> PhaseBox {
+          Text(
+            text = stringResource(Res.string.community_empty_source, state.providerName),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+          )
+        }
+
+        is CommunityContent.Available -> RatingContent(
+          content = content,
+          onOpenProvider = { url -> eventSink(LibraryItemUiEvent.OpenProviderPage(url)) },
+        )
       }
 
       if (state.needsRelink) {
@@ -168,18 +136,14 @@ class CommunitySlot(
         }
       }
 
-      if (state.reviews.isNotEmpty()) {
-        MetadataHeader(
-          title = stringResource(Res.string.community_reviews_title),
-          textStyle = MaterialTheme.typography.titleMedium,
-          textColor = MaterialTheme.colorScheme.onSurface,
-          modifier = Modifier.padding(horizontal = 16.dp),
-        )
+      val reviews = (state.content as? CommunityContent.Available)?.reviews.orEmpty()
+      if (reviews.isNotEmpty()) {
+        Spacer(Modifier.height(8.dp))
         LazyRow(
           contentPadding = PaddingValues(horizontal = 16.dp),
           horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-          items(state.reviews) { review ->
+          items(reviews) { review ->
             ReviewCard(
               review = review,
               providerKey = state.providerId.key,
@@ -190,12 +154,14 @@ class CommunitySlot(
       }
 
       // Serving source has no review text, but linking another provider adds it.
-      state.reviewsLinkProviderName?.takeIf { state.reviews.isEmpty() }?.let { linkName ->
-        TextButton(
-          onClick = { eventSink(LibraryItemUiEvent.RelinkProvider) },
-          modifier = Modifier.padding(horizontal = 8.dp),
-        ) {
-          Text(stringResource(Res.string.community_connect_for_reviews, linkName))
+      if (state.content !is CommunityContent.Loading && reviews.isEmpty()) {
+        state.reviewsLinkProviderName?.let { linkName ->
+          TextButton(
+            onClick = { eventSink(LibraryItemUiEvent.RelinkProvider) },
+            modifier = Modifier.padding(horizontal = 8.dp),
+          ) {
+            Text(stringResource(Res.string.community_connect_for_reviews, linkName))
+          }
         }
       }
     }
@@ -211,6 +177,73 @@ class CommunitySlot(
         onDismiss = { expandedReview = null },
       )
     }
+  }
+}
+
+/**
+ * Fixed-height container for the loading and empty phases, sized to the rating
+ * row so switching phases doesn't shift the page.
+ */
+@Composable
+private fun PhaseBox(
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  Box(
+    contentAlignment = Alignment.Center,
+    modifier = modifier
+      .fillMaxWidth()
+      .heightIn(min = 68.dp)
+      .padding(horizontal = 16.dp, vertical = 12.dp),
+  ) {
+    content()
+  }
+}
+
+@Composable
+private fun RatingContent(
+  content: CommunityContent.Available,
+  onOpenProvider: (String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val rating = content.info.rating ?: return
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier
+      .fillMaxWidth()
+      .thenIf(content.info.providerUrl != null) {
+        clickable {
+          onOpenProvider(content.info.providerUrl!!)
+        }
+      },
+  ) {
+    Spacer(Modifier.width(16.dp))
+
+    Text(
+      text = rating.roundToSingleDecimal(),
+      style = MaterialTheme.typography.headlineLarge,
+      color = MaterialTheme.colorScheme.onSurface,
+    )
+
+    Spacer(Modifier.width(16.dp))
+
+    Column(
+      modifier = Modifier
+        .padding(vertical = 12.dp),
+    ) {
+      StarRow(rating = rating)
+
+      Spacer(Modifier.height(2.dp))
+
+      content.info.ratingsCount?.let { count ->
+        Text(
+          text = stringResource(Res.string.community_rating_count, count.toString()),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+    Spacer(Modifier.width(16.dp))
   }
 }
 

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BookPresenterCommunityInfoTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/BookPresenterCommunityInfoTest.kt
@@ -5,6 +5,7 @@ package app.campfire.libraries.ui.detail
 
 import app.campfire.bookinfo.api.BookCommunityInfo
 import app.campfire.bookinfo.api.BookReview
+import app.campfire.bookinfo.api.CommunityContent
 import app.campfire.bookinfo.api.CommunityInfoState
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.common.screens.ConnectedProvidersScreen
@@ -16,7 +17,6 @@ import app.campfire.libraries.ui.detail.composables.slots.CommunitySlot
 import app.campfire.libraries.ui.detail.composables.slots.ContentSlot
 import app.cash.turbine.ReceiveTurbine
 import assertk.Assert
-import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
@@ -27,34 +27,62 @@ import kotlinx.coroutines.test.runTest
 
 class BookPresenterCommunityInfoTest : BaseLibraryItemPresenterTest() {
 
-  private val communityInfo = CommunityInfoState(
+  private val communityInfo = BookCommunityInfo(
+    providerBookId = "386446",
+    providerUrl = "https://hardcover.app/books/the-way-of-kings",
+    rating = 4.63,
+    ratingsCount = 4109,
+    ratingsDistribution = null,
+    reviewsCount = 422,
+    releaseDate = "2010-08-31",
+    coverUrl = null,
+  )
+
+  private fun communityState(
+    content: CommunityContent = CommunityContent.Available(communityInfo, emptyList()),
+  ) = CommunityInfoState(
     providerId = ProviderId.Hardcover,
     providerName = "Hardcover",
-    providerUrl = "https://hardcover.app/books/the-way-of-kings",
-    info = BookCommunityInfo(
-      providerBookId = "386446",
-      providerUrl = "https://hardcover.app/books/the-way-of-kings",
-      rating = 4.63,
-      ratingsCount = 4109,
-      ratingsDistribution = null,
-      reviewsCount = 422,
-      releaseDate = "2010-08-31",
-      coverUrl = null,
-    ),
-    reviews = emptyList(),
+    content = content,
   )
 
   @Test
-  fun present_CommunityInfo_GeneratesRatingSlot() = runTest {
+  fun present_CommunityInfo_GeneratesCommunitySlot() = runTest {
     libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
-    bookInfoRegistry.communityInfoFlow.emit(LoadState.Loaded(communityInfo))
+    bookInfoRegistry.communityInfoFlow.emit(communityState())
 
     presenter.test {
       assertThat(awaitItemWithSlot<CommunitySlot>())
         .loadedSlots
-        .all {
-          containsInstance<CommunitySlot>()
-        }
+        .containsInstance<CommunitySlot>()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_LoadingContent_StillGeneratesCommunitySlot() = runTest {
+    // The section renders through the fetch — its loading phase lives inside
+    // the slot instead of removing it, so source switches never blink.
+    libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
+    bookInfoRegistry.communityInfoFlow.emit(communityState(content = CommunityContent.Loading))
+
+    presenter.test {
+      assertThat(awaitItemWithSlot<CommunitySlot>())
+        .loadedSlots
+        .containsInstance<CommunitySlot>()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun present_UnavailableContent_StillGeneratesCommunitySlot() = runTest {
+    libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
+    bookInfoRegistry.communityInfoFlow.emit(communityState(content = CommunityContent.Unavailable))
+
+    presenter.test {
+      assertThat(awaitItemWithSlot<CommunitySlot>())
+        .loadedSlots
+        .containsInstance<CommunitySlot>()
       cancelAndIgnoreRemainingEvents()
     }
   }
@@ -63,8 +91,9 @@ class BookPresenterCommunityInfoTest : BaseLibraryItemPresenterTest() {
   fun present_CommunityInfoWithReviews_GeneratesCommunitySlot() = runTest {
     libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
     bookInfoRegistry.communityInfoFlow.emit(
-      LoadState.Loaded(
-        communityInfo.copy(
+      communityState(
+        content = CommunityContent.Available(
+          info = communityInfo,
           reviews = listOf(
             BookReview(author = "reader", rating = 5.0, text = "Loved it", hasSpoilers = false),
           ),
@@ -81,16 +110,14 @@ class BookPresenterCommunityInfoTest : BaseLibraryItemPresenterTest() {
   }
 
   @Test
-  fun present_NoCommunityInfo_GeneratesNoSlots() = runTest {
+  fun present_NoServableProvider_GeneratesNoSlot() = runTest {
     libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
-    bookInfoRegistry.communityInfoFlow.emit(LoadState.Loaded(null))
+    bookInfoRegistry.communityInfoFlow.emit(null)
 
     presenter.test {
       assertThat(awaitLoadedItem())
         .loadedSlots
-        .all {
-          doesNotContainInstance<CommunitySlot>()
-        }
+        .doesNotContainInstance<CommunitySlot>()
       cancelAndIgnoreRemainingEvents()
     }
   }
@@ -98,7 +125,7 @@ class BookPresenterCommunityInfoTest : BaseLibraryItemPresenterTest() {
   @Test
   fun present_OpenProviderPage_NavigatesToUrl() = runTest {
     libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
-    bookInfoRegistry.communityInfoFlow.emit(LoadState.Loaded(communityInfo))
+    bookInfoRegistry.communityInfoFlow.emit(communityState())
 
     presenter.test {
       val state = awaitItemWithSlot<CommunitySlot>()
@@ -115,7 +142,7 @@ class BookPresenterCommunityInfoTest : BaseLibraryItemPresenterTest() {
   @Test
   fun present_SelectCommunitySource_ResubscribesWithPreferredProvider() = runTest {
     libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
-    bookInfoRegistry.communityInfoFlow.emit(LoadState.Loaded(communityInfo))
+    bookInfoRegistry.communityInfoFlow.emit(communityState())
 
     presenter.test {
       val state = awaitItemWithSlot<CommunitySlot>()
@@ -135,9 +162,7 @@ class BookPresenterCommunityInfoTest : BaseLibraryItemPresenterTest() {
   @Test
   fun present_RelinkProvider_NavigatesToConnectedProviders() = runTest {
     libraryItemRepository.libraryItemFlow.emit(emptyLibraryItem())
-    bookInfoRegistry.communityInfoFlow.emit(
-      LoadState.Loaded(communityInfo.copy(needsRelink = true)),
-    )
+    bookInfoRegistry.communityInfoFlow.emit(communityState().copy(needsRelink = true))
 
     presenter.test {
       val state = awaitItemWithSlot<CommunitySlot>()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -144,6 +144,7 @@ include(
 )
 include(
   ":data:bookinfo:api",
+  ":data:bookinfo:audible",
   ":data:bookinfo:hardcover",
   ":data:bookinfo:impl",
   ":data:bookinfo:openlibrary",


### PR DESCRIPTION
## Summary

Completes the keyless fallback tier (stacked on #1025), replacing the Audnexus PR (#1026) — Audnexus proxies this same Audible data minus the star distribution and counts, so the direct source wins.

- **`:data:bookinfo:audible`**: keyless provider on Audible's public catalog API — the same anonymous endpoints the Audiobookshelf server's own Audible metadata provider has used for years. One request returns the aggregate rating, **full per-star distribution**, ratings + review counts, cover, and release date for any ASIN-bearing audiobook — and `getReviews` serves **written reviews** (entity-decoded to the HTML the cards render, with the reviewer's headline as a new optional `BookReview.title`), so review text now works with zero account setup. Since Audible has review text, the connect-Hardcover CTA only shows when the serving source truly has none. All response shapes verified live against `api.audible.com`. Pinned to the US marketplace for now (region setting later, like the ABS server has).
- **`AudibleCatalog`** wrapper also speaks batch lookups (chunked ≤50 ASINs) and series relationship edges — deliberate groundwork for the series listings PR that follows.
- Provider priority is Hardcover > Audible > Open Library: for audiobooks the Audible rating is the native signal, and it carries the distribution Open Library sometimes lacks.
- **Connect-for-reviews shortcut**: when ratings come from a source with no written reviews and Hardcover is enabled-but-unlinked, the Community section shows "Connect Hardcover to see reviews" routing to the Book Info page.

## Test plan
- `./gradlew :data:bookinfo:audible:jvmTest` — distribution/counts/cover mapping with ASIN normalization, unrated → miss, 404/400 → miss, 5xx → failure, ISBN-only short-circuit
- `./gradlew :data:bookinfo:impl:jvmTest` — identifier-aware selection + reviews-link surfacing
- Desktop DI graph compiles; live curl verification of product, rating, and image shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu