### PR TITLE
Improve automatic rewind ranges to be more sensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upcoming-release scans now run in the background on Android with a progress notification, and scan results survive app restarts on all platforms
+- Automatic rewind ranges are now 0s-2m and ignore pauses now increased to 30s max
 
 ### Deprecated
 
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cast playback stopping after about an hour (fixed on servers running Audiobookshelf 2.22.0 or newer)
 - App widgets breaking due to large image size
 - Cast devices not appearing reliably, including the cast button vanishing after rotating the screen
-- Selecting a cast device could hang audio playback until the app was restarted
 - Audiobooks not playing on Chromecast
 
 ### Other Notes & Contributions

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/ResumeRewindTier.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/ResumeRewindTier.kt
@@ -38,16 +38,16 @@ data class ResumeRewindConfig(
     val Default = ResumeRewindConfig(
       minPauseThreshold = 5.seconds,
       minRewind = 5.seconds,
-      maxRewind = 2.minutes,
+      maxRewind = 1.minutes,
     )
   }
 }
 
 /** The allowed range for [ResumeRewindConfig.minPauseThreshold]. */
-val MinPauseThresholdRange: ClosedRange<Duration> = Duration.ZERO..10.seconds
+val MinPauseThresholdRange: ClosedRange<Duration> = Duration.ZERO..30.seconds
 
 /** The allowed range for the rewind amount (both ends of the [ResumeRewindConfig] range slider). */
-val ResumeRewindRange: ClosedRange<Duration> = Duration.ZERO..5.minutes
+val ResumeRewindRange: ClosedRange<Duration> = Duration.ZERO..2.minutes
 
 /**
  * The fixed pause-duration checkpoints, above the configurable [ResumeRewindConfig.minPauseThreshold], across


### PR DESCRIPTION
<!--
Thanks for contributing to Campfire! Please fill out the sections below.
Feel free to delete sections that don't apply.
-->
## Summary
<!-- What does this PR do and why? Keep it short — 1-3 bullets. -->
Rewind range is now 0s - 2min instead of 0s - 5min
Max "Ignore pauses under" is now 30s instead of 10s