### PR TITLE
Let users choose a preferred community info source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Open Library as a built-in ratings source — books with an ISBN show community ratings even without a Hardcover account
 - Audible as a built-in source for audiobooks with an ASIN, showing the Audible rating, star distribution, and written reviews without any account
 - A "Connect Hardcover to see reviews" shortcut on the Community section when ratings come from a source without written reviews
+- A Preferred source setting on the Book Info page — choose which ratings source wins by default, or leave it on Automatic
 
 ### Changed
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/ProviderBranding.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/icons/ProviderBranding.kt
@@ -3,8 +3,13 @@
 
 package app.campfire.common.compose.icons
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.icons.rounded.LocalLibrary
 
 /**
  * Branding for book info providers, keyed by the provider's stable string key
@@ -14,11 +19,26 @@ import androidx.compose.ui.graphics.vector.ImageVector
  */
 private const val HARDCOVER = "hardcover"
 private const val AUDIBLE = "audible"
+private const val OPEN_LIBRARY = "openlibrary"
 
 fun providerBrandIcon(providerKey: String): ImageVector? = when (providerKey) {
   HARDCOVER -> CampfireIcons.Hardcover
   AUDIBLE -> CampfireIcons.Audible
+  OPEN_LIBRARY -> CampfireIcons.Rounded.LocalLibrary
   else -> null
+}
+
+@Composable
+fun providerBrandIconTint(providerKey: String): Color? = when (providerKey) {
+  AUDIBLE -> Color.Black
+  OPEN_LIBRARY -> MaterialTheme.colorScheme.onSurface
+  else -> null
+}
+
+fun providerBrandIconPadding(providerKey: String): Dp = when (providerKey) {
+  AUDIBLE -> 4.dp
+  OPEN_LIBRARY -> 4.dp
+  else -> 0.dp
 }
 
 /**

--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoProviderSettings.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoProviderSettings.kt
@@ -14,4 +14,13 @@ interface BookInfoProviderSettings {
   fun isEnabled(id: ProviderId): Boolean
   fun setEnabled(id: ProviderId, enabled: Boolean)
   fun observeEnabled(id: ProviderId): Flow<Boolean>
+
+  /**
+   * The user's preferred source, or null for the automatic default order.
+   * The preferred provider wins whenever it can serve a book; when it can't,
+   * selection falls back down the default order.
+   */
+  fun preferredProvider(): ProviderId?
+  fun setPreferredProvider(id: ProviderId?)
+  fun observePreferredProvider(): Flow<ProviderId?>
 }

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoProviderSettings.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoProviderSettings.kt
@@ -13,7 +13,9 @@ import com.r0adkll.kimchi.annotations.ContributesBinding
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.coroutines.getBooleanFlow
+import com.russhwolf.settings.coroutines.getStringOrNullFlow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import me.tatarka.inject.annotations.Inject
 
 @OptIn(ExperimentalSettingsApi::class)
@@ -37,7 +39,31 @@ class DefaultBookInfoProviderSettings(
     return settings.getBooleanFlow(key(id), defaultValue = true)
   }
 
+  override fun preferredProvider(): ProviderId? {
+    return settings.getStringOrNull(preferredKey()).toProviderId()
+  }
+
+  override fun setPreferredProvider(id: ProviderId?) {
+    if (id == null) {
+      settings.remove(preferredKey())
+    } else {
+      settings.putString(preferredKey(), id.key)
+    }
+  }
+
+  override fun observePreferredProvider(): Flow<ProviderId?> {
+    return settings.getStringOrNullFlow(preferredKey()).map { it.toProviderId() }
+  }
+
+  private fun String?.toProviderId(): ProviderId? {
+    return this?.let { stored -> ProviderId.entries.firstOrNull { it.key == stored } }
+  }
+
   private fun key(id: ProviderId): String {
     return "bookinfo_enabled_${id.key}_${userSession.userId.orEmpty()}"
+  }
+
+  private fun preferredKey(): String {
+    return "bookinfo_preferred_${userSession.userId.orEmpty()}"
   }
 }

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -70,26 +70,30 @@ class DefaultBookInfoRegistry(
     val userId = userSession.userId ?: return flowOf(null)
     val match = item.bestMatch() ?: return flowOf(null)
 
-    return observeProviders()
-      .map { statuses ->
-        val usable = statuses.filter { it.canServeBookInfo && it.provider.canServe(match) }
-        // An enabled-but-unlinked review-capable provider is worth advertising
-        // when whoever ends up serving has no review text of its own.
-        val reviewsVia = statuses.firstOrNull {
-          it.enabled &&
-            it.provider.capabilities.hasReviewText &&
-            it.linkState is ProviderLinkState.NotLinked
-        }?.provider?.displayName
-        usable to reviewsVia
+    return combine(observeProviders(), settings.observePreferredProvider()) { statuses, stored ->
+      val usable = statuses.filter { it.canServeBookInfo && it.provider.canServe(match) }
+      // An enabled-but-unlinked review-capable provider is worth advertising
+      // when whoever ends up serving has no review text of its own.
+      val reviewsVia = statuses.firstOrNull {
+        it.enabled &&
+          it.provider.capabilities.hasReviewText &&
+          it.linkState is ProviderLinkState.NotLinked
+      }?.provider?.displayName
+      // The caller's per-book choice wins over the persisted preference, which
+      // wins over the default order.
+      val status = usable.firstOrNull { it.provider.id == preferredProvider }
+        ?: usable.firstOrNull { it.provider.id == stored }
+        ?: usable.firstOrNull()
+      Selection(status, usable, reviewsVia)
+    }
+      .distinctUntilChanged { old, new ->
+        old.status?.provider?.id == new.status?.provider?.id &&
+          old.status?.linkState == new.status?.linkState &&
+          old.usable.map { it.provider.id to it.linkState } ==
+          new.usable.map { it.provider.id to it.linkState } &&
+          old.reviewsVia == new.reviewsVia
       }
-      .distinctUntilChanged { (oldUsable, oldVia), (newUsable, newVia) ->
-        oldUsable.map { it.provider.id to it.linkState } ==
-          newUsable.map { it.provider.id to it.linkState } &&
-          oldVia == newVia
-      }
-      .flatMapLatest { (usable, reviewsVia) ->
-        val status = usable.firstOrNull { it.provider.id == preferredProvider }
-          ?: usable.firstOrNull()
+      .flatMapLatest { (status, usable, reviewsVia) ->
         if (status == null) {
           flowOf(null)
         } else {
@@ -103,6 +107,12 @@ class DefaultBookInfoRegistry(
         }
       }
   }
+
+  private data class Selection(
+    val status: ProviderStatus?,
+    val usable: List<ProviderStatus>,
+    val reviewsVia: String?,
+  )
 
   override fun observeSeriesEntries(
     seriesName: String,
@@ -118,8 +128,10 @@ class DefaultBookInfoRegistry(
     val userId = userSession.userId ?: return flowOf(LoadState.Loaded(ownedOnly))
     val match = seriesMatch(seriesName, ownedItems) ?: return flowOf(LoadState.Loaded(ownedOnly))
 
-    return observeProviders()
-      .map { statuses -> statuses.firstOrNull { it.canServeSeries } }
+    return combine(observeProviders(), settings.observePreferredProvider()) { statuses, stored ->
+      val usable = statuses.filter { it.canServeSeries }
+      usable.firstOrNull { it.provider.id == stored } ?: usable.firstOrNull()
+    }
       .distinctUntilChanged { old, new ->
         old?.provider?.id == new?.provider?.id && old?.linkState == new?.linkState
       }

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -228,6 +228,87 @@ class DefaultBookInfoRegistryTest {
   }
 
   @Test
+  fun `the persisted preferred provider wins over the default order`() = runTest {
+    val hardcover = FakeBookInfoProvider(id = ProviderId.Hardcover, displayName = "Hardcover")
+    hardcover.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val audible = FakeBookInfoProvider(id = ProviderId.Audible, displayName = "Audible")
+    audible.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val settings = DefaultBookInfoProviderSettings(MapSettings(), session)
+    settings.setPreferredProvider(ProviderId.Audible)
+    val registry = registry(hardcover, audible, settings = settings)
+
+    val state = registry.observeCommunityInfo(item).awaitAvailable()
+
+    assertThat(state.providerId).isEqualTo(ProviderId.Audible)
+    // Both stay switchable in the pill.
+    assertThat(state.availableSources.map { it.id })
+      .isEqualTo(listOf(ProviderId.Hardcover, ProviderId.Audible))
+  }
+
+  @Test
+  fun `a per book choice overrides the persisted preference`() = runTest {
+    val hardcover = FakeBookInfoProvider(id = ProviderId.Hardcover, displayName = "Hardcover")
+    hardcover.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val audible = FakeBookInfoProvider(id = ProviderId.Audible, displayName = "Audible")
+    audible.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val settings = DefaultBookInfoProviderSettings(MapSettings(), session)
+    settings.setPreferredProvider(ProviderId.Audible)
+    val registry = registry(hardcover, audible, settings = settings)
+
+    val state = registry
+      .observeCommunityInfo(item, preferredProvider = ProviderId.Hardcover)
+      .awaitAvailable()
+
+    assertThat(state.providerId).isEqualTo(ProviderId.Hardcover)
+  }
+
+  @Test
+  fun `an unusable persisted preference falls back to the default order`() = runTest {
+    val hardcover = FakeBookInfoProvider(id = ProviderId.Hardcover, displayName = "Hardcover")
+    hardcover.bookInfoResult = BookInfoResult.Success(communityInfo)
+    val audible = FakeBookInfoProvider(id = ProviderId.Audible, displayName = "Audible")
+    audible.canServeResult = false
+    val settings = DefaultBookInfoProviderSettings(MapSettings(), session)
+    settings.setPreferredProvider(ProviderId.Audible)
+    val registry = registry(hardcover, audible, settings = settings)
+
+    val state = registry.observeCommunityInfo(item).awaitAvailable()
+
+    assertThat(state.providerId).isEqualTo(ProviderId.Hardcover)
+  }
+
+  @Test
+  fun `preferred provider setting round trips and clears`() = runTest {
+    val settings = DefaultBookInfoProviderSettings(MapSettings(), session)
+
+    assertThat(settings.preferredProvider()).isNull()
+    settings.setPreferredProvider(ProviderId.OpenLibrary)
+    assertThat(settings.preferredProvider()).isEqualTo(ProviderId.OpenLibrary)
+    assertThat(settings.observePreferredProvider().first()).isEqualTo(ProviderId.OpenLibrary)
+    settings.setPreferredProvider(null)
+    assertThat(settings.preferredProvider()).isNull()
+  }
+
+  @Test
+  fun `series selection respects the persisted preference`() = runTest {
+    val hardcover = FakeBookInfoProvider(id = ProviderId.Hardcover, displayName = "Hardcover")
+    val audible = FakeBookInfoProvider(id = ProviderId.Audible, displayName = "Audible")
+    audible.seriesResult = BookInfoResult.NotFound
+    val settings = DefaultBookInfoProviderSettings(MapSettings(), session)
+    settings.setPreferredProvider(ProviderId.Audible)
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ASIN = "B003P2WO5E")),
+    )
+    val registry = registry(hardcover, audible, settings = settings)
+
+    registry.observeSeriesEntries("The Stormlight Archive", listOf(owned))
+      .first { audible.seriesRequests.isNotEmpty() || hardcover.seriesRequests.isNotEmpty() }
+
+    assertThat(audible.seriesRequests.size).isEqualTo(1)
+    assertThat(hardcover.seriesRequests.size).isEqualTo(0)
+  }
+
+  @Test
   fun `a provider that cannot serve the match is skipped for one that can`() = runTest {
     // Mimics an ASIN-only audiobook: the first-priority provider is ISBN-keyed
     // and declares itself unservable, so the lower-priority one serves.

--- a/data/bookinfo/ui/src/commonMain/composeResources/values/bookinfo_ui_strings.xml
+++ b/data/bookinfo/ui/src/commonMain/composeResources/values/bookinfo_ui_strings.xml
@@ -17,6 +17,10 @@
   <string name="provider_disconnect">Disconnect</string>
   <string name="provider_link_error">Couldn't verify that token. Check it and try again.</string>
 
+  <string name="provider_preferred_title">Preferred source</string>
+  <string name="provider_preferred_subtitle">Which source wins when several have this book</string>
+  <string name="provider_preferred_automatic">Automatic</string>
+
   <string name="provider_clear_cache">Clear cached data</string>
   <string name="provider_clear_cache_subtitle">Removes saved ratings and reviews. They'll be fetched fresh the next time you view a book.</string>
 </resources>

--- a/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersPresenter.kt
+++ b/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersPresenter.kt
@@ -40,6 +40,10 @@ class ConnectedProvidersPresenter(
       bookInfoRegistry.observeProviders()
     }.collectAsState(emptyList())
 
+    val preferredProvider by remember {
+      settings.observePreferredProvider()
+    }.collectAsState(settings.preferredProvider())
+
     var verifyingId by remember { mutableStateOf<ProviderId?>(null) }
     var failedId by remember { mutableStateOf<ProviderId?>(null) }
     var clearingCache by remember { mutableStateOf(false) }
@@ -61,10 +65,15 @@ class ConnectedProvidersPresenter(
 
     return ConnectedProvidersUiState(
       providers = rows,
+      preferredProvider = preferredProvider,
       isClearingCache = clearingCache,
     ) { event ->
       when (event) {
         ConnectedProvidersUiEvent.Back -> navigator.pop()
+
+        is ConnectedProvidersUiEvent.SetPreferredProvider -> {
+          settings.setPreferredProvider(event.id)
+        }
 
         ConnectedProvidersUiEvent.ClearCache -> {
           if (!clearingCache) {

--- a/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersUi.kt
+++ b/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersUi.kt
@@ -5,8 +5,11 @@ package app.campfire.bookinfo.ui
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,21 +21,26 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.OutlinedButton
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -40,24 +48,32 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import app.campfire.bookinfo.api.ProviderCapabilities
+import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.providerBrandColor
 import app.campfire.common.compose.icons.providerBrandIcon
+import app.campfire.common.compose.icons.providerBrandIconPadding
+import app.campfire.common.compose.icons.providerBrandIconTint
 import app.campfire.common.compose.icons.providerBrandSecondaryColor
 import app.campfire.common.compose.icons.providerOnBrandColor
+import app.campfire.common.compose.icons.rounded.AutoMode
 import app.campfire.common.compose.icons.rounded.Disconnected
 import app.campfire.common.compose.theme.LocalUseDarkColors
 import app.campfire.common.compose.widgets.CampfireTopAppBar
@@ -81,6 +97,9 @@ import campfire.data.bookinfo.ui.generated.resources.provider_link_error
 import campfire.data.bookinfo.ui.generated.resources.provider_link_invalid
 import campfire.data.bookinfo.ui.generated.resources.provider_linked
 import campfire.data.bookinfo.ui.generated.resources.provider_linked_as
+import campfire.data.bookinfo.ui.generated.resources.provider_preferred_automatic
+import campfire.data.bookinfo.ui.generated.resources.provider_preferred_subtitle
+import campfire.data.bookinfo.ui.generated.resources.provider_preferred_title
 import campfire.data.bookinfo.ui.generated.resources.provider_token_hint
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import org.jetbrains.compose.resources.stringResource
@@ -136,14 +155,25 @@ fun ConnectedProvidersUi(
             .padding(horizontal = 16.dp),
         )
       }
-      item("clear_cache") {
-        ClearCacheRow(
-          isClearing = state.isClearingCache,
-          onClick = { state.eventSink(ConnectedProvidersUiEvent.ClearCache) },
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        )
+      item("preferred_provider") {
+        Column {
+          PreferredProviderRow(
+            providers = state.providers,
+            preferredProvider = state.preferredProvider,
+            onSelect = { state.eventSink(ConnectedProvidersUiEvent.SetPreferredProvider(it)) },
+            modifier = Modifier
+              .fillMaxWidth(),
+          )
+
+          Spacer(Modifier.height(4.dp))
+
+          ClearCacheRow(
+            isClearing = state.isClearingCache,
+            onClick = { state.eventSink(ConnectedProvidersUiEvent.ClearCache) },
+            modifier = Modifier
+              .fillMaxWidth(),
+          )
+        }
       }
     }
   }
@@ -207,7 +237,12 @@ private fun ProviderCard(
           Image(
             imageVector = brandIcon,
             contentDescription = null,
-            modifier = Modifier.size(40.dp),
+            modifier = Modifier
+              .size(40.dp)
+              .padding(providerBrandIconPadding(provider.id.key)),
+            colorFilter = providerBrandIconTint(provider.id.key)?.let { tint ->
+              ColorFilter.tint(tint)
+            },
           )
           Spacer(Modifier.width(12.dp))
         }
@@ -403,4 +438,135 @@ private fun ProviderCapabilities.summary(): String {
     if (hasSupplementalMetadata) add(stringResource(Res.string.capability_metadata))
   }
   return labels.joinToString(" · ")
+}
+
+@Composable
+private fun PreferredProviderRow(
+  providers: List<ProviderRowState>,
+  preferredProvider: ProviderId?,
+  onSelect: (ProviderId?) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var expanded by remember { mutableStateOf(false) }
+  val automaticLabel = stringResource(Res.string.provider_preferred_automatic)
+  val selectedLabel = providers.firstOrNull { it.id == preferredProvider }?.name ?: automaticLabel
+
+  ListItem(
+    headlineContent = {
+      Text(stringResource(Res.string.provider_preferred_title))
+    },
+    supportingContent = {
+      Text(stringResource(Res.string.provider_preferred_subtitle))
+    },
+    trailingContent = {
+      Box {
+        PreferredOptionChip(
+          icon = {
+            PreferredOptionIcon(
+              preferredProvider,
+              modifier = Modifier.size(16.dp),
+            )
+          },
+          text = { Text(selectedLabel) },
+          onClick = { expanded = true },
+        )
+
+        DropdownMenu(
+          expanded = expanded,
+          onDismissRequest = { expanded = false },
+        ) {
+          DropdownMenuItem(
+            leadingIcon = { PreferredOptionIcon(null) },
+            text = { Text(automaticLabel) },
+            onClick = {
+              onSelect(null)
+              expanded = false
+            },
+          )
+          providers.forEach { provider ->
+            DropdownMenuItem(
+              leadingIcon = { PreferredOptionIcon(provider.id) },
+              text = { Text(provider.name) },
+              onClick = {
+                onSelect(provider.id)
+                expanded = false
+              },
+            )
+          }
+        }
+      }
+    },
+    colors = ListItemDefaults.colors(
+      containerColor = Color.Transparent,
+    ),
+    modifier = modifier.clickable { expanded = true },
+  )
+}
+
+@Composable
+private fun PreferredOptionIcon(
+  id: ProviderId?,
+  modifier: Modifier = Modifier,
+) {
+  if (id == null) {
+    Icon(
+      imageVector = CampfireIcons.Rounded.AutoMode,
+      contentDescription = null,
+      modifier = modifier.size(20.dp),
+    )
+  } else {
+    providerBrandIcon(id.key)?.let { brandIcon ->
+      Icon(
+        imageVector = brandIcon,
+        contentDescription = null,
+        modifier = modifier
+          .size(20.dp),
+      )
+    }
+  }
+}
+
+// Mirrors the OptionChip used by the app's dropdown-valued settings (e.g.
+// Appearance > Theme mode) so this sub-settings screen reads as one of them.
+@Composable
+private fun PreferredOptionChip(
+  icon: @Composable () -> Unit,
+  text: @Composable () -> Unit,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier = modifier
+      .background(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(8.dp),
+      )
+      .border(
+        width = 1.dp,
+        color = MaterialTheme.colorScheme.primary,
+        shape = RoundedCornerShape(8.dp),
+      )
+      .clip(RoundedCornerShape(8.dp))
+      .clickable(onClick = onClick)
+      .padding(
+        horizontal = 12.dp,
+        vertical = 8.dp,
+      ),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    CompositionLocalProvider(
+      LocalContentColor provides MaterialTheme.colorScheme.primary,
+    ) {
+      icon()
+      Spacer(Modifier.width(8.dp))
+      ProvideTextStyle(MaterialTheme.typography.titleSmall) {
+        text()
+      }
+      Spacer(Modifier.width(4.dp))
+      Icon(
+        Icons.Rounded.ArrowDropDown,
+        contentDescription = null,
+      )
+    }
+  }
 }

--- a/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersUiState.kt
+++ b/data/bookinfo/ui/src/commonMain/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersUiState.kt
@@ -13,6 +13,8 @@ import com.slack.circuit.runtime.CircuitUiState
 @Immutable
 data class ConnectedProvidersUiState(
   val providers: List<ProviderRowState>,
+  /** The user's preferred source; null means the automatic default order. */
+  val preferredProvider: ProviderId? = null,
   val isClearingCache: Boolean = false,
   val eventSink: (ConnectedProvidersUiEvent) -> Unit,
 ) : CircuitUiState
@@ -34,6 +36,7 @@ sealed interface ConnectedProvidersUiEvent : CircuitUiEvent {
   data object Back : ConnectedProvidersUiEvent
   data object ClearCache : ConnectedProvidersUiEvent
   data class ToggleEnabled(val id: ProviderId, val enabled: Boolean) : ConnectedProvidersUiEvent
+  data class SetPreferredProvider(val id: ProviderId?) : ConnectedProvidersUiEvent
   data class Link(val id: ProviderId, val token: String) : ConnectedProvidersUiEvent
   data class Unlink(val id: ProviderId) : ConnectedProvidersUiEvent
   data class OpenLinkHelp(val url: String) : ConnectedProvidersUiEvent

--- a/data/bookinfo/ui/src/commonTest/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersPresenterTest.kt
+++ b/data/bookinfo/ui/src/commonTest/kotlin/app/campfire/bookinfo/ui/ConnectedProvidersPresenterTest.kt
@@ -53,6 +53,13 @@ private class FakeProviderSettings : BookInfoProviderSettings {
     this.enabled.value = this.enabled.value + (id to enabled)
   }
   override fun observeEnabled(id: ProviderId): Flow<Boolean> = enabled.map { it[id] ?: true }
+
+  val preferred = MutableStateFlow<ProviderId?>(null)
+  override fun preferredProvider(): ProviderId? = preferred.value
+  override fun setPreferredProvider(id: ProviderId?) {
+    preferred.value = id
+  }
+  override fun observePreferredProvider(): Flow<ProviderId?> = preferred
 }
 
 class ConnectedProvidersPresenterTest {
@@ -88,6 +95,26 @@ class ConnectedProvidersPresenterTest {
       assertThat(row.linkState).isEqualTo(ProviderLinkState.Linked("reader"))
       cancelAndIgnoreRemainingEvents()
     }
+  }
+
+  @Test
+  fun present_SetPreferredProvider_UpdatesSettingsAndState() = runTest {
+    emitProvider()
+
+    presenter.test {
+      skipItems(1)
+      val state = awaitItem()
+
+      state.eventSink(ConnectedProvidersUiEvent.SetPreferredProvider(ProviderId.Hardcover))
+      val updated = awaitItemMatching { it.preferredProvider == ProviderId.Hardcover }
+      assertThat(updated.preferredProvider).isEqualTo(ProviderId.Hardcover)
+
+      updated.eventSink(ConnectedProvidersUiEvent.SetPreferredProvider(null))
+      awaitItemMatching { it.preferredProvider == null }
+      cancelAndIgnoreRemainingEvents()
+    }
+
+    assertThat(settings.preferredProvider()).isEqualTo(null)
   }
 
   @Test

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/slots/CommunitySlot.kt
@@ -298,6 +298,7 @@ private fun SourcePill(
     DropdownMenu(
       expanded = expanded,
       onDismissRequest = { expanded = false },
+      shape = MaterialTheme.shapes.medium,
     ) {
       state.availableSources.forEach { source ->
         DropdownMenuItem(


### PR DESCRIPTION
## Summary

Tops the bookinfo stack (on #1028) with user control over provider priority.

- **Preferred source setting** on the Book Info page: a dropdown (Automatic / Hardcover / Audible / Open Library) above the provider cards. Automatic keeps the built-in order; a selection persists per user via `BookInfoProviderSettings.preferredProvider`.
- **Resolution order everywhere the registry picks**: the per-book pill choice > the persisted preference > the default order. An unusable preference (disabled, unlinked, or can't match a given book — e.g. Audible preferred on an ISBN-only book) silently falls back down the default order, and the pill keeps every usable source switchable regardless.
- Applies to ratings/reviews **and** series listings, so a preferred Audible also serves series resolution first (it's the only series-capable source today, but the plumbing is uniform).

## Test plan
- `./gradlew :data:bookinfo:impl:jvmTest` — persisted preference wins over default order, per-book choice overrides it, unusable preference falls back, setting round-trips/clears, series selection respects it (5 new tests)
- `./gradlew :data:bookinfo:ui:jvmTest` — set/clear flows through to settings and state
- Desktop DI graph compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu