### PR TITLE
Add a one-shot, definitive series fetch to the book info registry

### DIFF
--- a/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
+++ b/data/bookinfo/api/src/commonMain/kotlin/app/campfire/bookinfo/api/BookInfoRegistry.kt
@@ -47,10 +47,38 @@ interface BookInfoRegistry {
   ): Flow<LoadState<out SeriesInfoState>>
 
   /**
+   * One-shot, definitive series listing for a bulk scan: serves from the cache
+   * when fresh and refreshes otherwise. Unlike [observeSeriesEntries] the
+   * result distinguishes "the provider has no listing for this series" from
+   * "the provider couldn't be asked".
+   */
+  suspend fun fetchSeriesEntries(
+    seriesName: String,
+    ownedItems: List<LibraryItem>,
+  ): SeriesFetchResult
+
+  /**
    * Drops all locally cached provider data (for every provider and user).
    * Fresh data is fetched on the next read.
    */
   suspend fun clearCache()
+}
+
+sealed interface SeriesFetchResult {
+  /**
+   * A definitive answer; a null [SeriesInfoState.providerId] means the
+   * provider was asked and has no listing for the series.
+   */
+  data class Success(val state: SeriesInfoState) : SeriesFetchResult
+
+  /**
+   * The series can't be looked up at all — no series-capable provider, no
+   * user session, or no identifier-bearing owned members.
+   */
+  data object Unavailable : SeriesFetchResult
+
+  /** The fetch failed (network, rate limit) with nothing cached to serve. */
+  data object Error : SeriesFetchResult
 }
 
 data class ProviderStatus(

--- a/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
+++ b/data/bookinfo/impl/src/commonMain/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistry.kt
@@ -11,7 +11,9 @@ import app.campfire.bookinfo.api.CommunityInfoState
 import app.campfire.bookinfo.api.CommunitySource
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
+import app.campfire.bookinfo.api.ProviderSeries
 import app.campfire.bookinfo.api.ProviderStatus
+import app.campfire.bookinfo.api.SeriesFetchResult
 import app.campfire.bookinfo.api.SeriesInfoState
 import app.campfire.bookinfo.api.bestMatch
 import app.campfire.bookinfo.api.seriesMatch
@@ -32,12 +34,15 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import me.tatarka.inject.annotations.Inject
 import org.mobilenativefoundation.store.store5.StoreReadResponse
+import org.mobilenativefoundation.store.store5.StoreReadResponseOrigin
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @SingleIn(UserScope::class)
@@ -190,6 +195,63 @@ class DefaultBookInfoRegistry(
       }
     }
   }
+
+  override suspend fun fetchSeriesEntries(
+    seriesName: String,
+    ownedItems: List<LibraryItem>,
+  ): SeriesFetchResult {
+    val userId = userSession.userId ?: return SeriesFetchResult.Unavailable
+    val match = seriesMatch(seriesName, ownedItems) ?: return SeriesFetchResult.Unavailable
+
+    val status = combine(observeProviders(), settings.observePreferredProvider()) { statuses, stored ->
+      val usable = statuses.filter { it.canServeSeries }
+      usable.firstOrNull { it.provider.id == stored } ?: usable.firstOrNull()
+    }.first() ?: return SeriesFetchResult.Unavailable
+
+    val key = SeriesInfoStore.Key(userId, status.provider.id, match)
+    val cached = seriesStore.cached(key)
+    val invalidLink = status.linkState is ProviderLinkState.Invalid
+    val refresh = !invalidLink &&
+      (
+        cached == null ||
+          cached.isStale(
+            nowMillis = Clock.System.now().toEpochMilliseconds(),
+            currentMatchKey = key.match.cacheKey,
+          )
+        )
+
+    if (!refresh) {
+      // A rejected token means fetches would just 401; serve the cache or fail.
+      return when (cached) {
+        null -> SeriesFetchResult.Error
+        else -> SeriesFetchResult.Success(status.toSeriesState(cached.series, ownedItems))
+      }
+    }
+
+    // With refresh the store re-emits any stale cached row (SourceOfTruth
+    // origin) before the fetcher lands — only a fetcher-origin Data is the
+    // definitive answer here.
+    return seriesStore.stream(key, refresh = true)
+      .mapNotNull { response ->
+        when {
+          response is StoreReadResponse.Data && response.origin is StoreReadResponseOrigin.Fetcher ->
+            SeriesFetchResult.Success(status.toSeriesState(response.value.series, ownedItems))
+          response is StoreReadResponse.Error -> SeriesFetchResult.Error
+          else -> null
+        }
+      }
+      .first()
+  }
+
+  private fun ProviderStatus.toSeriesState(
+    series: ProviderSeries?,
+    ownedItems: List<LibraryItem>,
+  ): SeriesInfoState = SeriesInfoState(
+    providerId = series?.let { provider.id },
+    providerName = series?.let { provider.displayName },
+    isCompleted = series?.isCompleted,
+    entries = mergeSeriesEntries(ownedItems, series, provider.id),
+  )
 
   override suspend fun clearCache() {
     store.clearAll()

--- a/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
+++ b/data/bookinfo/impl/src/jvmTest/kotlin/app/campfire/bookinfo/DefaultBookInfoRegistryTest.kt
@@ -13,6 +13,7 @@ import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderLinkState
 import app.campfire.bookinfo.api.ProviderSeries
 import app.campfire.bookinfo.api.ProviderSeriesEntry
+import app.campfire.bookinfo.api.SeriesFetchResult
 import app.campfire.bookinfo.db.BookInfoDatabase
 import app.campfire.bookinfo.store.BookInfoStore
 import app.campfire.bookinfo.store.SeriesInfoStore
@@ -53,6 +54,43 @@ class DefaultBookInfoRegistryTest {
     reviewsCount = 422,
     releaseDate = "2010-08-31",
     coverUrl = null,
+  )
+
+  private val stormlightSeries = ProviderSeries(
+    providerSeriesId = "B005NB27MK",
+    name = "The Stormlight Archive",
+    isCompleted = null,
+    entries = listOf(
+      ProviderSeriesEntry(
+        providerBookId = "B003P2WO5E",
+        position = 1.0,
+        title = "The Way of Kings",
+        releaseDate = "2010-08-31",
+        isReleased = true,
+        providerUrl = null,
+        coverUrl = null,
+        asins = listOf("B003P2WO5E"),
+      ),
+      ProviderSeriesEntry(
+        providerBookId = "B00BWWSVPU",
+        position = 2.0,
+        title = "Words of Radiance",
+        releaseDate = "2014-03-04",
+        isReleased = true,
+        providerUrl = null,
+        coverUrl = null,
+        asins = listOf("B00BWWSVPU"),
+      ),
+      ProviderSeriesEntry(
+        providerBookId = "B0UPCOMING",
+        position = 6.0,
+        title = "Untitled #6",
+        releaseDate = "2031-01-01",
+        isReleased = false,
+        providerUrl = null,
+        coverUrl = null,
+      ),
+    ),
   )
 
   private fun TestScope.registry(
@@ -379,43 +417,7 @@ class DefaultBookInfoRegistryTest {
     val owned = libraryItem(
       media = media(metadata = mediaMetadata(title = "The Way of Kings", ASIN = "B003P2WO5E")),
     )
-    provider.seriesResult = BookInfoResult.Success(
-      ProviderSeries(
-        providerSeriesId = "B005NB27MK",
-        name = "The Stormlight Archive",
-        isCompleted = null,
-        entries = listOf(
-          ProviderSeriesEntry(
-            providerBookId = "B003P2WO5E",
-            position = 1.0,
-            title = "The Way of Kings",
-            releaseDate = "2010-08-31",
-            isReleased = true,
-            providerUrl = null,
-            coverUrl = null,
-            asins = listOf("B003P2WO5E"),
-          ),
-          ProviderSeriesEntry(
-            providerBookId = "B00BWWSVPU",
-            position = 2.0,
-            title = "Words of Radiance",
-            releaseDate = "2014-03-04",
-            isReleased = true,
-            providerUrl = null,
-            coverUrl = null,
-          ),
-          ProviderSeriesEntry(
-            providerBookId = "B0UPCOMING",
-            position = 6.0,
-            title = "Untitled #6",
-            releaseDate = "2031-01-01",
-            isReleased = false,
-            providerUrl = null,
-            coverUrl = null,
-          ),
-        ),
-      ),
-    )
+    provider.seriesResult = BookInfoResult.Success(stormlightSeries)
     val registry = registry(provider)
 
     val state = registry
@@ -442,6 +444,115 @@ class DefaultBookInfoRegistryTest {
 
     assertThat((state as LoadState.Loaded).data.entries.size).isEqualTo(1)
     assertThat(provider.seriesRequests.size).isEqualTo(0)
+  }
+
+  @Test
+  fun `fetching series entries returns a definitive listing and caches it`() = runTest {
+    val provider = FakeBookInfoProvider()
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ASIN = "B003P2WO5E")),
+    )
+    provider.seriesResult = BookInfoResult.Success(stormlightSeries)
+    val registry = registry(provider)
+
+    val result = registry.fetchSeriesEntries("The Stormlight Archive", listOf(owned))
+    val again = registry.fetchSeriesEntries("The Stormlight Archive", listOf(owned))
+
+    val state = (result as SeriesFetchResult.Success).state
+    assertThat(state.providerId).isEqualTo(ProviderId.Hardcover)
+    assertThat(state.entries.map { it::class.simpleName })
+      .isEqualTo(listOf("Owned", "Missing", "Upcoming"))
+    // The second read serves the fresh cache without refetching.
+    assertThat(again).isInstanceOf(SeriesFetchResult.Success::class)
+    assertThat(provider.seriesRequests.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `fetching series entries serves a cached miss without refetching`() = runTest {
+    val provider = FakeBookInfoProvider()
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ASIN = "B003P2WO5E")),
+    )
+    val registry = registry(provider)
+
+    val result = registry.fetchSeriesEntries("The Stormlight Archive", listOf(owned))
+    val again = registry.fetchSeriesEntries("The Stormlight Archive", listOf(owned))
+
+    // A miss is still a definitive answer: the provider has no listing.
+    assertThat((result as SeriesFetchResult.Success).state.providerId).isNull()
+    assertThat((again as SeriesFetchResult.Success).state.providerId).isNull()
+    assertThat(provider.seriesRequests.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `fetching series entries is unavailable without identifiable members`() = runTest {
+    val provider = FakeBookInfoProvider()
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "Untracked", ISBN = null, ASIN = null)),
+    )
+    val registry = registry(provider)
+
+    val result = registry.fetchSeriesEntries("Mystery Series", listOf(owned))
+
+    assertThat(result).isEqualTo(SeriesFetchResult.Unavailable)
+    assertThat(provider.seriesRequests.size).isEqualTo(0)
+  }
+
+  @Test
+  fun `fetching series entries is unavailable without a series capable provider`() = runTest {
+    val provider = FakeBookInfoProvider(
+      capabilities = ProviderCapabilities(hasAggregateRating = true),
+    )
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ASIN = "B003P2WO5E")),
+    )
+    val registry = registry(provider)
+
+    val result = registry.fetchSeriesEntries("The Stormlight Archive", listOf(owned))
+
+    assertThat(result).isEqualTo(SeriesFetchResult.Unavailable)
+    assertThat(provider.seriesRequests.size).isEqualTo(0)
+  }
+
+  @Test
+  fun `fetching series entries reports fetch failures`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.seriesResult = BookInfoResult.Failure(Exception("boom"))
+    val owned = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ASIN = "B003P2WO5E")),
+    )
+    val registry = registry(provider)
+
+    val result = registry.fetchSeriesEntries("The Stormlight Archive", listOf(owned))
+
+    assertThat(result).isEqualTo(SeriesFetchResult.Error)
+  }
+
+  @Test
+  fun `fetching series entries refetches when member identifiers change`() = runTest {
+    val provider = FakeBookInfoProvider()
+    provider.seriesResult = BookInfoResult.Success(stormlightSeries)
+    val wayOfKings = libraryItem(
+      media = media(metadata = mediaMetadata(title = "The Way of Kings", ASIN = "B003P2WO5E")),
+    )
+    val wordsOfRadiance = libraryItem(
+      id = "item-2",
+      media = media(metadata = mediaMetadata(title = "Words of Radiance", ASIN = "B00BWWSVPU")),
+    )
+    val registry = registry(provider)
+
+    registry.fetchSeriesEntries("The Stormlight Archive", listOf(wayOfKings))
+    // Adding a book changes the match key, which invalidates the fresh row and
+    // must return the refetched listing, not the stale cached one.
+    val result = registry.fetchSeriesEntries(
+      "The Stormlight Archive",
+      listOf(wayOfKings, wordsOfRadiance),
+    )
+
+    assertThat(provider.seriesRequests.size).isEqualTo(2)
+    val state = (result as SeriesFetchResult.Success).state
+    assertThat(state.entries.map { it::class.simpleName })
+      .isEqualTo(listOf("Owned", "Owned", "Upcoming"))
   }
 
   @Test

--- a/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoRegistry.kt
+++ b/data/bookinfo/test/src/commonMain/kotlin/app/campfire/bookinfo/test/FakeBookInfoRegistry.kt
@@ -7,6 +7,7 @@ import app.campfire.bookinfo.api.BookInfoRegistry
 import app.campfire.bookinfo.api.CommunityInfoState
 import app.campfire.bookinfo.api.ProviderId
 import app.campfire.bookinfo.api.ProviderStatus
+import app.campfire.bookinfo.api.SeriesFetchResult
 import app.campfire.bookinfo.api.SeriesInfoState
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.model.LibraryItem
@@ -36,6 +37,21 @@ class FakeBookInfoRegistry : BookInfoRegistry {
   ): Flow<LoadState<out SeriesInfoState>> {
     seriesEntriesRequests += seriesName to ownedItems
     return seriesEntriesFlow
+  }
+
+  val fetchSeriesResults = mutableMapOf<String, SeriesFetchResult>()
+  val fetchSeriesRequests = mutableListOf<Pair<String, List<LibraryItem>>>()
+
+  /** Optional suspension point so tests can hold fetches mid-flight. */
+  var fetchSeriesGate: (suspend () -> Unit)? = null
+
+  override suspend fun fetchSeriesEntries(
+    seriesName: String,
+    ownedItems: List<LibraryItem>,
+  ): SeriesFetchResult {
+    fetchSeriesRequests += seriesName to ownedItems
+    fetchSeriesGate?.invoke()
+    return fetchSeriesResults[seriesName] ?: SeriesFetchResult.Unavailable
   }
 
   var clearCacheCount = 0


### PR DESCRIPTION
## Summary

Adds `BookInfoRegistry.fetchSeriesEntries(seriesName, ownedItems): SeriesFetchResult` — a one-shot, cache-respecting series lookup for bulk consumers, alongside the existing `observeSeriesEntries` flow.

The flow API can't drive a library-wide scan: it always emits the owned-only listing first with `providerId = null`, and a definitive "provider has no listing" answer also carries `providerId = null` — indistinguishable from "not asked yet". The new API returns a sealed result instead:

- `Success(state)` — definitive; a null `providerId` means the provider was asked and has no listing
- `Unavailable` — no series-capable provider, no session, or no identifier-bearing members
- `Error` — the fetch failed (network, rate limit) with nothing cached to serve

Cache behavior mirrors the flow path exactly (same key, invalid-link check, and staleness computation, 7-day hit / 1-hour miss TTLs). A fresh row — hit or miss — is served directly with no store round-trip. When refreshing, the implementation waits for the **fetcher-origin** Store5 emission: `stream(refresh = true)` re-emits the stale cached row (SourceOfTruth origin) before the fetcher lands, and without the origin filter a post-TTL rescan would return stale data and never surface fetch errors.

`FakeBookInfoRegistry` gains primed per-series results, a request recorder, and an optional suspension gate so consumers can test mid-flight scan states.

This is the seam the Discover library scan (next PR in the stack) builds on.

## Test plan

- [x] `:data:bookinfo:impl:jvmTest` — six new registry tests: fresh-cache hit fetches nothing; cached miss within its TTL returns `Success` with null providerId without fetching; unidentifiable members → `Unavailable` with no provider call; no series-capable provider → `Unavailable`; fetcher failure → `Error`; changed member identifiers invalidate the row and return the refetched listing
- [x] `:app:android:assembleAlphaRelease` + `:app:desktop:compileKotlin` (merged DI graphs)
- [x] `./scripts/ktlint --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu