### PR TITLE
Show the book title in Android Auto and the media notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Android Auto and the media notification now show the book title with the chapter instead of only the chapter and author
 - Playback timing and progress showing blank after reopening the app until playback started
 - End-of-chapter sleep timer not stopping at chapter boundaries while casting
 - Cast playback stopping after about an hour (fixed on servers running Audiobookshelf 2.22.0 or newer)

--- a/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaItemBuilder.kt
+++ b/infra/audioplayer/impl/src/androidMain/kotlin/app/campfire/audioplayer/impl/MediaItemBuilder.kt
@@ -48,7 +48,11 @@ fun MediaItem.asPlatformMediaItem(context: Context): PlatformMediaItem {
         setMediaMetadata(
           MediaMetadata.Builder()
             .setTitle(metadata.title)
-            .setArtist(metadata.artist)
+            // Android Auto and the system media notification only render title + artist,
+            // so surface the book/podcast name in the artist slot (instead of the author)
+            // and keep the real author in albumArtist for hosts that show album metadata.
+            .setArtist(metadata.albumTitle ?: metadata.artist)
+            .setAlbumArtist(metadata.artist)
             .setMediaType(MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
             .setDescription(metadata.description)
             .setSubtitle(metadata.subtitle)


### PR DESCRIPTION
## Summary

Android Auto's now-playing view (and the system media notification) only render **title + artist**, biasing toward music layouts — so the book title, which we carry in `albumTitle`, was never shown (only chapter + author).

This swaps the metadata at the Android platform-conversion layer (`asPlatformMediaItem`):
- **artist** now carries the book/podcast name (`albumTitle`, falling back to the author when absent)
- **albumArtist** keeps the real author for hosts that render album metadata

Doing it in the platform mapping (rather than the common `MediaItemBuilder`) covers every Android surface with one change — the chapter queue, track-only queues, the HLS single-stream path (`ChapterWindowForwardingPlayer` builds chapter metadata on the base item, so it inherits the swap), podcasts (episode title + podcast name), and the media notification — while leaving iOS, desktop, and Cast metadata untouched.

Tested on Android Auto and it renders the book title alongside the chapter as expected.

Fixes #1035
<img width="1716" height="557" alt="Screenshot 2026-09-02 at 10 27 14 PM" src="https://github.com/user-attachments/assets/657848ad-e22c-408f-a044-8dcd704d3f45" />


