### PR TITLE
Version desktop SQLite databases with user_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Desktop app crashing on launch
+- Desktop app crashing on launch, and again on every launch after the first
 - Item detail showing a stray download button while the item is playing or already downloading, and a mismatched play button shape while a download is in progress
 
 ### Other Notes & Contributions

--- a/data/db/core/build.gradle.kts
+++ b/data/db/core/build.gradle.kts
@@ -57,6 +57,12 @@ kotlin {
         implementation(libs.sqldelight.sqlite)
       }
     }
+
+    jvmTest {
+      dependencies {
+        implementation(libs.bundles.test.common)
+      }
+    }
   }
 }
 

--- a/data/db/core/src/jvmMain/kotlin/app/campfire/db/DesktopSqliteDriver.kt
+++ b/data/db/core/src/jvmMain/kotlin/app/campfire/db/DesktopSqliteDriver.kt
@@ -1,0 +1,96 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.db
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import java.io.File
+
+/**
+ * Open (or create) a file-backed SQLite database for the desktop app and bring it up to
+ * [schema]'s version, tracking the applied version in SQLite's `user_version` pragma the same
+ * way the Android and native drivers do.
+ *
+ * - A brand new file gets [SqlSchema.create] and is stamped with [SqlSchema.version].
+ * - A file stamped with an older version gets [SqlSchema.migrate] from that version.
+ * - A file that already has tables but was never stamped (created by older desktop builds that
+ *   ran `create` on every launch) is handed to [onLegacyDatabase], which must leave the file at
+ *   a known version, either by rebuilding it or by stamping it once it matches the schema.
+ */
+fun desktopSqliteDriver(
+  databaseFile: File,
+  schema: SqlSchema<QueryResult.Value<Unit>>,
+  onLegacyDatabase: SqlDriver.() -> Unit,
+): SqlDriver {
+  val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:${databaseFile.absolutePath}")
+  driver.upgradeTo(schema, onLegacyDatabase)
+  return driver
+}
+
+internal fun SqlDriver.upgradeTo(
+  schema: SqlSchema<QueryResult.Value<Unit>>,
+  onLegacyDatabase: SqlDriver.() -> Unit,
+) {
+  if (userVersion() == 0L && hasUserTables()) {
+    onLegacyDatabase()
+  }
+
+  val version = userVersion()
+  when {
+    version == 0L -> {
+      schema.create(this).value
+      setUserVersion(schema.version)
+    }
+    version < schema.version -> {
+      schema.migrate(this, version, schema.version).value
+      setUserVersion(schema.version)
+    }
+  }
+}
+
+/** Rebuild the database from scratch, dropping every user table before creating [schema]. */
+fun SqlDriver.rebuild(schema: SqlSchema<QueryResult.Value<Unit>>) {
+  DestructiveMigrationSchema.perform(this)
+  schema.create(this).value
+  setUserVersion(schema.version)
+}
+
+fun SqlDriver.userVersion(): Long = executeQuery(
+  identifier = null,
+  sql = "PRAGMA user_version",
+  parameters = 0,
+  mapper = { cursor ->
+    cursor.next().value
+    QueryResult.Value(cursor.getLong(0) ?: 0L)
+  },
+).value
+
+fun SqlDriver.setUserVersion(version: Long) {
+  execute(identifier = null, sql = "PRAGMA user_version = $version", parameters = 0)
+}
+
+fun SqlDriver.hasUserTables(): Boolean = executeQuery(
+  identifier = null,
+  sql = "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+  parameters = 0,
+  mapper = { cursor ->
+    cursor.next().value
+    QueryResult.Value((cursor.getLong(0) ?: 0L) > 0)
+  },
+).value
+
+fun SqlDriver.hasColumn(table: String, column: String): Boolean = executeQuery(
+  identifier = null,
+  sql = "PRAGMA table_info($table)",
+  parameters = 0,
+  mapper = { cursor ->
+    var found = false
+    while (cursor.next().value) {
+      if (cursor.getString(1) == column) found = true
+    }
+    QueryResult.Value(found)
+  },
+).value

--- a/data/db/core/src/jvmMain/kotlin/app/campfire/db/SqlDelightDatabasePlatformComponent.kt
+++ b/data/db/core/src/jvmMain/kotlin/app/campfire/db/SqlDelightDatabasePlatformComponent.kt
@@ -8,7 +8,6 @@ import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
 import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import java.io.File
 import me.tatarka.inject.annotations.Provides
 
@@ -24,14 +23,12 @@ actual interface SqlDelightDatabasePlatformComponent {
     val userDir = File(userRoot)
     val appDir = File(userDir, ".config/Campfire").apply { mkdirs() }
     val databaseFile = File(appDir, "campfire.db")
+    val schema = CampfireDatabase.Schema.synchronous()
 
-//    bark { "Creating SqlDriver for Database: ${databaseFile.absolutePath}" }
-
-    val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:${databaseFile.absolutePath}")
-//    DestructiveMigrationSchema.perform(driver)
-    CampfireDatabase.Schema
-      .synchronous()
-      .create(driver)
-    return driver
+    return desktopSqliteDriver(databaseFile, schema) {
+      // Older desktop builds re-ran `create` on every launch and never stamped a version, so
+      // the shape of such a file is unknown. It is only a cache of server data, so rebuild it.
+      rebuild(schema)
+    }
   }
 }

--- a/data/db/core/src/jvmTest/kotlin/app/campfire/db/DesktopSqliteDriverTest.kt
+++ b/data/db/core/src/jvmTest/kotlin/app/campfire/db/DesktopSqliteDriverTest.kt
@@ -1,0 +1,119 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.db
+
+import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class DesktopSqliteDriverTest {
+
+  @Test
+  fun `fresh database is created and stamped with the schema version`() {
+    val schema = RecordingSchema(version = 3)
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+
+    driver.upgradeTo(schema) { error("legacy hook should not run") }
+
+    assertThat(schema.calls).containsExactly("create")
+    assertThat(driver.userVersion()).isEqualTo(3L)
+    assertThat(driver.hasColumn("thing", "id")).isTrue()
+  }
+
+  @Test
+  fun `database already at the schema version is left alone`() {
+    val schema = RecordingSchema(version = 3)
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    driver.upgradeTo(schema) { error("legacy hook should not run") }
+    schema.calls.clear()
+
+    driver.upgradeTo(schema) { error("legacy hook should not run") }
+
+    assertThat(schema.calls).containsExactly()
+    assertThat(driver.userVersion()).isEqualTo(3L)
+  }
+
+  @Test
+  fun `database at an older version is migrated and restamped`() {
+    val schema = RecordingSchema(version = 3)
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    driver.execute(null, "CREATE TABLE thing (id INTEGER PRIMARY KEY)", 0)
+    driver.setUserVersion(1)
+
+    driver.upgradeTo(schema) { error("legacy hook should not run") }
+
+    assertThat(schema.calls).containsExactly("migrate 1 -> 3")
+    assertThat(driver.userVersion()).isEqualTo(3L)
+  }
+
+  @Test
+  fun `unstamped database with tables runs the legacy hook before upgrading`() {
+    val schema = RecordingSchema(version = 3)
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    driver.execute(null, "CREATE TABLE stale (id INTEGER PRIMARY KEY)", 0)
+    var legacyCalled = false
+
+    driver.upgradeTo(schema) {
+      legacyCalled = true
+      rebuild(schema)
+    }
+
+    assertThat(legacyCalled).isTrue()
+    assertThat(schema.calls).containsExactly("create")
+    assertThat(driver.userVersion()).isEqualTo(3L)
+    assertThat(driver.hasColumn("stale", "id")).isFalse()
+    assertThat(driver.hasColumn("thing", "id")).isTrue()
+  }
+
+  @Test
+  fun `legacy hook that stamps the version skips create and migrate`() {
+    val schema = RecordingSchema(version = 3)
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    driver.execute(null, "CREATE TABLE thing (id INTEGER PRIMARY KEY)", 0)
+
+    driver.upgradeTo(schema) { setUserVersion(schema.version) }
+
+    assertThat(schema.calls).containsExactly()
+    assertThat(driver.userVersion()).isEqualTo(3L)
+  }
+
+  @Test
+  fun `hasUserTables ignores sqlite internal tables`() {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    assertThat(driver.hasUserTables()).isFalse()
+
+    driver.execute(null, "CREATE TABLE thing (id INTEGER PRIMARY KEY AUTOINCREMENT)", 0)
+    driver.execute(null, "INSERT INTO thing DEFAULT VALUES", 0)
+
+    assertThat(driver.hasUserTables()).isTrue()
+  }
+
+  private class RecordingSchema(override val version: Long) : SqlSchema<QueryResult.Value<Unit>> {
+    val calls = mutableListOf<String>()
+
+    override fun create(driver: SqlDriver): QueryResult.Value<Unit> {
+      calls += "create"
+      driver.execute(null, "CREATE TABLE thing (id INTEGER PRIMARY KEY)", 0)
+      return QueryResult.Unit
+    }
+
+    override fun migrate(
+      driver: SqlDriver,
+      oldVersion: Long,
+      newVersion: Long,
+      vararg callbacks: AfterVersion,
+    ): QueryResult.Value<Unit> {
+      calls += "migrate $oldVersion -> $newVersion"
+      return QueryResult.Unit
+    }
+  }
+}

--- a/ui/theming/impl/build.gradle.kts
+++ b/ui/theming/impl/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
 
     jvmMain {
       dependencies {
+        implementation(projects.data.db.core)
         implementation(libs.sqldelight.sqlite)
       }
     }

--- a/ui/theming/impl/src/jvmMain/kotlin/app/campfire/ui/theming/db/ThemingDatabaseComponent.jvm.kt
+++ b/ui/theming/impl/src/jvmMain/kotlin/app/campfire/ui/theming/db/ThemingDatabaseComponent.jvm.kt
@@ -5,10 +5,12 @@ package app.campfire.ui.theming.db
 
 import app.campfire.core.di.AppScope
 import app.campfire.core.di.SingleIn
+import app.campfire.db.desktopSqliteDriver
+import app.campfire.db.hasColumn
+import app.campfire.db.setUserVersion
 import app.campfire.themes.CampfireThemeDatabase
 import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import java.io.File
 import me.tatarka.inject.annotations.Provides
 
@@ -25,14 +27,17 @@ actual interface SqlDelightDatabasePlatformComponent {
     val userDir = File(userRoot)
     val appDir = File(userDir, ".config/Campfire").apply { mkdirs() }
     val databaseFile = File(appDir, "campfire_themes.db")
+    val schema = CampfireThemeDatabase.Schema.synchronous()
 
-//    bark { "Creating SqlDriver for Database: ${databaseFile.absolutePath}" }
-
-    val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:${databaseFile.absolutePath}")
-//    DestructiveMigrationSchema.perform(driver)
-    CampfireThemeDatabase.Schema
-      .synchronous()
-      .create(driver)
-    return driver
+    return desktopSqliteDriver(databaseFile, schema) {
+      // Older desktop builds never stamped a version. This database holds user-made themes, so
+      // keep it: every table is `CREATE TABLE IF NOT EXISTS`, and the only migration so far
+      // (1.sqm) added columns to customAppTheme, so apply it when those columns are missing.
+      schema.create(this).value
+      if (!hasColumn(table = "customAppTheme", column = "isAi")) {
+        schema.migrate(this, 0, schema.version).value
+      }
+      setUserVersion(schema.version)
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follows #1062.

The desktop app's JVM SQLite drivers ran `Schema.create` on every launch and never recorded a schema version. Most tables in the main database are plain `CREATE TABLE`, so every launch after the first failed with `table authorsPage already exists`. The themes database uses `IF NOT EXISTS` so it did not crash, but its `1.sqm` column migration never ran on desktop either.

**Change.** `desktopSqliteDriver(file, schema, onLegacyDatabase)` in `:data:db:core` jvmMain opens the file and brings it to the schema version using SQLite's `user_version` pragma, matching what the Android and native drivers already do:

- fresh file: `create`, stamp `schema.version`
- stamped with an older version: `migrate(old, new)`, restamp
- unstamped file that already has tables (every desktop database created before this change): call the per-database legacy hook, which must leave the file at a known version

Per-database legacy policy:
- `campfire.db` rebuilds (drop all tables, `create`, stamp). It only caches server data, and no such file could have survived a second launch anyway.
- `campfire_themes.db` keeps user-made themes: `create` fills any missing tables, the column migration runs when `customAppTheme` lacks `isAi`, then it stamps the current version.

Small helpers (`userVersion`, `setUserVersion`, `hasUserTables`, `hasColumn`, `rebuild`) are public so other JVM database components can reuse them. `bookinfo_v1.db` is untouched; it versions by file name and rebuilds destructively by design.

## Verification

- `DesktopSqliteDriverTest` (6 tests) covers fresh create, no-op at current version, migrate from an older version, legacy rebuild, legacy stamp-only, and internal-table filtering, all against in-memory SQLite.
- Real run against the existing unstamped desktop databases: first launch rebuilt `campfire.db` (57 tables, `user_version` 11) and stamped `campfire_themes.db` at 2 with `isAi` present; second launch was a no-op and the app stayed up on the home screen. Previously the second launch crashed.

## Not changed

Foreign key enforcement and WAL are still not enabled on the JVM driver, unlike Android. Left out to keep this change to the versioning problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)