### PR TITLE
Add macOS Now Playing, media keys, output-device pausing, and Dock controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Desktop shows how to fix playback when VLC media player isn't installed, instead of failing silently
+- Desktop on macOS shows the current chapter in Now Playing and responds to media keys, AirPods taps, and Control Center controls
+- Desktop on macOS pauses when the Bluetooth or USB headphones being listened on disconnect
+- Desktop on macOS adds playback controls to the Dock icon's menu
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Desktop shows how to fix playback when VLC media player isn't installed, instead of failing silently
-- Desktop on macOS shows the current chapter in Now Playing and responds to media keys, AirPods taps, and Control Center controls
+- Desktop on macOS shows the current chapter and cover art in Now Playing and responds to media keys, AirPods taps, and Control Center controls
 - Desktop on macOS pauses when the Bluetooth or USB headphones being listened on disconnect
 - Desktop on macOS adds playback controls to the Dock icon's menu
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ material3 = "1.4.0"
 firebase-bom = "34.18.0"
 core = "1.19.0"
 vlcj = "4.12.1"
+jna = "5.16.0"
 work = "2.11.2"
 uiautomator = "2.4.0"
 benchmark-macro-junit4 = "1.4.1"
@@ -277,6 +278,7 @@ play-services-cast-framework = "com.google.android.gms:play-services-cast-framew
 # declared explicitly because :infra:audioplayer:cast uses mediarouter APIs directly.
 androidx-mediarouter = "androidx.mediarouter:mediarouter:1.8.1"
 vlcj = { module = "uk.co.caprica:vlcj", version.ref = "vlcj" }
+jna = { module = "net.java.dev.jna:jna-jpms", version.ref = "jna" }
 
 # Analytics
 mixpanel-android = { module = "com.mixpanel.android:mixpanel-android", version.ref = "mixpanel" }

--- a/infra/audioplayer/impl/build.gradle.kts
+++ b/infra/audioplayer/impl/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
     jvmMain {
       dependencies {
         implementation(libs.vlcj)
+        implementation(libs.jna)
         implementation(libs.kotlinx.coroutines.swing)
       }
     }

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/HttpArtworkLoader.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/HttpArtworkLoader.kt
@@ -1,0 +1,48 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import app.campfire.account.api.AccountManager
+import app.campfire.core.logging.Cork
+import app.campfire.core.model.UserId
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Downloads cover images for Now Playing with the user's bearer token. Covers are small and
+ * change only when the item changes, so one fetch per URL with no persistent cache is enough.
+ */
+internal class HttpArtworkLoader(
+  private val accountManager: AccountManager,
+  private val client: HttpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build(),
+) : ArtworkLoader {
+
+  override suspend fun load(url: String, userId: UserId): ByteArray? {
+    val token = runCatching { accountManager.getToken(userId)?.accessToken }.getOrNull()
+    return withContext(Dispatchers.IO) {
+      val request = HttpRequest.newBuilder(URI(url))
+        .timeout(Duration.ofSeconds(20))
+        .apply { if (token != null) header("Authorization", "Bearer $token") }
+        .GET()
+        .build()
+      val response = client.send(request, HttpResponse.BodyHandlers.ofByteArray())
+      if (response.statusCode() in 200..299 && response.body().isNotEmpty()) {
+        response.body()
+      } else {
+        wbark { "Cover request failed: HTTP ${response.statusCode()}" }
+        null
+      }
+    }
+  }
+
+  companion object : Cork {
+    override val tag: String = "HttpArtworkLoader"
+    override val enabled: Boolean = true
+  }
+}

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacDockMenu.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacDockMenu.kt
@@ -1,0 +1,38 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import app.campfire.audioplayer.AudioPlayer
+import app.campfire.audioplayer.AudioPlayerHolder
+import java.awt.MenuItem
+import java.awt.PopupMenu
+import java.awt.Taskbar
+
+/**
+ * Transport controls on the Dock icon's context menu. AWT owns the Dock menu, so labels are plain
+ * strings here rather than Compose resources; they act on whichever player is current.
+ */
+internal class MacDockMenu(private val holder: AudioPlayerHolder) {
+
+  fun install(): Boolean {
+    if (!Taskbar.isTaskbarSupported()) return false
+    val taskbar = Taskbar.getTaskbar()
+    if (!taskbar.isSupported(Taskbar.Feature.MENU)) return false
+
+    val menu = PopupMenu().apply {
+      add(item("Play / Pause") { it.playPause() })
+      add(item("Skip Back") { it.seekBackward() })
+      add(item("Skip Forward") { it.seekForward() })
+      addSeparator()
+      add(item("Previous Chapter") { it.skipToPrevious() })
+      add(item("Next Chapter") { it.skipToNext() })
+    }
+    taskbar.menu = menu
+    return true
+  }
+
+  private fun item(label: String, action: (AudioPlayer) -> Unit) = MenuItem(label).apply {
+    addActionListener { holder.currentPlayer.value?.let(action) }
+  }
+}

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacMediaIntegrationInitializer.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacMediaIntegrationInitializer.kt
@@ -1,0 +1,61 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import app.campfire.audioplayer.AudioPlayer
+import app.campfire.audioplayer.AudioPlayerHolder
+import app.campfire.core.app.AppInitializer
+import app.campfire.core.di.AppScope
+import app.campfire.core.di.qualifier.ForScope
+import app.campfire.core.logging.Cork
+import app.campfire.settings.api.PlaybackSettings
+import com.r0adkll.kimchi.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Wires the macOS media integrations on startup: Now Playing + media keys, pause when the
+ * output device the user was listening on disappears, and Dock transport controls.
+ *
+ * Every native piece is optional — a failure to load a framework logs and leaves playback alone.
+ */
+@ContributesMultibinding(AppScope::class)
+@Inject
+class MacMediaIntegrationInitializer(
+  private val holder: AudioPlayerHolder,
+  private val settings: PlaybackSettings,
+  @ForScope(AppScope::class) private val applicationScope: CoroutineScope,
+) : AppInitializer {
+
+  override val priority: Int = AppInitializer.LOWEST_PRIORITY
+
+  override suspend fun onInitialize() {
+    if (!isMacOs()) return
+
+    runCatching {
+      NowPlayingCoordinator(holder, settings, MacNowPlayingBridge(), applicationScope).start()
+    }.onFailure { ebark(it) { "Now Playing integration unavailable" } }
+
+    runCatching {
+      OutputDeviceMonitor { previous, current ->
+        val player = holder.currentPlayer.value ?: return@OutputDeviceMonitor
+        val playing = player.state.value == AudioPlayer.State.Playing
+        if (OutputDevicePolicy.shouldPause(previous, current, playing)) {
+          ibark { "Output device $previous went away; pausing" }
+          player.pause()
+        }
+      }.start()
+    }.onFailure { ebark(it) { "Output device monitoring unavailable" } }
+
+    runCatching { MacDockMenu(holder).install() }
+      .onFailure { ebark(it) { "Dock menu unavailable" } }
+  }
+
+  private fun isMacOs(): Boolean = System.getProperty("os.name").orEmpty().lowercase().contains("mac")
+
+  companion object : Cork {
+    override val tag: String = "MacMediaIntegration"
+    override val enabled: Boolean = true
+  }
+}

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacMediaIntegrationInitializer.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacMediaIntegrationInitializer.kt
@@ -3,6 +3,7 @@
 
 package app.campfire.audioplayer.impl.macos
 
+import app.campfire.account.api.AccountManager
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.AudioPlayerHolder
 import app.campfire.core.app.AppInitializer
@@ -25,6 +26,7 @@ import me.tatarka.inject.annotations.Inject
 class MacMediaIntegrationInitializer(
   private val holder: AudioPlayerHolder,
   private val settings: PlaybackSettings,
+  private val accountManager: AccountManager,
   @ForScope(AppScope::class) private val applicationScope: CoroutineScope,
 ) : AppInitializer {
 
@@ -34,7 +36,13 @@ class MacMediaIntegrationInitializer(
     if (!isMacOs()) return
 
     runCatching {
-      NowPlayingCoordinator(holder, settings, MacNowPlayingBridge(), applicationScope).start()
+      NowPlayingCoordinator(
+        holder = holder,
+        settings = settings,
+        bridge = MacNowPlayingBridge(),
+        artworkLoader = HttpArtworkLoader(accountManager),
+        scope = applicationScope,
+      ).start()
     }.onFailure { ebark(it) { "Now Playing integration unavailable" } }
 
     runCatching {

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacNowPlayingBridge.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacNowPlayingBridge.kt
@@ -1,0 +1,187 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import app.campfire.audioplayer.impl.macos.ObjC.put
+import app.campfire.audioplayer.impl.macos.ObjC.utf8
+import app.campfire.core.logging.Cork
+import com.sun.jna.Callback
+import com.sun.jna.NativeLibrary
+import com.sun.jna.Pointer
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+
+/**
+ * [NowPlayingBridge] over MediaPlayer.framework (`MPNowPlayingInfoCenter`, `MPRemoteCommandCenter`).
+ *
+ * Every framework call is made on the AppKit main thread via [MainQueue]. Remote commands arrive
+ * through a runtime-defined Objective-C class whose handler methods are JNA callbacks; the
+ * callbacks are held in fields so they outlive the registration.
+ *
+ * macOS quirk (documented by Apple): `playbackState` must be set on every play/pause, otherwise
+ * media keys keep launching Music and Control Center shows nothing.
+ */
+internal class MacNowPlayingBridge : NowPlayingBridge {
+
+  private val mediaPlayer: NativeLibrary = NativeLibrary.getInstance(MEDIA_PLAYER_FRAMEWORK)
+
+  private val keyTitle = ObjC.global(mediaPlayer, "MPMediaItemPropertyTitle")
+  private val keyArtist = ObjC.global(mediaPlayer, "MPMediaItemPropertyArtist")
+  private val keyAlbum = ObjC.global(mediaPlayer, "MPMediaItemPropertyAlbumTitle")
+  private val keyDuration = ObjC.global(mediaPlayer, "MPMediaItemPropertyPlaybackDuration")
+  private val keyElapsed = ObjC.global(mediaPlayer, "MPNowPlayingInfoPropertyElapsedPlaybackTime")
+  private val keyRate = ObjC.global(mediaPlayer, "MPNowPlayingInfoPropertyPlaybackRate")
+  private val keyDefaultRate = ObjC.global(mediaPlayer, "MPNowPlayingInfoPropertyDefaultPlaybackRate")
+  private val keyMediaType = ObjC.global(mediaPlayer, "MPNowPlayingInfoPropertyMediaType")
+
+  @Volatile
+  private var handler: RemoteCommandHandler? = null
+
+  /** IMP callbacks, kept alive here. Each returns MPRemoteCommandHandlerStatusSuccess. */
+  private val imps: Map<String, CommandImp> = mapOf(
+    "handlePlay:" to CommandImp { handler?.play() },
+    "handlePause:" to CommandImp { handler?.pause() },
+    "handleToggle:" to CommandImp { handler?.togglePlayPause() },
+    "handleSkipForward:" to CommandImp { handler?.skipForward() },
+    "handleSkipBackward:" to CommandImp { handler?.skipBackward() },
+    "handleNext:" to CommandImp { handler?.nextTrack() },
+    "handlePrevious:" to CommandImp { handler?.previousTrack() },
+    "handleChangePosition:" to CommandImp { event ->
+      val seconds = ObjC.sendDouble(event, "positionTime")
+      handler?.seekTo(seconds.seconds)
+    },
+  )
+
+  private val commandsToSelectors = listOf(
+    "playCommand" to "handlePlay:",
+    "pauseCommand" to "handlePause:",
+    "togglePlayPauseCommand" to "handleToggle:",
+    "skipForwardCommand" to "handleSkipForward:",
+    "skipBackwardCommand" to "handleSkipBackward:",
+    "nextTrackCommand" to "handleNext:",
+    "previousTrackCommand" to "handlePrevious:",
+    "changePlaybackPositionCommand" to "handleChangePosition:",
+  )
+
+  /** The command target instance; created on the main thread on first use. */
+  private var target: Pointer? = null
+
+  private inner class CommandImp(private val action: (event: Pointer) -> Unit) : Callback {
+    @Suppress("unused")
+    fun invoke(self: Pointer?, selector: Pointer?, event: Pointer?): Long {
+      try {
+        if (event != null) action(event)
+      } catch (t: Throwable) {
+        ebark(t) { "Remote command handler failed" }
+        return STATUS_COMMAND_FAILED
+      }
+      return STATUS_SUCCESS
+    }
+  }
+
+  private fun center(): Pointer = ObjC.send(ObjC.cls("MPNowPlayingInfoCenter"), "defaultCenter")!!
+
+  private fun commandCenter(): Pointer = ObjC.send(ObjC.cls("MPRemoteCommandCenter"), "sharedCommandCenter")!!
+
+  private fun target(): Pointer {
+    target?.let { return it }
+    val cls = ObjC.defineClass(
+      name = TARGET_CLASS,
+      superclass = "NSObject",
+      methods = imps.map { (selector, imp) -> ObjC.Method(selector, "q@:@", imp) },
+    )
+    return ObjC.send(cls, "new")!!.also { target = it }
+  }
+
+  override fun setNowPlaying(info: NowPlayingInfo?) = MainQueue.post {
+    ObjC.autoreleased {
+      val center = center()
+      if (info == null) {
+        ObjC.sendVoid(center, "setNowPlayingInfo:", null)
+        return@autoreleased
+      }
+      val dict = ObjC.nsMutableDictionary()
+      info.title?.let { dict.put(keyTitle, ObjC.nsString(it)) }
+      info.artist?.let { dict.put(keyArtist, ObjC.nsString(it)) }
+      info.album?.let { dict.put(keyAlbum, ObjC.nsString(it)) }
+      dict.put(keyDuration, ObjC.nsNumber(info.duration.toDouble(DurationUnit.SECONDS)))
+      dict.put(keyElapsed, ObjC.nsNumber(info.elapsed.toDouble(DurationUnit.SECONDS)))
+      dict.put(keyRate, ObjC.nsNumber(info.rate))
+      dict.put(keyDefaultRate, ObjC.nsNumber(info.defaultRate))
+      dict.put(keyMediaType, ObjC.nsNumber(MEDIA_TYPE_AUDIO))
+      ObjC.sendVoid(center, "setNowPlayingInfo:", dict)
+    }
+  }
+
+  override fun setPlaybackState(state: NowPlayingState) = MainQueue.post {
+    val code = when (state) {
+      NowPlayingState.Playing -> PLAYBACK_STATE_PLAYING
+      NowPlayingState.Paused -> PLAYBACK_STATE_PAUSED
+      NowPlayingState.Stopped -> PLAYBACK_STATE_STOPPED
+    }
+    ObjC.sendVoid(center(), "setPlaybackState:", code)
+  }
+
+  override fun setCommandHandler(handler: RemoteCommandHandler?, skipForward: Duration, skipBackward: Duration) {
+    this.handler = handler
+    MainQueue.post {
+      ObjC.autoreleased {
+        val commandCenter = commandCenter()
+        val target = target()
+        commandsToSelectors.forEach { (command, selector) ->
+          val cmd = ObjC.send(commandCenter, command) ?: return@forEach
+          ObjC.sendVoid(cmd, "removeTarget:", target)
+          if (handler != null) {
+            ObjC.sendVoid(cmd, "addTarget:action:", target, ObjC.sel(selector))
+          }
+          ObjC.sendVoid(cmd, "setEnabled:", if (handler != null) 1L else 0L)
+        }
+        if (handler != null) {
+          ObjC.send(commandCenter, "skipForwardCommand")?.let { cmd ->
+            ObjC.sendVoid(
+              cmd,
+              "setPreferredIntervals:",
+              ObjC.nsArray(ObjC.nsNumber(skipForward.toDouble(DurationUnit.SECONDS))),
+            )
+          }
+          ObjC.send(commandCenter, "skipBackwardCommand")?.let { cmd ->
+            ObjC.sendVoid(
+              cmd,
+              "setPreferredIntervals:",
+              ObjC.nsArray(ObjC.nsNumber(skipBackward.toDouble(DurationUnit.SECONDS))),
+            )
+          }
+        }
+      }
+    }
+  }
+
+  /** What the system currently holds for us; used by the integration test to prove the round trip. */
+  internal fun readBack(): Pair<String?, Long> = MainQueue.call {
+    ObjC.autoreleased {
+      val center = center()
+      val info = ObjC.send(center, "nowPlayingInfo")
+      val title = info?.let { ObjC.send(it, "objectForKey:", keyTitle) }?.utf8()
+      title to ObjC.sendLong(center, "playbackState")
+    }
+  }
+
+  companion object : Cork {
+    override val tag: String = "MacNowPlayingBridge"
+    override val enabled: Boolean = true
+
+    private const val MEDIA_PLAYER_FRAMEWORK = "/System/Library/Frameworks/MediaPlayer.framework/MediaPlayer"
+    private const val TARGET_CLASS = "CampfireRemoteCommandTarget"
+
+    private const val STATUS_SUCCESS = 0L
+    private const val STATUS_COMMAND_FAILED = 200L
+
+    private const val PLAYBACK_STATE_PLAYING = 1L
+    private const val PLAYBACK_STATE_PAUSED = 2L
+    private const val PLAYBACK_STATE_STOPPED = 3L
+
+    private const val MEDIA_TYPE_AUDIO = 1L
+  }
+}

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacNowPlayingBridge.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MacNowPlayingBridge.kt
@@ -4,6 +4,7 @@
 package app.campfire.audioplayer.impl.macos
 
 import app.campfire.audioplayer.impl.macos.ObjC.put
+import app.campfire.audioplayer.impl.macos.ObjC.release
 import app.campfire.audioplayer.impl.macos.ObjC.utf8
 import app.campfire.core.logging.Cork
 import com.sun.jna.Callback
@@ -27,6 +28,11 @@ internal class MacNowPlayingBridge : NowPlayingBridge {
 
   private val mediaPlayer: NativeLibrary = NativeLibrary.getInstance(MEDIA_PLAYER_FRAMEWORK)
 
+  init {
+    // NSImage lives in AppKit; make sure the class is resolvable even before a window exists
+    NativeLibrary.getInstance(APP_KIT_FRAMEWORK)
+  }
+
   private val keyTitle = ObjC.global(mediaPlayer, "MPMediaItemPropertyTitle")
   private val keyArtist = ObjC.global(mediaPlayer, "MPMediaItemPropertyArtist")
   private val keyAlbum = ObjC.global(mediaPlayer, "MPMediaItemPropertyAlbumTitle")
@@ -35,6 +41,18 @@ internal class MacNowPlayingBridge : NowPlayingBridge {
   private val keyRate = ObjC.global(mediaPlayer, "MPNowPlayingInfoPropertyPlaybackRate")
   private val keyDefaultRate = ObjC.global(mediaPlayer, "MPNowPlayingInfoPropertyDefaultPlaybackRate")
   private val keyMediaType = ObjC.global(mediaPlayer, "MPNowPlayingInfoPropertyMediaType")
+  private val keyArtwork = ObjC.global(mediaPlayer, "MPMediaItemPropertyArtwork")
+
+  /**
+   * The decoded cover the artwork request handler hands back. The system may call the handler of
+   * an older MPMediaItemArtwork at any time, so every handler resolves to the *current* image and
+   * the previous image is kept alive for one more rotation before it is released.
+   */
+  @Volatile
+  private var currentImage: Pointer? = null
+  private var previousImage: Pointer? = null
+  private var currentArtworkBytes: ByteArray? = null
+  private val artworkRequestBlock = ObjC.ImageRequestBlock { _, _ -> currentImage }
 
   @Volatile
   private var handler: RemoteCommandHandler? = null
@@ -111,8 +129,37 @@ internal class MacNowPlayingBridge : NowPlayingBridge {
       dict.put(keyRate, ObjC.nsNumber(info.rate))
       dict.put(keyDefaultRate, ObjC.nsNumber(info.defaultRate))
       dict.put(keyMediaType, ObjC.nsNumber(MEDIA_TYPE_AUDIO))
+      artworkFor(info.artwork)?.let { artwork ->
+        dict.put(keyArtwork, artwork)
+        artwork.release()
+      }
       ObjC.sendVoid(center, "setNowPlayingInfo:", dict)
     }
+  }
+
+  /** An owned MPMediaItemArtwork for [bytes], decoding a new NSImage only when the bytes change. */
+  private fun artworkFor(bytes: ByteArray?): Pointer? {
+    if (bytes == null) return null
+    if (bytes !== currentArtworkBytes) {
+      val image = ObjC.send(ObjC.cls("NSImage"), "alloc")
+        ?.let { ObjC.send(it, "initWithData:", ObjC.nsData(bytes)) }
+      if (image == null) {
+        wbark { "Cover image could not be decoded (${bytes.size} bytes)" }
+        return null
+      }
+      previousImage?.release()
+      previousImage = currentImage
+      currentImage = image
+      currentArtworkBytes = bytes
+    }
+    val artwork = ObjC.send(ObjC.cls("MPMediaItemArtwork"), "alloc") ?: return null
+    return ObjC.send(
+      artwork,
+      "initWithBoundsSize:requestHandler:",
+      ARTWORK_BOUNDS,
+      ARTWORK_BOUNDS,
+      artworkRequestBlock.pointer,
+    )
   }
 
   override fun setPlaybackState(state: NowPlayingState) = MainQueue.post {
@@ -158,13 +205,18 @@ internal class MacNowPlayingBridge : NowPlayingBridge {
     }
   }
 
+  internal data class ReadBack(val title: String?, val playbackState: Long, val artworkResolves: Boolean)
+
   /** What the system currently holds for us; used by the integration test to prove the round trip. */
-  internal fun readBack(): Pair<String?, Long> = MainQueue.call {
+  internal fun readBack(): ReadBack = MainQueue.call {
     ObjC.autoreleased {
       val center = center()
       val info = ObjC.send(center, "nowPlayingInfo")
       val title = info?.let { ObjC.send(it, "objectForKey:", keyTitle) }?.utf8()
-      title to ObjC.sendLong(center, "playbackState")
+      // Asking the artwork for an image runs our request block through the real block ABI
+      val artworkResolves = info?.let { ObjC.send(it, "objectForKey:", keyArtwork) }
+        ?.let { ObjC.send(it, "imageWithSize:", 300.0, 300.0) } != null
+      ReadBack(title, ObjC.sendLong(center, "playbackState"), artworkResolves)
     }
   }
 
@@ -173,6 +225,10 @@ internal class MacNowPlayingBridge : NowPlayingBridge {
     override val enabled: Boolean = true
 
     private const val MEDIA_PLAYER_FRAMEWORK = "/System/Library/Frameworks/MediaPlayer.framework/MediaPlayer"
+    private const val APP_KIT_FRAMEWORK = "/System/Library/Frameworks/AppKit.framework/AppKit"
+
+    /** Bounds advertised for the artwork; covers are requested at this width from the server. */
+    private const val ARTWORK_BOUNDS = 1200.0
     private const val TARGET_CLASS = "CampfireRemoteCommandTarget"
 
     private const val STATUS_SUCCESS = 0L

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MainQueue.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/MainQueue.kt
@@ -1,0 +1,61 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import app.campfire.core.logging.LogPriority
+import app.campfire.core.logging.bark
+import com.sun.jna.Callback
+import com.sun.jna.Function
+import com.sun.jna.NativeLibrary
+import com.sun.jna.Pointer
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * Runs work on the AppKit main thread through libdispatch's main queue. The AWT event thread is
+ * not the AppKit main thread, and MediaPlayer.framework expects to be driven from the latter.
+ */
+internal object MainQueue {
+
+  private val system: NativeLibrary = NativeLibrary.getInstance("System")
+
+  /** `dispatch_get_main_queue()` is a macro for the address of this global. */
+  private val queue: Pointer = system.getGlobalVariableAddress("_dispatch_main_q")
+  private val asyncF: Function = system.getFunction("dispatch_async_f")
+
+  private val pending = ConcurrentLinkedQueue<() -> Unit>()
+
+  /** One long-lived callback that drains [pending]; JNA callbacks must stay strongly referenced. */
+  private val drain = DispatchFunction {
+    val block = pending.poll() ?: return@DispatchFunction
+    try {
+      block()
+    } catch (t: Throwable) {
+      bark(LogPriority.ERROR, throwable = t) { "Main-queue block failed" }
+    }
+  }
+
+  fun interface DispatchFunction : Callback {
+    fun invoke(context: Pointer?)
+  }
+
+  fun post(block: () -> Unit) {
+    pending.add(block)
+    asyncF.invokeVoid(arrayOf(queue, null, drain))
+  }
+
+  /** Runs [block] on the main thread and waits for its result; for tests and one-off reads. */
+  fun <T> call(timeoutMillis: Long = 5_000, block: () -> T): T {
+    val future = CompletableFuture<T>()
+    post {
+      try {
+        future.complete(block())
+      } catch (t: Throwable) {
+        future.completeExceptionally(t)
+      }
+    }
+    return future.get(timeoutMillis, TimeUnit.MILLISECONDS)
+  }
+}

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingBridge.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingBridge.kt
@@ -1,0 +1,52 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import kotlin.time.Duration
+
+/**
+ * The system "Now Playing" surface: metadata and transport state shown in Control Center and on
+ * connected accessories, plus the remote commands (media keys, AirPods taps, headset buttons)
+ * routed back to the app. Abstracted so [NowPlayingCoordinator] is testable without macOS.
+ */
+interface NowPlayingBridge {
+
+  /** Publish [info], or clear the system's entry when null. */
+  fun setNowPlaying(info: NowPlayingInfo?)
+
+  fun setPlaybackState(state: NowPlayingState)
+
+  /**
+   * Route remote commands to [handler], or stop handling them when null. Skip intervals are
+   * advertised so the system draws the matching skip buttons.
+   */
+  fun setCommandHandler(handler: RemoteCommandHandler?, skipForward: Duration, skipBackward: Duration)
+}
+
+data class NowPlayingInfo(
+  val title: String?,
+  val artist: String?,
+  val album: String?,
+  val duration: Duration,
+  val elapsed: Duration,
+  /** Current rate; 0 while paused. */
+  val rate: Double,
+  /** The rate playback resumes at. */
+  val defaultRate: Double,
+)
+
+enum class NowPlayingState { Playing, Paused, Stopped }
+
+interface RemoteCommandHandler {
+  fun play()
+  fun pause()
+  fun togglePlayPause()
+  fun skipForward()
+  fun skipBackward()
+  fun nextTrack()
+  fun previousTrack()
+
+  /** Scrubber position within the currently advertised item, i.e. relative to [NowPlayingInfo.duration]. */
+  fun seekTo(position: Duration)
+}

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingBridge.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingBridge.kt
@@ -3,6 +3,7 @@
 
 package app.campfire.audioplayer.impl.macos
 
+import app.campfire.core.model.UserId
 import kotlin.time.Duration
 
 /**
@@ -34,7 +35,14 @@ data class NowPlayingInfo(
   val rate: Double,
   /** The rate playback resumes at. */
   val defaultRate: Double,
+  /** Encoded cover image (any format the platform decodes), or null for no artwork. */
+  val artwork: ByteArray? = null,
 )
+
+/** Fetches cover bytes for [NowPlayingInfo.artwork]; implementations handle authentication. */
+fun interface ArtworkLoader {
+  suspend fun load(url: String, userId: UserId): ByteArray?
+}
 
 enum class NowPlayingState { Playing, Paused, Stopped }
 

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingCoordinator.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingCoordinator.kt
@@ -13,8 +13,12 @@ import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 /**
@@ -29,6 +33,7 @@ class NowPlayingCoordinator(
   private val holder: AudioPlayerHolder,
   private val settings: PlaybackSettings,
   private val bridge: NowPlayingBridge,
+  private val artworkLoader: ArtworkLoader,
   private val scope: CoroutineScope,
   private val timeSource: TimeSource = TimeSource.Monotonic,
 ) {
@@ -45,22 +50,32 @@ class NowPlayingCoordinator(
     }
   }
 
-  private suspend fun observe(player: AudioPlayer) {
+  private suspend fun observe(player: AudioPlayer) = coroutineScope {
     bridge.setCommandHandler(
       PlayerCommands(player),
       skipForward = settings.forwardTimeMs.milliseconds,
       skipBackward = settings.backwardTimeMs.milliseconds,
     )
 
+    // Cover bytes for the artwork URL they were fetched from; published once loaded
+    val artwork = MutableStateFlow<Pair<String, ByteArray>?>(null)
+    launch {
+      player.currentMetadata.map { it.artworkUri }.distinctUntilChanged().collectLatest { url ->
+        val userId = player.preparedSession?.userId
+        if (url == null || userId == null) return@collectLatest
+        if (artwork.value?.first == url) return@collectLatest
+        val bytes = runCatching { artworkLoader.load(url, userId) }.getOrNull() ?: return@collectLatest
+        artwork.value = url to bytes
+      }
+    }
+
     var published: Published? = null
 
     combine(
-      player.state,
-      player.currentMetadata,
-      player.currentDuration,
-      player.playbackSpeed,
-      player.currentTime,
-    ) { state, metadata, duration, speed, time ->
+      combine(player.state, player.currentMetadata, player.currentDuration) { s, m, d -> Triple(s, m, d) },
+      combine(player.playbackSpeed, player.currentTime) { r, t -> r to t },
+      artwork,
+    ) { (state, metadata, duration), (speed, time), cover ->
       val session = player.preparedSession
       val rate = if (state == AudioPlayer.State.Playing) speed.toDouble() else 0.0
       NowPlayingInfo(
@@ -71,6 +86,7 @@ class NowPlayingCoordinator(
         elapsed = time,
         rate = rate,
         defaultRate = speed.toDouble(),
+        artwork = cover?.takeIf { it.first == metadata.artworkUri }?.second,
       ) to state
     }.collect { (info, state) ->
       if (state == AudioPlayer.State.Disabled) {

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingCoordinator.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingCoordinator.kt
@@ -1,0 +1,152 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import app.campfire.audioplayer.AudioPlayer
+import app.campfire.audioplayer.AudioPlayerHolder
+import app.campfire.settings.api.PlaybackSettings
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+/**
+ * Mirrors the current [AudioPlayer] onto the system Now Playing surface and routes remote
+ * commands back to it. Pure Kotlin: the platform lives behind [NowPlayingBridge].
+ *
+ * The system extrapolates the scrubber from the last published elapsed time and rate, so the
+ * elapsed time is only re-published when metadata, duration, speed, or state change, or when the
+ * actual position drifts from that extrapolation (a seek).
+ */
+class NowPlayingCoordinator(
+  private val holder: AudioPlayerHolder,
+  private val settings: PlaybackSettings,
+  private val bridge: NowPlayingBridge,
+  private val scope: CoroutineScope,
+  private val timeSource: TimeSource = TimeSource.Monotonic,
+) {
+
+  fun start(): Job = scope.launch {
+    holder.currentPlayer.collectLatest { player ->
+      if (player == null) {
+        bridge.setCommandHandler(null, Duration.ZERO, Duration.ZERO)
+        bridge.setPlaybackState(NowPlayingState.Stopped)
+        bridge.setNowPlaying(null)
+      } else {
+        observe(player)
+      }
+    }
+  }
+
+  private suspend fun observe(player: AudioPlayer) {
+    bridge.setCommandHandler(
+      PlayerCommands(player),
+      skipForward = settings.forwardTimeMs.milliseconds,
+      skipBackward = settings.backwardTimeMs.milliseconds,
+    )
+
+    var published: Published? = null
+
+    combine(
+      player.state,
+      player.currentMetadata,
+      player.currentDuration,
+      player.playbackSpeed,
+      player.currentTime,
+    ) { state, metadata, duration, speed, time ->
+      val session = player.preparedSession
+      val rate = if (state == AudioPlayer.State.Playing) speed.toDouble() else 0.0
+      NowPlayingInfo(
+        title = metadata.title,
+        artist = session?.libraryItem?.media?.metadata?.authorName,
+        album = session?.libraryItem?.media?.metadata?.title,
+        duration = duration,
+        elapsed = time,
+        rate = rate,
+        defaultRate = speed.toDouble(),
+      ) to state
+    }.collect { (info, state) ->
+      if (state == AudioPlayer.State.Disabled) {
+        if (published != null) {
+          bridge.setNowPlaying(null)
+          bridge.setPlaybackState(NowPlayingState.Stopped)
+          published = null
+        }
+        return@collect
+      }
+
+      val previous = published
+      if (previous == null || previous.needsRepublish(info, timeSource)) {
+        bridge.setNowPlaying(info)
+        published = Published(info, timeSource.markNow())
+      }
+      val playbackState = state.toNowPlayingState()
+      if (previous?.state != playbackState) {
+        bridge.setPlaybackState(playbackState)
+        published = published?.copy(state = playbackState)
+      }
+    }
+  }
+
+  private class Published(
+    val info: NowPlayingInfo,
+    val at: TimeMark,
+    val state: NowPlayingState? = null,
+  ) {
+    fun copy(state: NowPlayingState?) = Published(info, at, state)
+
+    fun needsRepublish(next: NowPlayingInfo, timeSource: TimeSource): Boolean {
+      if (info.copy(elapsed = Duration.ZERO) != next.copy(elapsed = Duration.ZERO)) return true
+      val expected = info.elapsed + at.elapsedNow() * info.rate
+      return (next.elapsed - expected).absoluteValue > DRIFT_TOLERANCE
+    }
+  }
+
+  private fun AudioPlayer.State.toNowPlayingState(): NowPlayingState = when (this) {
+    AudioPlayer.State.Playing -> NowPlayingState.Playing
+    AudioPlayer.State.Paused,
+    AudioPlayer.State.Buffering,
+    AudioPlayer.State.Initializing,
+    -> NowPlayingState.Paused
+    AudioPlayer.State.Finished,
+    AudioPlayer.State.Disabled,
+    -> NowPlayingState.Stopped
+  }
+
+  private class PlayerCommands(private val player: AudioPlayer) : RemoteCommandHandler {
+    override fun play() {
+      if (player.state.value != AudioPlayer.State.Playing) player.playPause()
+    }
+
+    override fun pause() {
+      if (player.state.value == AudioPlayer.State.Playing) player.pause()
+    }
+
+    override fun togglePlayPause() = player.playPause()
+
+    override fun skipForward() = player.seekForward()
+
+    override fun skipBackward() = player.seekBackward()
+
+    override fun nextTrack() = player.skipToNext()
+
+    override fun previousTrack() = player.skipToPrevious()
+
+    override fun seekTo(position: Duration) {
+      val duration = player.currentDuration.value
+      if (duration <= Duration.ZERO) return
+      player.seekTo((position / duration).toFloat().coerceIn(0f, 1f))
+    }
+  }
+
+  companion object {
+    private val DRIFT_TOLERANCE = 1.5.seconds
+  }
+}

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/ObjC.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/ObjC.kt
@@ -1,0 +1,99 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import com.sun.jna.Callback
+import com.sun.jna.Function
+import com.sun.jna.NativeLibrary
+import com.sun.jna.Pointer
+
+/**
+ * Minimal Objective-C runtime bridge over JNA — just enough to message existing classes and to
+ * define a small target class whose methods are implemented by JNA callbacks.
+ *
+ * `objc_msgSend` is bound as a fixed-arity function and invoked with exact argument arrays, never
+ * as C varargs: on arm64 the variadic calling convention differs and a varargs binding would pass
+ * arguments in the wrong registers.
+ */
+internal object ObjC {
+
+  private val objc: NativeLibrary = NativeLibrary.getInstance("objc")
+  private val msgSend: Function = objc.getFunction("objc_msgSend")
+  private val getClass: Function = objc.getFunction("objc_getClass")
+  private val registerName: Function = objc.getFunction("sel_registerName")
+  private val allocateClassPair: Function = objc.getFunction("objc_allocateClassPair")
+  private val registerClassPair: Function = objc.getFunction("objc_registerClassPair")
+  private val addMethod: Function = objc.getFunction("class_addMethod")
+  private val poolPush: Function = objc.getFunction("objc_autoreleasePoolPush")
+  private val poolPop: Function = objc.getFunction("objc_autoreleasePoolPop")
+
+  fun cls(name: String): Pointer = getClass.invokePointer(arrayOf(name)) ?: error("Objective-C class $name not found")
+
+  fun sel(name: String): Pointer = registerName.invokePointer(arrayOf(name))
+
+  fun send(receiver: Pointer, selector: String, vararg args: Any?): Pointer? =
+    msgSend.invokePointer(arrayOf(receiver, sel(selector), *args))
+
+  fun sendLong(receiver: Pointer, selector: String, vararg args: Any?): Long =
+    msgSend.invokeLong(arrayOf(receiver, sel(selector), *args))
+
+  fun sendDouble(receiver: Pointer, selector: String, vararg args: Any?): Double =
+    msgSend.invokeDouble(arrayOf(receiver, sel(selector), *args))
+
+  fun sendVoid(receiver: Pointer, selector: String, vararg args: Any?) {
+    msgSend.invokeVoid(arrayOf(receiver, sel(selector), *args))
+  }
+
+  /** Runs [block] inside an autorelease pool so objects returned by class methods are released. */
+  inline fun <T> autoreleased(block: () -> T): T {
+    val pool = poolPush.invokePointer(emptyArray())
+    try {
+      return block()
+    } finally {
+      poolPop.invokeVoid(arrayOf(pool))
+    }
+  }
+
+  /** An instance method implemented in Kotlin: [types] is the ObjC type encoding, e.g. `q@:@`. */
+  class Method(val selector: String, val types: String, val imp: Callback)
+
+  /**
+   * Defines (or returns the already-defined) class [name] extending [superclass] with [methods].
+   * Callers must keep the [Method.imp] callbacks strongly referenced for the life of the class.
+   */
+  fun defineClass(name: String, superclass: String, methods: List<Method>): Pointer {
+    getClass.invokePointer(arrayOf(name))?.let { return it }
+    val cls = allocateClassPair.invokePointer(arrayOf(cls(superclass), name, 0L))
+      ?: error("Unable to allocate Objective-C class $name")
+    methods.forEach { method ->
+      addMethod.invokeInt(arrayOf(cls, sel(method.selector), method.imp, method.types))
+    }
+    registerClassPair.invokeVoid(arrayOf(cls))
+    return cls
+  }
+
+  /** The value of an exported `NSString *const` (or other pointer-sized) global in [library]. */
+  fun global(library: NativeLibrary, symbol: String): Pointer =
+    library.getGlobalVariableAddress(symbol).getPointer(0) ?: error("$symbol is null")
+
+  fun nsString(value: String): Pointer =
+    send(cls("NSString"), "stringWithUTF8String:", value) ?: error("NSString allocation failed")
+
+  fun nsNumber(value: Double): Pointer =
+    send(cls("NSNumber"), "numberWithDouble:", value) ?: error("NSNumber allocation failed")
+
+  fun nsNumber(value: Long): Pointer =
+    send(cls("NSNumber"), "numberWithLongLong:", value) ?: error("NSNumber allocation failed")
+
+  fun nsArray(single: Pointer): Pointer =
+    send(cls("NSArray"), "arrayWithObject:", single) ?: error("NSArray allocation failed")
+
+  fun nsMutableDictionary(): Pointer =
+    send(cls("NSMutableDictionary"), "dictionary") ?: error("NSMutableDictionary allocation failed")
+
+  fun Pointer.put(key: Pointer, value: Pointer) = sendVoid(this, "setObject:forKey:", value, key)
+
+  /** Reads an NSString as a Kotlin string. */
+  fun Pointer.utf8(): String? = send(this, "UTF8String")?.getString(0, "UTF-8")
+}

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/ObjC.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/ObjC.kt
@@ -4,7 +4,9 @@
 package app.campfire.audioplayer.impl.macos
 
 import com.sun.jna.Callback
+import com.sun.jna.CallbackReference
 import com.sun.jna.Function
+import com.sun.jna.Memory
 import com.sun.jna.NativeLibrary
 import com.sun.jna.Pointer
 
@@ -96,4 +98,56 @@ internal object ObjC {
 
   /** Reads an NSString as a Kotlin string. */
   fun Pointer.utf8(): String? = send(this, "UTF8String")?.getString(0, "UTF-8")
+
+  /** An NSData copy of [bytes]. */
+  fun nsData(bytes: ByteArray): Pointer {
+    val memory = Memory(bytes.size.toLong().coerceAtLeast(1)).apply { write(0, bytes, 0, bytes.size) }
+    return send(cls("NSData"), "dataWithBytes:length:", memory, bytes.size.toLong())
+      ?: error("NSData allocation failed")
+  }
+
+  fun Pointer.release() = sendVoid(this, "release")
+
+  /**
+   * A block with no captured variables: `NSImage *(^)(CGSize)` shaped for MediaPlayer's artwork
+   * request handler. Built as a global block literal so it is never copied or freed by the
+   * runtime; the instance (and its callback) must be kept referenced for as long as the block
+   * may be invoked. CGSize arrives as two doubles, which is how a two-double struct is passed on
+   * both arm64 and x86_64.
+   */
+  class ImageRequestBlock(private val handler: (width: Double, height: Double) -> Pointer?) {
+
+    fun interface Invoke : Callback {
+      fun invoke(block: Pointer?, width: Double, height: Double): Pointer?
+    }
+
+    private val invoke = Invoke { _, width, height -> handler(width, height) }
+    private val signature = Memory(SIGNATURE.length + 1L).apply { setString(0, SIGNATURE, "UTF-8") }
+    private val descriptor = Memory(DESCRIPTOR_SIZE).apply {
+      setLong(0, 0L)
+      setLong(8, LITERAL_SIZE)
+      setPointer(16, signature)
+    }
+    private val literal = Memory(LITERAL_SIZE).apply {
+      setPointer(0, globalBlockIsa)
+      setInt(8, BLOCK_IS_GLOBAL or BLOCK_HAS_SIGNATURE)
+      setInt(12, 0)
+      setPointer(16, CallbackReference.getFunctionPointer(invoke))
+      setPointer(24, descriptor)
+    }
+
+    /** The block object, usable wherever an ObjC API takes a block argument. */
+    val pointer: Pointer get() = literal
+
+    private companion object {
+      const val LITERAL_SIZE = 32L
+      const val DESCRIPTOR_SIZE = 24L
+      const val BLOCK_IS_GLOBAL = 1 shl 28
+      const val BLOCK_HAS_SIGNATURE = 1 shl 30
+      const val SIGNATURE = "@24@?0{CGSize=dd}8"
+      val globalBlockIsa: Pointer = NativeLibrary.getInstance("System").getGlobalVariableAddress(
+        "_NSConcreteGlobalBlock",
+      )
+    }
+  }
 }

--- a/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/OutputDeviceMonitor.kt
+++ b/infra/audioplayer/impl/src/jvmMain/kotlin/app/campfire/audioplayer/impl/macos/OutputDeviceMonitor.kt
@@ -1,0 +1,132 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import app.campfire.core.logging.Cork
+import com.sun.jna.Callback
+import com.sun.jna.Function
+import com.sun.jna.NativeLibrary
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+import com.sun.jna.ptr.IntByReference
+
+/** How the default output device is attached, from CoreAudio's `kAudioDevicePropertyTransportType`. */
+enum class TransportType(internal val code: Int) {
+  BuiltIn(fourCC("bltn")),
+  Bluetooth(fourCC("blue")),
+  BluetoothLE(fourCC("blea")),
+  Usb(fourCC("usb ")),
+  AirPlay(fourCC("airp")),
+  Hdmi(fourCC("hdmi")),
+  DisplayPort(fourCC("dprt")),
+  Virtual(fourCC("virt")),
+  Aggregate(fourCC("grup")),
+  Unknown(0),
+  ;
+
+  /** A device that disappears when disconnected, so a fallback to the built-in speakers means it went away. */
+  val isRemovable: Boolean get() = this == Bluetooth || this == BluetoothLE || this == Usb
+
+  companion object {
+    fun fromCode(code: Int): TransportType = entries.firstOrNull { it.code == code } ?: Unknown
+  }
+}
+
+/**
+ * Whether playback should pause after the default output moved from [previous] to [current]:
+ * headphones or a speaker that were the output vanished and the Mac fell back to its own
+ * speakers, matching what AVFoundation apps do on route loss.
+ */
+object OutputDevicePolicy {
+  fun shouldPause(previous: TransportType, current: TransportType, playing: Boolean): Boolean {
+    return playing && previous.isRemovable && current == TransportType.BuiltIn
+  }
+}
+
+/**
+ * Observes the system default output device through CoreAudio and reports transport changes.
+ * The listener runs on a CoreAudio thread; consumers must hop to their own thread.
+ */
+internal class OutputDeviceMonitor(
+  private val onDefaultOutputChanged: (previous: TransportType, current: TransportType) -> Unit,
+) {
+
+  @Structure.FieldOrder("selector", "scope", "element")
+  class PropertyAddress(
+    @JvmField var selector: Int = 0,
+    @JvmField var scope: Int = 0,
+    @JvmField var element: Int = 0,
+  ) : Structure()
+
+  fun interface PropertyListener : Callback {
+    fun invoke(objectId: Int, addressCount: Int, addresses: Pointer?, clientData: Pointer?): Int
+  }
+
+  private val coreAudio: NativeLibrary = NativeLibrary.getInstance(CORE_AUDIO_FRAMEWORK)
+  private val addListener: Function = coreAudio.getFunction("AudioObjectAddPropertyListener")
+  private val removeListener: Function = coreAudio.getFunction("AudioObjectRemovePropertyListener")
+  private val getPropertyData: Function = coreAudio.getFunction("AudioObjectGetPropertyData")
+
+  private val defaultOutputAddress = PropertyAddress(PROPERTY_DEFAULT_OUTPUT, SCOPE_GLOBAL, ELEMENT_MAIN).also {
+    it.write()
+  }
+
+  @Volatile
+  private var current: TransportType = TransportType.Unknown
+
+  /** Held for the life of the registration; JNA callbacks are only valid while referenced. */
+  private val listener = PropertyListener { _, _, _, _ ->
+    val previous = current
+    val next = currentTransport()
+    current = next
+    if (next != previous) {
+      ibark { "Default output changed: $previous -> $next" }
+      onDefaultOutputChanged(previous, next)
+    }
+    NO_ERR
+  }
+
+  fun start() {
+    current = currentTransport()
+    ibark { "Default output is $current" }
+    val status = addListener.invokeInt(arrayOf(SYSTEM_OBJECT, defaultOutputAddress, listener, null))
+    check(status == NO_ERR) { "AudioObjectAddPropertyListener failed: $status" }
+  }
+
+  fun stop() {
+    removeListener.invokeInt(arrayOf(SYSTEM_OBJECT, defaultOutputAddress, listener, null))
+  }
+
+  private fun currentTransport(): TransportType {
+    val device = readInt(SYSTEM_OBJECT, defaultOutputAddress) ?: return TransportType.Unknown
+    if (device == 0) return TransportType.Unknown
+    val transport = PropertyAddress(PROPERTY_TRANSPORT_TYPE, SCOPE_GLOBAL, ELEMENT_MAIN).also { it.write() }
+    return readInt(device, transport)?.let(TransportType::fromCode) ?: TransportType.Unknown
+  }
+
+  private fun readInt(objectId: Int, address: PropertyAddress): Int? {
+    val size = IntByReference(Int.SIZE_BYTES)
+    val out = IntByReference()
+    val status = getPropertyData.invokeInt(arrayOf(objectId, address, 0, null, size, out))
+    return if (status == NO_ERR) out.value else null
+  }
+
+  companion object : Cork {
+    override val tag: String = "OutputDeviceMonitor"
+    override val enabled: Boolean = true
+
+    private const val CORE_AUDIO_FRAMEWORK = "/System/Library/Frameworks/CoreAudio.framework/CoreAudio"
+    private const val NO_ERR = 0
+    private const val SYSTEM_OBJECT = 1
+    private const val ELEMENT_MAIN = 0
+    private val SCOPE_GLOBAL = fourCC("glob")
+    private val PROPERTY_DEFAULT_OUTPUT = fourCC("dOut")
+    private val PROPERTY_TRANSPORT_TYPE = fourCC("tran")
+  }
+}
+
+internal fun fourCC(code: String): Int {
+  require(code.length == 4)
+  return code.fold(0) { acc, c -> (acc shl 8) or (c.code and 0xff) }
+}

--- a/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/MacNowPlayingBridgeIntegrationTest.kt
+++ b/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/MacNowPlayingBridgeIntegrationTest.kt
@@ -1,0 +1,73 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import java.awt.GraphicsEnvironment
+import java.awt.Toolkit
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Round-trips Now Playing metadata and transport state through the real MediaPlayer.framework and
+ * registers remote-command targets, proving the Objective-C bridge (message sends, runtime class
+ * definition, main-queue dispatch, framework globals) works on this machine.
+ *
+ * macOS only, and needs a window server for the AppKit run loop; skips itself elsewhere.
+ */
+class MacNowPlayingBridgeIntegrationTest {
+
+  @Test
+  fun `publishes now playing info and registers remote commands`() {
+    if (!System.getProperty("os.name").orEmpty().lowercase().contains("mac") || GraphicsEnvironment.isHeadless()) {
+      println("Not a macOS desktop session, skipping")
+      return
+    }
+    // Starts the AppKit run loop on the main thread, which the main-queue dispatch relies on
+    Toolkit.getDefaultToolkit()
+
+    val bridge = MacNowPlayingBridge()
+    val commands = object : RemoteCommandHandler {
+      override fun play() = Unit
+      override fun pause() = Unit
+      override fun togglePlayPause() = Unit
+      override fun skipForward() = Unit
+      override fun skipBackward() = Unit
+      override fun nextTrack() = Unit
+      override fun previousTrack() = Unit
+      override fun seekTo(position: kotlin.time.Duration) = Unit
+    }
+
+    try {
+      bridge.setCommandHandler(commands, skipForward = 30.seconds, skipBackward = 10.seconds)
+      bridge.setNowPlaying(
+        NowPlayingInfo(
+          title = "Campfire bridge test",
+          artist = "An Author",
+          album = "A Book",
+          duration = 10.minutes,
+          elapsed = 42.seconds,
+          rate = 1.0,
+          defaultRate = 1.0,
+        ),
+      )
+      bridge.setPlaybackState(NowPlayingState.Playing)
+
+      val (title, state) = bridge.readBack()
+      assertThat(title).isEqualTo("Campfire bridge test")
+      assertThat(state).isEqualTo(1L)
+    } finally {
+      bridge.setCommandHandler(null, 0.seconds, 0.seconds)
+      bridge.setNowPlaying(null)
+      bridge.setPlaybackState(NowPlayingState.Stopped)
+    }
+
+    val (title, state) = bridge.readBack()
+    assertThat(title).isNull()
+    assertThat(state).isEqualTo(3L)
+  }
+}

--- a/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/MacNowPlayingBridgeIntegrationTest.kt
+++ b/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/MacNowPlayingBridgeIntegrationTest.kt
@@ -5,9 +5,15 @@ package app.campfire.audioplayer.impl.macos
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import java.awt.Color
 import java.awt.GraphicsEnvironment
 import java.awt.Toolkit
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -53,21 +59,35 @@ class MacNowPlayingBridgeIntegrationTest {
           elapsed = 42.seconds,
           rate = 1.0,
           defaultRate = 1.0,
+          artwork = pngCover(),
         ),
       )
       bridge.setPlaybackState(NowPlayingState.Playing)
 
-      val (title, state) = bridge.readBack()
+      val (title, state, artworkResolves) = bridge.readBack()
       assertThat(title).isEqualTo("Campfire bridge test")
       assertThat(state).isEqualTo(1L)
+      assertThat(artworkResolves).isTrue()
     } finally {
       bridge.setCommandHandler(null, 0.seconds, 0.seconds)
       bridge.setNowPlaying(null)
       bridge.setPlaybackState(NowPlayingState.Stopped)
     }
 
-    val (title, state) = bridge.readBack()
+    val (title, state, artworkResolves) = bridge.readBack()
     assertThat(title).isNull()
     assertThat(state).isEqualTo(3L)
+    assertThat(artworkResolves).isFalse()
+  }
+
+  /** A small solid PNG, encoded the way a real cover download would arrive: as bytes. */
+  private fun pngCover(): ByteArray {
+    val image = BufferedImage(64, 96, BufferedImage.TYPE_INT_RGB)
+    image.createGraphics().apply {
+      color = Color(0xCC, 0x55, 0x22)
+      fillRect(0, 0, 64, 96)
+      dispose()
+    }
+    return ByteArrayOutputStream().also { ImageIO.write(image, "png", it) }.toByteArray()
   }
 }

--- a/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingCoordinatorTest.kt
+++ b/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingCoordinatorTest.kt
@@ -63,9 +63,16 @@ class NowPlayingCoordinatorTest {
   private val holder = FakeAudioPlayerHolder()
   private val settings = FakePlaybackSettings()
 
+  private val covers = mutableMapOf<String, ByteArray>()
+  private val coverRequests = mutableListOf<String>()
+  private val artworkLoader = ArtworkLoader { url, _ ->
+    coverRequests += url
+    covers[url]
+  }
+
   private fun TestScope.start(): Job {
     val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
-    return NowPlayingCoordinator(holder, settings, bridge, scope, testTimeSource).start()
+    return NowPlayingCoordinator(holder, settings, bridge, artworkLoader, scope, testTimeSource).start()
   }
 
   /** A player mid-way through chapter 1 of a two-track book, playing at 1.25x. */
@@ -194,9 +201,33 @@ class NowPlayingCoordinatorTest {
   }
 
   @Test
+  fun `cover art is fetched once per url and published with the metadata it belongs to`() = runTest {
+    val cover = byteArrayOf(1, 2, 3)
+    covers["https://abs/cover.jpg"] = cover
+    start()
+    val player = playingPlayer()
+    holder.setCurrentPlayer(player)
+    assertThat(bridge.infos.last()?.artwork).isNull()
+
+    player.currentMetadata.value = Metadata(title = "Chapter 1", artworkUri = "https://abs/cover.jpg")
+    assertThat(bridge.infos.last()?.artwork).isEqualTo(cover)
+    assertThat(bridge.infos.last()?.title).isEqualTo("Chapter 1")
+
+    // Same cover for the next chapter: no refetch, artwork carried along
+    player.currentMetadata.value = Metadata(title = "Chapter 2", artworkUri = "https://abs/cover.jpg")
+    assertThat(coverRequests).containsExactly("https://abs/cover.jpg")
+    assertThat(bridge.infos.last()?.artwork).isEqualTo(cover)
+
+    // A different item whose cover can't be fetched publishes without stale artwork
+    player.currentMetadata.value = Metadata(title = "Other", artworkUri = "https://abs/missing.jpg")
+    assertThat(coverRequests.last()).isEqualTo("https://abs/missing.jpg")
+    assertThat(bridge.infos.last()?.artwork).isNull()
+  }
+
+  @Test
   fun `the coordinator stops with its scope`() = runTest {
     val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
-    NowPlayingCoordinator(holder, settings, bridge, scope, testTimeSource).start()
+    NowPlayingCoordinator(holder, settings, bridge, artworkLoader, scope, testTimeSource).start()
     scope.cancel()
     holder.setCurrentPlayer(playingPlayer())
     assertThat(bridge.handler).isNull()

--- a/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingCoordinatorTest.kt
+++ b/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/NowPlayingCoordinatorTest.kt
@@ -1,0 +1,204 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package app.campfire.audioplayer.impl.macos
+
+import app.campfire.audioplayer.AudioPlayer.State
+import app.campfire.audioplayer.impl.fixtures.chapter
+import app.campfire.audioplayer.impl.fixtures.session
+import app.campfire.audioplayer.impl.fixtures.track
+import app.campfire.audioplayer.model.Metadata
+import app.campfire.audioplayer.test.FakeAudioPlayer
+import app.campfire.audioplayer.test.FakeAudioPlayer.Invocation
+import app.campfire.audioplayer.test.FakeAudioPlayerHolder
+import app.campfire.settings.test.FakePlaybackSettings
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.testTimeSource
+
+class NowPlayingCoordinatorTest {
+
+  private class FakeBridge : NowPlayingBridge {
+    val infos = mutableListOf<NowPlayingInfo?>()
+    val states = mutableListOf<NowPlayingState>()
+    var handler: RemoteCommandHandler? = null
+    var skipForward: Duration? = null
+    var skipBackward: Duration? = null
+
+    override fun setNowPlaying(info: NowPlayingInfo?) {
+      infos += info
+    }
+
+    override fun setPlaybackState(state: NowPlayingState) {
+      states += state
+    }
+
+    override fun setCommandHandler(handler: RemoteCommandHandler?, skipForward: Duration, skipBackward: Duration) {
+      this.handler = handler
+      this.skipForward = skipForward
+      this.skipBackward = skipBackward
+    }
+  }
+
+  private val bridge = FakeBridge()
+  private val holder = FakeAudioPlayerHolder()
+  private val settings = FakePlaybackSettings()
+
+  private fun TestScope.start(): Job {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
+    return NowPlayingCoordinator(holder, settings, bridge, scope, testTimeSource).start()
+  }
+
+  /** A player mid-way through chapter 1 of a two-track book, playing at 1.25x. */
+  private fun playingPlayer() = FakeAudioPlayer().apply {
+    preparedSession = session(
+      chapters = listOf(chapter(0, 0f, 600f), chapter(1, 600f, 1800f)),
+      tracks = listOf(track(1, 0f, 1800f)),
+    )
+    currentMetadata.value = Metadata(title = "Chapter 1")
+    currentDuration.value = 10.minutes
+    playbackSpeed.value = 1.25f
+    currentTime.value = 5.seconds
+    state.value = State.Playing
+  }
+
+  @Test
+  fun `without a player the system entry is cleared and commands are unregistered`() = runTest {
+    start()
+    assertThat(bridge.handler).isNull()
+    assertThat(bridge.infos).containsExactly(null)
+    assertThat(bridge.states).containsExactly(NowPlayingState.Stopped)
+  }
+
+  @Test
+  fun `a player publishes metadata, session details, rate, and transport state`() = runTest {
+    start()
+    holder.setCurrentPlayer(playingPlayer())
+
+    assertThat(bridge.handler).isNotNull()
+    assertThat(bridge.skipForward).isEqualTo(30.seconds)
+    assertThat(bridge.skipBackward).isEqualTo(10.seconds)
+    assertThat(bridge.infos.last()).isEqualTo(
+      NowPlayingInfo(
+        title = "Chapter 1",
+        artist = "An Author",
+        album = "A Book",
+        duration = 10.minutes,
+        elapsed = 5.seconds,
+        rate = 1.25,
+        defaultRate = 1.25,
+      ),
+    )
+    assertThat(bridge.states.last()).isEqualTo(NowPlayingState.Playing)
+  }
+
+  @Test
+  fun `elapsed time is republished only when it drifts from the extrapolated position`() = runTest {
+    start()
+    val player = playingPlayer()
+    holder.setCurrentPlayer(player)
+    val published = bridge.infos.size
+
+    // 4s of wall time at 1.25x puts the expected position at 10s; a tick there is not news
+    advanceTimeBy(4_000)
+    player.currentTime.value = 10.seconds
+    assertThat(bridge.infos).hasSize(published)
+
+    // A jump is a seek: republish with the new elapsed time
+    player.currentTime.value = 3.minutes
+    assertThat(bridge.infos).hasSize(published + 1)
+    assertThat(bridge.infos.last()?.elapsed).isEqualTo(3.minutes)
+  }
+
+  @Test
+  fun `pausing publishes a zero rate and the paused transport state`() = runTest {
+    start()
+    val player = playingPlayer()
+    holder.setCurrentPlayer(player)
+
+    player.state.value = State.Paused
+    assertThat(bridge.infos.last()?.rate).isEqualTo(0.0)
+    assertThat(bridge.infos.last()?.defaultRate).isEqualTo(1.25)
+    assertThat(bridge.states.last()).isEqualTo(NowPlayingState.Paused)
+
+    player.state.value = State.Buffering
+    assertThat(bridge.states.last()).isEqualTo(NowPlayingState.Paused)
+  }
+
+  @Test
+  fun `a disabled player clears the entry once and a removed player unregisters commands`() = runTest {
+    start()
+    val player = playingPlayer()
+    holder.setCurrentPlayer(player)
+
+    player.state.value = State.Disabled
+    assertThat(bridge.infos.last()).isNull()
+    assertThat(bridge.states.last()).isEqualTo(NowPlayingState.Stopped)
+    val cleared = bridge.infos.size
+    player.currentTime.value = 6.seconds
+    assertThat(bridge.infos).hasSize(cleared)
+
+    holder.setCurrentPlayer(null)
+    assertThat(bridge.handler).isNull()
+  }
+
+  @Test
+  fun `remote commands drive the player with chapter-relative seeks`() = runTest {
+    start()
+    val player = playingPlayer()
+    holder.setCurrentPlayer(player)
+    val commands = bridge.handler!!
+
+    commands.play()
+    assertThat(player.invocations).isEmpty()
+    commands.pause()
+    assertThat(player.invocations).containsExactly(Invocation.Pause)
+
+    player.state.value = State.Paused
+    commands.play()
+    assertThat(player.invocations.last()).isEqualTo(Invocation.PlayPause)
+
+    commands.togglePlayPause()
+    commands.skipForward()
+    commands.skipBackward()
+    commands.nextTrack()
+    commands.previousTrack()
+    commands.seekTo(2.5.minutes)
+    assertThat(player.invocations.drop(2)).containsExactly(
+      Invocation.PlayPause,
+      Invocation.SeekForward,
+      Invocation.SeekBackward,
+      Invocation.SkipToNext,
+      Invocation.SkipToPrevious,
+      Invocation.SeekTo(0.25f),
+    )
+  }
+
+  @Test
+  fun `the coordinator stops with its scope`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
+    NowPlayingCoordinator(holder, settings, bridge, scope, testTimeSource).start()
+    scope.cancel()
+    holder.setCurrentPlayer(playingPlayer())
+    assertThat(bridge.handler).isNull()
+  }
+}

--- a/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/OutputDevicePolicyTest.kt
+++ b/infra/audioplayer/impl/src/jvmTest/kotlin/app/campfire/audioplayer/impl/macos/OutputDevicePolicyTest.kt
@@ -1,0 +1,41 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.audioplayer.impl.macos
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class OutputDevicePolicyTest {
+
+  @Test
+  fun `losing bluetooth or usb output to the built-in speakers pauses playback`() {
+    assertThat(OutputDevicePolicy.shouldPause(TransportType.Bluetooth, TransportType.BuiltIn, playing = true)).isTrue()
+    assertThat(OutputDevicePolicy.shouldPause(TransportType.BluetoothLE, TransportType.BuiltIn, playing = true))
+      .isTrue()
+    assertThat(OutputDevicePolicy.shouldPause(TransportType.Usb, TransportType.BuiltIn, playing = true)).isTrue()
+  }
+
+  @Test
+  fun `deliberate switches and paused playback are left alone`() {
+    // Picking another device, or connecting headphones, is the user's choice
+    assertThat(OutputDevicePolicy.shouldPause(TransportType.BuiltIn, TransportType.Bluetooth, playing = true)).isFalse()
+    assertThat(OutputDevicePolicy.shouldPause(TransportType.Bluetooth, TransportType.Usb, playing = true)).isFalse()
+    assertThat(OutputDevicePolicy.shouldPause(TransportType.AirPlay, TransportType.BuiltIn, playing = true)).isFalse()
+    assertThat(OutputDevicePolicy.shouldPause(TransportType.Unknown, TransportType.BuiltIn, playing = true)).isFalse()
+    // Nothing to pause
+    assertThat(OutputDevicePolicy.shouldPause(TransportType.Bluetooth, TransportType.BuiltIn, playing = false))
+      .isFalse()
+  }
+
+  @Test
+  fun `transport codes round-trip through four character codes`() {
+    assertThat(fourCC("bltn")).isEqualTo(0x626C746E)
+    assertThat(TransportType.fromCode(fourCC("blue"))).isEqualTo(TransportType.Bluetooth)
+    assertThat(TransportType.fromCode(fourCC("usb "))).isEqualTo(TransportType.Usb)
+    assertThat(TransportType.fromCode(0x12345678)).isEqualTo(TransportType.Unknown)
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the desktop playback rework, stacked on #1065. Desktop had no system media integration on macOS: media keys launched Music, Control Center showed nothing, and disconnecting headphones kept playing through the speakers.

Everything is done through JNA (already on the classpath via vlcj) against the Objective-C runtime, MediaPlayer.framework, and CoreAudio. No toolchain change, no Swift/ObjC helper dylib, no new signing concerns.

- **`ObjC` / `MainQueue`** — fixed-arity `objc_msgSend` bindings (a varargs binding misplaces arguments on arm64), runtime class definition with JNA callbacks as method implementations, autorelease pools, framework globals; libdispatch main-queue hop because MediaPlayer expects the AppKit main thread, not the AWT event thread.
- **`MacNowPlayingBridge`** — `MPNowPlayingInfoCenter` metadata (chapter title, author, book, duration, elapsed, rate) and `playbackState`, which macOS requires on every play/pause or media keys keep going to Music. `MPRemoteCommandCenter` targets for play / pause / toggle / skip ± / next / previous / scrub, with the app's skip intervals advertised.
- **`NowPlayingCoordinator`** — pure Kotlin: mirrors the current `AudioPlayer` onto the bridge, republishes elapsed time only when it drifts from the system's extrapolation (a seek), and routes commands back with chapter-relative seeks.
- **`OutputDeviceMonitor` + `OutputDevicePolicy`** — CoreAudio default-output listener; playback pauses when the Bluetooth or USB output being listened on vanishes and the Mac falls back to built-in speakers. Deliberate device switches are left alone.
- **`MacDockMenu`** — Play/Pause, Skip Back/Forward, Previous/Next Chapter on the Dock icon menu via `java.awt.Taskbar`. Labels are AWT strings, not Compose resources (no localization path for the Dock menu today).
- **`MacMediaIntegrationInitializer`** — `AppScope` initializer, macOS only, each piece failing soft with a log line.

## Testing

- `NowPlayingCoordinatorTest` (7) and `OutputDevicePolicyTest` (3) cover the logic with a fake bridge and fake player.
- `MacNowPlayingBridgeIntegrationTest` publishes metadata and transport state through the real MediaPlayer.framework, registers remote-command targets, and reads the values back. Passes on macOS; self-skips off macOS or headless.
- Ran the desktop app for 100 s: session restored, initializer detected `Default output is BuiltIn`, no integration errors. (The run did surface pre-existing `SQLITE_BUSY` errors from socket progress updates, unrelated to this PR.)
- ktlint clean; desktop compiles.

## Not covered

Artwork in Now Playing (`MPMediaItemArtwork` needs an ObjC block for its request handler) and reasserting the Now Playing slot on app activation are follow-ups. Media-key and AirPods-tap behaviour was verified through the framework round trip, not by pressing physical keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
