### PR TITLE
Bake background-scan session learnings into the agent docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Campfire is an unofficial Kotlin Multiplatform native client for [Audiobookshelf
 ./gradlew iosSimulatorArm64Test                 # iOS tests
 
 # Generate module dependency graph (updates docs/architecture/MODULARIZATION.md)
-./gradlew moduleGraph
+./gradlew createModuleGraph
 
 # Store screenshots (phone | seven | ten) → fastlane/metadata/android (see tools/screenshots/README.md)
 tools/screenshots/run.py --class phone
@@ -112,6 +112,13 @@ fun MyUi(state: MyUiState, modifier: Modifier = Modifier) { /* ... */ }
 - `AppScope` - App-level singletons (APIs, database)
 - `UserScope` - Per-user instances (created on login, destroyed on logout)
 
+### Platform bindings (Kimchi/KSP)
+
+- A module whose `@Contributes*` annotations all live in commonMain uses `addKspDependencyForCommon(libs.kimchi.compiler)`. Adding a contribution in a platform sourceset (androidMain etc.) requires switching that module to `addKspDependencyForAllTargets` — and clean the module once after switching (stale metadata-target output lingers).
+- A platform sourceset can override a common binding in the same module with `@ContributesBinding(Scope::class, replaces = [CommonImpl::class])`; the platform target's merge sees both and drops the replaced one. Precedents: `AndroidDiscoverScanTracker` replaces `InProcessDiscoverScanTracker` (same module), `MediaRouterCastController` replaces `NoOpCastController` (cross-module).
+- After binding changes, confirm which implementation the graph constructs by grepping the generated merged component under `app/android/build/generated/ksp/<variant>/kotlin/kimchi/merge/`.
+- Framework-constructed objects (Services, WorkManager workers) resolve dependencies through `ComponentHolder` accessor interfaces (`@ContributesTo` on the scope), re-resolved fresh on each use — the `UserComponent` is rebuilt on every session change (see `AudioPlayerService`, `DiscoverScanWorker`).
+
 ## Code Coverage Requirements
 
 - **Minimum overall**: 50% line coverage
@@ -132,16 +139,27 @@ fun MyUi(state: MyUiState, modifier: Modifier = Modifier) { /* ... */ }
 
 Every PR that changes app behavior must include an entry in `CHANGELOG.md` under `## [Unreleased]`, in the most appropriate [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) category (Added / Changed / Deprecated / Removed / Fixed / Other Notes & Contributions). Write a single concise, user-facing line describing the change — no implementation details (e.g. "Offline playback failing when the server is unreachable", not "Split the ExoPlayer SimpleCache into download and streaming caches"). Update the changelog before opening the PR.
 
+The changelog describes what the user gets in the release, not the PR history: a feature shipped across multiple (often stacked) PRs keeps ONE entry covering the whole feature — the first PR adds the line, later PRs refine it (or leave it alone) rather than adding entries of their own.
+
 ## Database Migrations
 
 Schema lives in `data/db/core/src/commonMain/sqldelight/app/campfire/data/*.sq`; migrations live alongside in `migrations/{N}.sqm` and the baseline schema dump is `app/campfire/databases/1.db`. SQLDelight's `verifyCommonMainCampfireDatabaseMigration` task compares the migrated database against the fresh `.sq` schema — any drift fails the build.
 
-Whenever you change a `.sq` file, reflect the change in a `.sqm`:
+Danger fails any PR touching a `.sq` file that doesn't also touch a `.sqm`, unless the PR carries the `ignore-db-change` label. When a PR touches `.sq` files, pick the branch that matches:
 
-- **If the latest `.sqm` is newer than the most recent GitHub release/tag (i.e. not yet shipped)**: fold the change into that file. Users mid-upgrade only run unshipped migrations once. Check with `git log <latest-tag>..HEAD -- data/db/core/.../migrations/`.
-- **Otherwise**: create a new `{N+1}.sqm` with the additive change.
+- **Query-only change** (added/edited statements, table shapes untouched): no migration needed — add the `ignore-db-change` label to the PR.
+- **Schema change in a database without migrations** (e.g. `BookInfoDatabase`, which versions by file name and rebuilds destructively): add the `ignore-db-change` label.
+- **Schema change in the main Campfire database** — reflect it in a `.sqm` (which also satisfies Danger, no label):
+  - **If the latest `.sqm` is newer than the most recent GitHub release/tag (i.e. not yet shipped)**: fold the change into that file. Users mid-upgrade only run unshipped migrations once. Check with `git log <latest-tag>..HEAD -- data/db/core/.../migrations/`.
+  - **Otherwise**: create a new `{N+1}.sqm` with the additive change.
 
 Run `./gradlew :data:db:core:verifyCommonMainCampfireDatabaseMigration` after any schema or migration edit to confirm parity. SQLDelight is strict about column ordinal positions — adding a column mid-table requires a full `CREATE TABLE ... _new` + copy + `DROP` + `RENAME`, not `ALTER TABLE ADD COLUMN`.
+
+## Android Background Work & Notifications
+
+- Long-running background jobs are regular unique WorkManager work with a guarded `setForeground` promotion (`DiscoverScanWorker` is the template: userId validation against the restored session, `NonCancellable` finally for terminal persistence, a `Scoped` multibinding cancelling the unique work on logout). Regular work, not expedited — on minSdk 31 expedited work runs as a job whose notification never shows. Declare the FGS type by merging it onto WorkManager's `SystemForegroundService` in the module's androidMain manifest (`tools:node="merge"`).
+- Notification ids and channels are one app-wide ledger — claim the next free id and record it here: 100 playback (`app.campfire.notifications.playback`), 101 downloads (`app.campfire.notifications.download`), 102 scan progress + 103 scan completed (`app.campfire.notifications.scan`).
+- A notification tap-through to a screen gets a release-safe deep link: a `campfire_`-prefixed extra in `DeepLinkKeys`, parsed in the non-automation branch of `Intent.toDeepLink`, handled in `LoggedIn.kt`. Give each PendingIntent its own request code — `Intent.filterEquals` ignores extras, so same-code PendingIntents to `MainActivity` clobber each other.
 
 ## Pre-commit Hook
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -11,6 +11,8 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`
 
+- **Edit a PR**: `gh pr edit` fails in this repo (it queries the deprecated projectCards GraphQL field). Update title/body via `gh api -X PATCH repos/{owner}/{repo}/pulls/<n> -F body=@file.md`; add/remove PR labels via `gh issue edit <n> --add-label ...` (issues and PRs share one number space and the issues API handles PR labels).
+
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
 ## Pull requests as a triage surface


### PR DESCRIPTION
## Summary

Recovery PR: this commit was pushed to `discover/02-background-scan` just after #1040 was squash-merged, so it re-created the deleted branch instead of landing in main. Cherry-picked onto main unchanged.

- **Database Migrations** becomes a decision tree matching the Danger `.sq` check: query-only changes and schema changes in migration-less databases (e.g. `BookInfoDatabase`) take the `ignore-db-change` label; main-db schema changes fold into an unshipped `.sqm` or add `{N+1}.sqm` (which satisfies Danger without a label).
- **Changelog**: one entry per feature, not per PR — multi-PR features keep a single user-facing line that later PRs refine.
- **Platform bindings (Kimchi/KSP)** (new section): per-target KSP switch for platform-sourceset contributions, same-module `replaces` bindings, verifying the generated merged component, `ComponentHolder` accessors for framework-constructed objects.
- **Android Background Work & Notifications** (new section): regular unique work + guarded `setForeground` (not expedited), FGS type via manifest merge, the notification id/channel ledger (100–103), release-safe deep-link conventions, distinct PendingIntent request codes.
- **docs/agents/issue-tracker.md**: `gh pr edit` fails on this repo — use the REST PATCH for title/body and `gh issue edit` for PR labels.
- Fix the module graph command: the task is `createModuleGraph`, not `moduleGraph`.

## Test plan

- [x] Docs-only; content references (`DiscoverScanWorker`, `AndroidDiscoverScanTracker`, notification ids) verified present on main after the #1040 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX5QLNDCKshC3Pre7nJudu