### PR TITLE
Cache stats responses with a TTL + top-bar refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Automatic rewind ranges are now 0s-2m and ignore pauses now increased to 30s max
+- Statistics now load instantly from a short-lived cache, with a refresh button in the top bar to fetch the latest numbers
 
 ### Deprecated
 

--- a/data/network/test/src/commonMain/kotlin/app/campfire/network/test/FakeAudioBookShelfApi.kt
+++ b/data/network/test/src/commonMain/kotlin/app/campfire/network/test/FakeAudioBookShelfApi.kt
@@ -36,6 +36,14 @@ import app.campfire.network.models.User
 
 class FakeAudioBookShelfApi : AudioBookShelfApi {
 
+  var listeningStatsResult: suspend () -> Result<ListeningStats> = {
+    Result.failure(NotImplementedError("Set listeningStatsResult on the fake"))
+  }
+
+  var libraryStatsResult: suspend (libraryId: String) -> Result<LibraryStats> = {
+    Result.failure(NotImplementedError("Set libraryStatsResult on the fake"))
+  }
+
   override suspend fun getCurrentUser(): Result<User> {
     TODO("Not yet implemented")
   }
@@ -64,7 +72,7 @@ class FakeAudioBookShelfApi : AudioBookShelfApi {
   }
 
   override suspend fun getLibraryStats(libraryId: String): Result<LibraryStats> {
-    TODO("Not yet implemented")
+    return libraryStatsResult(libraryId)
   }
 
   override suspend fun getPersonalizedHome(libraryId: String): Result<List<Shelf>> {
@@ -330,7 +338,7 @@ class FakeAudioBookShelfApi : AudioBookShelfApi {
   }
 
   override suspend fun getListeningStats(): Result<ListeningStats> {
-    TODO("Not yet implemented")
+    return listeningStatsResult()
   }
 
   override suspend fun getFilterData(libraryId: String): Result<FilterData> {

--- a/features/stats/api/src/commonMain/kotlin/app/campfire/stats/api/StatsRepository.kt
+++ b/features/stats/api/src/commonMain/kotlin/app/campfire/stats/api/StatsRepository.kt
@@ -11,4 +11,12 @@ interface StatsRepository {
 
   fun getLibraryStats(): Flow<LibraryStats>
   fun getUserStats(): Flow<ListeningStats>
+
+  /**
+   * Force-refetch both the user listening stats and the current library's stats from
+   * the server, updating any active [getUserStats]/[getLibraryStats] collectors with
+   * the fresh data. Returns a failure instead of throwing so callers can keep showing
+   * the cached data when the server is unreachable.
+   */
+  suspend fun refresh(): Result<Unit>
 }

--- a/features/stats/impl/build.gradle.kts
+++ b/features/stats/impl/build.gradle.kts
@@ -22,6 +22,16 @@ kotlin {
         implementation(projects.features.user.api)
       }
     }
+
+    commonTest {
+      dependencies {
+        implementation(projects.data.account.test)
+        implementation(projects.data.network.test)
+        implementation(projects.features.user.test)
+        implementation(libs.bundles.test.common)
+        implementation(libs.bundles.test.impl)
+      }
+    }
   }
 }
 

--- a/features/stats/impl/src/commonMain/kotlin/app/campfire/stats/NetworkStatsRepository.kt
+++ b/features/stats/impl/src/commonMain/kotlin/app/campfire/stats/NetworkStatsRepository.kt
@@ -4,51 +4,140 @@
 package app.campfire.stats
 
 import app.campfire.account.api.UrlHydrator
+import app.campfire.core.di.SingleIn
 import app.campfire.core.di.UserScope
+import app.campfire.core.model.LibraryId
 import app.campfire.core.model.LibraryStats
 import app.campfire.core.model.ListeningStats
+import app.campfire.core.time.FatherTime
 import app.campfire.data.mapping.asDomainModel
 import app.campfire.network.AudioBookShelfApi
 import app.campfire.stats.api.StatsRepository
 import app.campfire.user.api.UserRepository
 import com.r0adkll.kimchi.annotations.ContributesBinding
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import me.tatarka.inject.annotations.Inject
 
+@SingleIn(UserScope::class)
 @ContributesBinding(UserScope::class)
 @Inject
 class NetworkStatsRepository(
   private val api: AudioBookShelfApi,
   private val userRepository: UserRepository,
   private val urlHydrator: UrlHydrator,
+  private val fatherTime: FatherTime,
 ) : StatsRepository {
+
+  private val userStatsCache = MutableStateFlow<Cached<ListeningStats>?>(null)
+  private val userStatsMutex = Mutex()
+
+  private val libraryStatsCache = MutableStateFlow<Map<LibraryId, Cached<LibraryStats>>>(emptyMap())
+  private val libraryStatsMutex = Mutex()
+
+  override fun getUserStats(): Flow<ListeningStats> {
+    return flow {
+      if (userStatsCache.value.isExpired(UserStatsTtl)) {
+        try {
+          fetchUserStats(force = false)
+        } catch (e: Exception) {
+          // Serve the stale cache when the server is unreachable; only fail
+          // when there is nothing to show at all
+          if (userStatsCache.value == null) throw e
+        }
+      }
+      emitAll(
+        userStatsCache
+          .filterNotNull()
+          .map { it.value },
+      )
+    }
+  }
 
   @OptIn(ExperimentalCoroutinesApi::class)
   override fun getLibraryStats(): Flow<LibraryStats> {
     return userRepository.observeCurrentUser()
-      .flatMapLatest { user ->
+      .map { it.selectedLibraryId }
+      .distinctUntilChanged()
+      .flatMapLatest { libraryId ->
         flow {
-          val result = api.getLibraryStats(user.selectedLibraryId)
-          if (result.isSuccess) {
-            emit(result.getOrThrow().asDomainModel(urlHydrator))
-          } else {
-            throw result.exceptionOrNull()!!
+          if (libraryStatsCache.value[libraryId].isExpired(LibraryStatsTtl)) {
+            try {
+              fetchLibraryStats(libraryId, force = false)
+            } catch (e: Exception) {
+              if (libraryStatsCache.value[libraryId] == null) throw e
+            }
           }
+          emitAll(
+            libraryStatsCache
+              .mapNotNull { it[libraryId]?.value }
+              .distinctUntilChanged(),
+          )
         }
       }
   }
 
-  override fun getUserStats(): Flow<ListeningStats> {
-    return flow {
-      val result = api.getListeningStats()
-      if (result.isSuccess) {
-        emit(result.getOrThrow().asDomainModel(urlHydrator))
-      } else {
-        throw result.exceptionOrNull()!!
+  override suspend fun refresh(): Result<Unit> = runCatching {
+    coroutineScope {
+      val userStats = async { fetchUserStats(force = true) }
+      val libraryStats = async {
+        val libraryId = userRepository.observeCurrentUser().first().selectedLibraryId
+        fetchLibraryStats(libraryId, force = true)
       }
+      userStats.await()
+      libraryStats.await()
     }
+  }
+
+  private suspend fun fetchUserStats(force: Boolean) {
+    userStatsMutex.withLock {
+      // Freshness is re-checked under the lock so concurrent collectors coalesce
+      // into a single fetch instead of racing duplicate requests
+      if (!force && !userStatsCache.value.isExpired(UserStatsTtl)) return
+
+      val stats = api.getListeningStats().getOrThrow().asDomainModel(urlHydrator)
+      userStatsCache.value = Cached(stats, fatherTime.nowInEpochMillis())
+    }
+  }
+
+  private suspend fun fetchLibraryStats(libraryId: LibraryId, force: Boolean) {
+    libraryStatsMutex.withLock {
+      if (!force && !libraryStatsCache.value[libraryId].isExpired(LibraryStatsTtl)) return
+
+      val stats = api.getLibraryStats(libraryId).getOrThrow().asDomainModel(urlHydrator)
+      libraryStatsCache.value = libraryStatsCache.value +
+        (libraryId to Cached(stats, fatherTime.nowInEpochMillis()))
+    }
+  }
+
+  private fun Cached<*>?.isExpired(ttl: Duration): Boolean {
+    if (this == null) return true
+    return fatherTime.nowInEpochMillis() - fetchedAtMillis > ttl.inWholeMilliseconds
+  }
+
+  private data class Cached<T>(
+    val value: T,
+    val fetchedAtMillis: Long,
+  )
+
+  companion object {
+    val UserStatsTtl = 5.minutes
+    val LibraryStatsTtl = 1.hours
   }
 }

--- a/features/stats/impl/src/commonTest/kotlin/app/campfire/stats/NetworkStatsRepositoryTest.kt
+++ b/features/stats/impl/src/commonTest/kotlin/app/campfire/stats/NetworkStatsRepositoryTest.kt
@@ -1,0 +1,177 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.stats
+
+import app.campfire.account.test.FakeUrlHydrator
+import app.campfire.core.time.FatherTime
+import app.campfire.network.models.LibraryStats
+import app.campfire.network.models.ListeningStats
+import app.campfire.network.test.FakeAudioBookShelfApi
+import app.campfire.user.test.FakeUserRepository
+import app.campfire.user.test.fixtures.user
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+class NetworkStatsRepositoryTest {
+
+  private val api = FakeAudioBookShelfApi()
+  private val userRepository = FakeUserRepository()
+  private val fatherTime = FakeFatherTime()
+
+  private val repository = NetworkStatsRepository(
+    api = api,
+    userRepository = userRepository,
+    urlHydrator = FakeUrlHydrator(),
+    fatherTime = fatherTime,
+  )
+
+  private var userStatsFetches = 0
+  private var libraryStatsFetches = 0
+
+  init {
+    userRepository.currentUserFlow.tryEmit(user("fake_user_id"))
+    api.listeningStatsResult = {
+      userStatsFetches++
+      Result.success(networkListeningStats(totalTime = userStatsFetches.toFloat()))
+    }
+    api.libraryStatsResult = {
+      libraryStatsFetches++
+      Result.success(networkLibraryStats(totalItems = libraryStatsFetches))
+    }
+  }
+
+  @Test
+  fun `user stats are served from the cache within the ttl`() = runTest {
+    assertThat(repository.getUserStats().first().totalTime).isEqualTo(1.seconds)
+
+    fatherTime.nowMillis += NetworkStatsRepository.UserStatsTtl.inWholeMilliseconds - 1
+
+    assertThat(repository.getUserStats().first().totalTime).isEqualTo(1.seconds)
+    assertThat(userStatsFetches).isEqualTo(1)
+  }
+
+  @Test
+  fun `user stats are refetched after the ttl expires`() = runTest {
+    repository.getUserStats().first()
+
+    fatherTime.nowMillis += NetworkStatsRepository.UserStatsTtl.inWholeMilliseconds + 1
+
+    assertThat(repository.getUserStats().first().totalTime).isEqualTo(2.seconds)
+    assertThat(userStatsFetches).isEqualTo(2)
+  }
+
+  @Test
+  fun `stale user stats are served when the refetch fails`() = runTest {
+    repository.getUserStats().first()
+
+    fatherTime.nowMillis += NetworkStatsRepository.UserStatsTtl.inWholeMilliseconds + 1
+    api.listeningStatsResult = { Result.failure(RuntimeException("server unreachable")) }
+
+    assertThat(repository.getUserStats().first().totalTime).isEqualTo(1.seconds)
+  }
+
+  @Test
+  fun `user stats fail when there is no cache and the fetch fails`() = runTest {
+    api.listeningStatsResult = { Result.failure(RuntimeException("server unreachable")) }
+
+    assertThat(
+      runCatching { repository.getUserStats().first() },
+    ).isFailure()
+  }
+
+  @Test
+  fun `refresh forces a refetch within the ttl and updates active collectors`() = runTest {
+    repository.getUserStats().test {
+      assertThat(awaitItem().totalTime).isEqualTo(1.seconds)
+
+      val result = repository.refresh()
+
+      assertThat(result.isSuccess).isEqualTo(true)
+      assertThat(awaitItem().totalTime).isEqualTo(2.seconds)
+      assertThat(userStatsFetches).isEqualTo(2)
+      assertThat(libraryStatsFetches).isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun `refresh returns failure and keeps the cache when the fetch fails`() = runTest {
+    repository.getUserStats().first()
+    repository.getLibraryStats().first()
+
+    api.listeningStatsResult = { Result.failure(RuntimeException("server unreachable")) }
+
+    val result = repository.refresh()
+
+    assertThat(result.isFailure).isEqualTo(true)
+    assertThat(repository.getUserStats().first().totalTime).isEqualTo(1.seconds)
+  }
+
+  @Test
+  fun `library stats are served from the cache within the ttl`() = runTest {
+    assertThat(repository.getLibraryStats().first().totalItems).isEqualTo(1)
+
+    fatherTime.nowMillis += NetworkStatsRepository.LibraryStatsTtl.inWholeMilliseconds - 1
+
+    assertThat(repository.getLibraryStats().first().totalItems).isEqualTo(1)
+    assertThat(libraryStatsFetches).isEqualTo(1)
+  }
+
+  @Test
+  fun `library stats are refetched after the ttl expires`() = runTest {
+    repository.getLibraryStats().first()
+
+    fatherTime.nowMillis += NetworkStatsRepository.LibraryStatsTtl.inWholeMilliseconds + 1
+
+    assertThat(repository.getLibraryStats().first().totalItems).isEqualTo(2)
+    assertThat(libraryStatsFetches).isEqualTo(2)
+  }
+}
+
+private class FakeFatherTime(
+  var nowMillis: Long = 0L,
+) : FatherTime {
+  override fun now(): LocalDateTime =
+    Instant.fromEpochMilliseconds(nowMillis).toLocalDateTime(TimeZone.UTC)
+
+  override fun today(): LocalDate = now().date
+
+  override fun nowInEpochMillis(): Long = nowMillis
+}
+
+private fun networkListeningStats(
+  totalTime: Float = 0f,
+) = ListeningStats(
+  totalTime = totalTime,
+  today = 0f,
+  days = emptyMap(),
+  dayOfWeek = emptyMap(),
+  items = emptyMap(),
+  recentSessions = emptyList(),
+)
+
+private fun networkLibraryStats(
+  totalItems: Int = 0,
+) = LibraryStats(
+  largestItems = emptyList(),
+  totalAuthors = null,
+  authorsWithCount = null,
+  totalGenres = 0,
+  genresWithCount = emptyList(),
+  totalItems = totalItems,
+  longestItems = emptyList(),
+  totalSize = 0L,
+  totalDuration = 0.0,
+  numAudioTracks = 0,
+)

--- a/features/stats/ui/src/commonMain/composeResources/values/user_stats_ui_strings.xml
+++ b/features/stats/ui/src/commonMain/composeResources/values/user_stats_ui_strings.xml
@@ -36,5 +36,6 @@
   <string name="stats_library">Library</string>
 
   <string name="action_back">Back</string>
+  <string name="action_refresh">Refresh</string>
   <string name="action_toggle_dark_mode">Toggle dark mode</string>
 </resources>

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsPresenter.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsPresenter.kt
@@ -6,7 +6,10 @@ package app.campfire.stats.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import app.campfire.common.screens.AuthorDetailScreen
 import app.campfire.common.screens.StatisticsScreen
 import app.campfire.core.coroutines.DispatcherProvider
@@ -34,6 +37,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
@@ -74,15 +78,33 @@ class StatsPresenter(
       }.catch<LoadState<out List<StatsUiModel>>> { emit(LoadState.Error) }
     }.collectAsState(LoadState.Loading)
 
+    val scope = rememberCoroutineScope()
+    var isRefreshing by remember { mutableStateOf(false) }
+
     return StatsUiState(
       libraryStats = libraryStats,
       listeningStats = listeningStats,
+      isRefreshing = isRefreshing,
     ) { event ->
       when (event) {
         StatsUiEvent.Back -> navigator.pop()
         is StatsUiEvent.ItemClick -> navigator.goTo(LibraryItemScreen(event.itemId))
         is StatsUiEvent.AuthorClick -> navigator.goTo(AuthorDetailScreen(event.authorId, event.authorName))
         is StatsUiEvent.SessionClick -> navigator.goTo(LibraryItemScreen(event.session.libraryItemId))
+        StatsUiEvent.Refresh -> {
+          if (!isRefreshing) {
+            scope.launch {
+              isRefreshing = true
+              try {
+                // Failures keep showing the cached stats; active collectors
+                // receive the fresh data on success
+                statsRepository.refresh()
+              } finally {
+                isRefreshing = false
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
@@ -13,11 +13,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -79,6 +82,7 @@ import app.campfire.stats.ui.composables.WeeklyListeningCard
 import app.campfire.stats.ui.composables.showFinishedThisYearBottomSheet
 import campfire.features.stats.ui.generated.resources.Res
 import campfire.features.stats.ui.generated.resources.action_back
+import campfire.features.stats.ui.generated.resources.action_refresh
 import campfire.features.stats.ui.generated.resources.stats_library
 import campfire.features.stats.ui.generated.resources.stats_user
 import campfire.features.stats.ui.generated.resources.user_stats_error_message
@@ -137,6 +141,12 @@ fun StatsUi(
               }
             }
           },
+          actions = {
+            RefreshAction(
+              isRefreshing = state.isRefreshing,
+              onClick = { state.eventSink(StatsUiEvent.Refresh) },
+            )
+          },
         )
       } else {
         CampfireTopAppBar(
@@ -157,6 +167,12 @@ fun StatsUi(
                 Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = backLabel)
               }
             }
+          },
+          actions = {
+            RefreshAction(
+              isRefreshing = state.isRefreshing,
+              onClick = { state.eventSink(StatsUiEvent.Refresh) },
+            )
           },
         )
       }
@@ -199,6 +215,33 @@ fun StatsUi(
           )
         },
       )
+    }
+  }
+}
+
+@Composable
+private fun RefreshAction(
+  isRefreshing: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val refreshLabel = stringResource(Res.string.action_refresh)
+  IconButtonTooltip(
+    text = refreshLabel,
+    modifier = modifier,
+  ) {
+    IconButton(
+      onClick = onClick,
+      enabled = !isRefreshing,
+    ) {
+      if (isRefreshing) {
+        CircularProgressIndicator(
+          strokeWidth = 2.dp,
+          modifier = Modifier.size(24.dp),
+        )
+      } else {
+        Icon(Icons.Rounded.Refresh, contentDescription = refreshLabel)
+      }
     }
   }
 }

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
@@ -128,7 +128,6 @@ fun StatsUi(
                 isUser = isUserStats,
                 onChange = { isUserStats = it },
               )
-              Spacer(Modifier.width(16.dp))
             }
           },
           navigationIcon = {

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUiState.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUiState.kt
@@ -23,6 +23,7 @@ import org.jetbrains.compose.resources.StringResource
 data class StatsUiState(
   val libraryStats: LoadState<out List<StatsUiModel>>,
   val listeningStats: LoadState<out List<StatsUiModel>>,
+  val isRefreshing: Boolean,
   val eventSink: (StatsUiEvent) -> Unit,
 ) : CircuitUiState
 
@@ -138,4 +139,5 @@ sealed interface StatsUiEvent : CircuitUiEvent {
   data class ItemClick(val itemId: LibraryItemId) : StatsUiEvent
   data class AuthorClick(val authorId: AuthorId, val authorName: String) : StatsUiEvent
   data class SessionClick(val session: PlaybackSession) : StatsUiEvent
+  data object Refresh : StatsUiEvent
 }


### PR DESCRIPTION
## Summary

- **`NetworkStatsRepository` is now a `@SingleIn(UserScope)` singleton with in-memory TTL caches**: user listening stats for **5 minutes** (they change as you listen), per-library stats for **1 hour** (library totals change rarely). Re-entering the Statistics page within the TTL renders instantly from cache; the finished-this-year sheet's book-metadata lookup benefits too since it reads the same cached user stats.
- **Graceful degradation**: when a refetch fails, collectors are served the stale cache instead of an error — the error state only appears when there is nothing cached at all. Concurrent collectors coalesce into a single request via a mutex-guarded freshness re-check.
- **Refresh action in the top bar** (both single- and two-pane layouts): force-refetches user + library stats concurrently and streams fresh data into active collectors; the icon swaps to a progress spinner while in flight. Chose a top-bar action over pull-to-refresh since the `exitUntilCollapsed` medium top bar makes the pull gesture ambiguous.
- **`StatsRepository.refresh(): Result<Unit>`** added to the api; `FakeAudioBookShelfApi` stats methods made configurable for testing.

## Testing

- New `NetworkStatsRepositoryTest` (8 tests): TTL serve/expiry for both caches, stale-serve on fetch failure, failure with empty cache, refresh forcing a refetch and updating active collectors (turbine), refresh failure keeping the cache.
- `:features:stats:impl:jvmTest` + `:features:stats:ui:compileKotlinJvm` + ktlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)