### PR TITLE
Fix stray download button on item detail while playing or downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Item detail showing a stray download button while the item is playing or already downloading, and a mismatched play button shape while a download is in progress
+
 ### Other Notes & Contributions
 
 ## [1.1.0]

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/PlayAndDownloadButtons.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/composables/PlayAndDownloadButtons.kt
@@ -78,12 +78,19 @@ internal fun PlayAndDownloadButtons(
     val hasOfflineDownload = offlineDownload?.state != null &&
       offlineDownload.state != OfflineDownload.State.None
 
+    // The trailing button is either the play-options menu (HLS-capable servers) or a plain
+    // download button. It never shows for ebooks, the menu is pointless while this item is
+    // already playing, and the download button never shows once a download record exists.
+    val showPlayOptionsMenu = canStreamHls && !isCurrentSession && !isEbookOnly
+    val showDownloadButton = !showPlayOptionsMenu && !hasOfflineDownload && !isEbookOnly
+    val showTrailingButton = showPlayOptionsMenu || showDownloadButton
+
     val size = ButtonDefaults.MediumContainerHeight
     val splitButtonRadius = 4.dp
     val pressedSplitButtonRadius = 6.dp
-    val pressedCornerRadius = if (hasOfflineDownload) pressedSplitButtonRadius else 12.dp
+    val pressedCornerRadius = if (showTrailingButton) pressedSplitButtonRadius else 12.dp
     val endCornerRadius by animateDpAsState(
-      targetValue = if (hasOfflineDownload || isEbookOnly) size / 2 else splitButtonRadius,
+      targetValue = if (showTrailingButton) splitButtonRadius else size / 2,
     )
 
     Button(
@@ -136,11 +143,11 @@ internal fun PlayAndDownloadButtons(
     Spacer(Modifier.width(2.dp))
 
     AnimatedVisibility(
-      visible = (!hasOfflineDownload && !isEbookOnly) || canStreamHls,
+      visible = showTrailingButton,
       enter = expandHorizontally(),
       exit = shrinkHorizontally(),
     ) {
-      if (canStreamHls && !isCurrentSession) {
+      if (showPlayOptionsMenu) {
         var expanded by remember { mutableStateOf(false) }
         val trailingButtonRadius by animateDpAsState(
           if (expanded) 20.dp else splitButtonRadius,

--- a/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/composables/slots/ExpressiveControlSlotTest.kt
+++ b/features/libraries/ui/src/commonTest/kotlin/app/campfire/libraries/ui/detail/composables/slots/ExpressiveControlSlotTest.kt
@@ -137,7 +137,131 @@ class ExpressiveControlSlotTest {
     onNodeWithTag("offline_status_title").assertExists()
     onNodeWithText("Downloading").assertIsDisplayed()
     onNodeWithTag("indeterminate_progress_bar").assertIsDisplayed()
+    onNodeWithTag("button_download").assertDoesNotExist()
   }
+
+  @Test
+  fun hlsShowsPlayOptionsMenuInsteadOfDownloadButton() = runComposeUiTest {
+    val slot = ExpressiveControlSlot(
+      libraryItem = libraryItem(),
+      offlineDownload = null,
+      mediaProgress = null,
+      isCurrentSession = false,
+      isQueued = false,
+      hasSession = false,
+      addToPlaylistDialog = AddToPlaylistDialog.NoOp,
+      showConfirmDownloadDialogSetting = false,
+      canStreamHls = true,
+    )
+
+    setCampfireContent {
+      slot.Content(Modifier) {}
+    }
+
+    onNodeWithTag("button_download").assertExists()
+    onNodeWithContentDescription("More options").assertExists()
+    onNodeWithContentDescription("Download").assertDoesNotExist()
+  }
+
+  @Test
+  fun hlsKeepsPlayOptionsMenuWhileDownloading() = runComposeUiTest {
+    val slot = ExpressiveControlSlot(
+      libraryItem = libraryItem(),
+      offlineDownload = downloadingOfflineDownload(),
+      mediaProgress = null,
+      isCurrentSession = false,
+      isQueued = false,
+      hasSession = false,
+      addToPlaylistDialog = AddToPlaylistDialog.NoOp,
+      showConfirmDownloadDialogSetting = false,
+      canStreamHls = true,
+    )
+
+    setCampfireContent {
+      slot.Content(Modifier) {}
+    }
+
+    onNodeWithContentDescription("More options").assertExists()
+    onNodeWithContentDescription("Download").assertDoesNotExist()
+  }
+
+  @Test
+  fun hlsCurrentSessionWithoutDownloadShowsDownloadButton() = runComposeUiTest {
+    val slot = ExpressiveControlSlot(
+      libraryItem = libraryItem(),
+      offlineDownload = null,
+      mediaProgress = null,
+      isCurrentSession = true,
+      isQueued = false,
+      hasSession = true,
+      addToPlaylistDialog = AddToPlaylistDialog.NoOp,
+      showConfirmDownloadDialogSetting = false,
+      canStreamHls = true,
+    )
+
+    setCampfireContent {
+      slot.Content(Modifier) {}
+    }
+
+    onNodeWithContentDescription("More options").assertDoesNotExist()
+    onNodeWithContentDescription("Download").assertExists()
+  }
+
+  @Test
+  fun hlsCurrentSessionWhileDownloadingHidesTrailingButton() = runComposeUiTest {
+    val slot = ExpressiveControlSlot(
+      libraryItem = libraryItem(),
+      offlineDownload = downloadingOfflineDownload(),
+      mediaProgress = null,
+      isCurrentSession = true,
+      isQueued = false,
+      hasSession = true,
+      addToPlaylistDialog = AddToPlaylistDialog.NoOp,
+      showConfirmDownloadDialogSetting = false,
+      canStreamHls = true,
+    )
+
+    setCampfireContent {
+      slot.Content(Modifier) {}
+    }
+
+    onNodeWithTag("button_download").assertDoesNotExist()
+    onNodeWithContentDescription("More options").assertDoesNotExist()
+    onNodeWithContentDescription("Download").assertDoesNotExist()
+  }
+
+  @Test
+  fun hlsCurrentSessionWithCompletedDownloadHidesTrailingButton() = runComposeUiTest {
+    val contentLength = 10L * 1024L * 1024L
+    val slot = ExpressiveControlSlot(
+      libraryItem = libraryItem(),
+      offlineDownload = OfflineDownload(
+        libraryItemId = TestLibraryItemId,
+        state = OfflineDownload.State.Completed,
+        contentLength = contentLength,
+        progress = OfflineDownload.Progress(contentLength, 1f),
+      ),
+      mediaProgress = null,
+      isCurrentSession = true,
+      isQueued = false,
+      hasSession = true,
+      addToPlaylistDialog = AddToPlaylistDialog.NoOp,
+      showConfirmDownloadDialogSetting = false,
+      canStreamHls = true,
+    )
+
+    setCampfireContent {
+      slot.Content(Modifier) {}
+    }
+
+    onNodeWithTag("button_download").assertDoesNotExist()
+  }
+
+  private fun downloadingOfflineDownload() = OfflineDownload(
+    libraryItemId = TestLibraryItemId,
+    state = OfflineDownload.State.Downloading,
+    progress = OfflineDownload.Progress(0L, 0.1f, indeterminate = true),
+  )
 
   @Test
   fun determinateTest() = runComposeUiTest {


### PR DESCRIPTION
## Summary

On HLS-capable servers (introduced in #1004) the item detail's trailing button slot was forced visible for every download state, and fell back to a plain download button whenever the play-options dropdown was excluded. That produced:

- A **Download** button next to the disabled "Currently playing" button, even when the item was already downloading or downloaded. Tapping it re-requested a download.
- A fully rounded play button pill while the dropdown was still attached during an in-flight download, so the two shapes no longer lined up.
- A Download button for ebook-only items on HLS servers.

## Fix

- `PlayAndDownloadButtons` derives `showPlayOptionsMenu` / `showDownloadButton` / `showTrailingButton` once and drives visibility, branch selection, and the play button's corner radii from those.
  - Menu: HLS-capable, not the current session, not an ebook.
  - Download button: no menu, no download record, not an ebook.
- The pressed corner radius on the play button was inverted relative to the trailing button's pressed shape; it now matches.
- The dropdown stays visible while a download is in progress, since the stream-method choice still applies until the file lands. The presenter already clears `willStreamHls` on a completed download.

## Tests

Added five HLS cases to `ExpressiveControlSlotTest` (menu vs. download button, current session with/without download, completed download while playing) and tightened the existing downloading test to assert no download button. The two "current session + download exists" cases fail on the old code.

`:features:libraries:ui:jvmTest` slot tests: 11 passed, 0 failed. `scripts/ktlint --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
