### PR TITLE
Make the sleep timer scrim cover the whole expanded cover art

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End-of-chapter sleep timer not stopping at chapter boundaries while casting
 - Cast playback stopping after about an hour (fixed on servers running Audiobookshelf 2.22.0 or newer)
 - App widgets breaking due to large image size
+- Sleep timer countdown scrim on the playing screen's cover art not covering the whole cover
 - Cast devices not appearing reliably, including the cast button vanishing after rotating the screen
 - Audiobooks not playing on Chromecast
 

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ExpandedItemImage.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ExpandedItemImage.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -71,16 +69,18 @@ internal fun SharedTransitionScope.ExpandedItemImage(
         ),
     )
 
+    // Callers size the cover through the slot (size == Dp.Unspecified), so the scrim has to match
+    // the parent rather than request [size] itself, and it clips to the same [shape] as the cover.
     AnimatedVisibility(
       visible = runningTimer != null,
       enter = fadeIn() + expandIn(expandFrom = Alignment.Center),
-      modifier = Modifier.size(size),
+      modifier = Modifier.matchParentSize(),
     ) {
       Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
-          .size(size)
-          .background(Color.Black.copy(0.3f), RoundedCornerShape(32.dp)),
+          .fillMaxSize()
+          .background(Color.Black.copy(0.3f), shape),
       ) {
         if (runningTimer?.isShakeToRestartEnabled == true) {
           Icon(


### PR DESCRIPTION
## What

The sleep timer countdown overlay on the expanded player's cover art only shaded the area behind the countdown text instead of the whole cover.

## Why

`ExpandedItemImage` sized the overlay with `Modifier.size(size)`, but both `ExpandedPlaybackBar` and `SmallExpandedPlaybackBar` pass `Dp.Unspecified` and size the cover through its `weight`/`aspectRatio` slot. `size(Dp.Unspecified)` degrades to wrap-content, so the scrim shrank to its content. The scrim also used a hardcoded 32dp corner radius that didn't match the cover's `shape`.

## Fix

The overlay now uses `matchParentSize()` and clips to the same `shape` the cover is clipped to.

## Verification

`:features:sessions:ui:compileKotlinJvm` green, ktlint clean. UI-only change, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
