### PR TITLE
Redesign the desktop playback bar around a whole-book timeline

### DIFF
--- a/.idea/runConfigurations/app_desktop__hot__.xml
+++ b/.idea/runConfigurations/app_desktop__hot__.xml
@@ -1,0 +1,35 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="app.desktop [hot] 🔥" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/app/desktop" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="hotRun" />
+          <option value="--mainClass" />
+          <option value="&quot;app.campfire.MainKt&quot;" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <EXTENSION ID="org.jetbrains.compose.desktop.ide.hotreload.ComposeHotReloadRunConfigurationExtension">
+      <ComposeHotReload>
+        <isHotReloadWarmupEnabled>true</isHotReloadWarmupEnabled>
+        <useIntelliJJBR>true</useIntelliJJBR>
+      </ComposeHotReload>
+    </EXTENSION>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "compose-hot-reload": {
+      "command": "./gradlew",
+      "args": ["--no-daemon", "--quiet", "--console=plain", ":app:desktop:hotMcpServer"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Desktop plays each audio file whole and navigates chapters within it, instead of re-opening the file at every chapter
+- Desktop playback bar is shorter and shows progress through the whole book, with chapter and bookmark markers you can hover and click
 
 ### Deprecated
 

--- a/features/sessions/ui/build.gradle.kts
+++ b/features/sessions/ui/build.gradle.kts
@@ -36,5 +36,11 @@ kotlin {
         implementation(libs.molecule)
       }
     }
+
+    jvmTest {
+      dependencies {
+        implementation(compose.desktop.currentOs)
+      }
+    }
   }
 }

--- a/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
+++ b/features/sessions/ui/src/commonMain/composeResources/values/sessions_ui_strings.xml
@@ -105,4 +105,9 @@
   <!-- Content Descriptions -->
   <string name="cd_forward_time">Forward %1$s seconds</string>
   <string name="cd_rewind_time">Rewind %1$s seconds</string>
+  <string name="bottom_bar_nothing_playing">Nothing playing</string>
+  <string name="bottom_bar_nothing_playing_hint">Pick something from your library to start listening</string>
+  <string name="bottom_bar_chapter_remaining">%1$s left in chapter</string>
+  <string name="timeline_content_description">Book progress</string>
+  <string name="timeline_time_placeholder">--:--</string>
 </resources>

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
@@ -4,7 +4,6 @@
 package app.campfire.sessions.ui
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -17,15 +16,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
@@ -46,7 +42,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.model.EqualizerState
@@ -56,13 +51,8 @@ import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.common.compose.extensions.readoutFormat
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Bookmarks
-import app.campfire.common.compose.icons.rounded.EditAudio
 import app.campfire.common.compose.icons.rounded.Equalizer
 import app.campfire.common.compose.icons.rounded.List
-import app.campfire.common.compose.icons.rounded.Pause
-import app.campfire.common.compose.icons.rounded.PlayArrow
-import app.campfire.common.compose.icons.rounded.SkipNext
-import app.campfire.common.compose.icons.rounded.SkipPrevious
 import app.campfire.common.compose.icons.rounded.Timer
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.widgets.CoverImage
@@ -74,9 +64,8 @@ import app.campfire.core.model.Bookmark
 import app.campfire.core.model.Chapter
 import app.campfire.core.model.Session
 import app.campfire.sessions.ui.bottombar.BookTimeline
-import app.campfire.sessions.ui.composables.ForwardIcon
+import app.campfire.sessions.ui.bottombar.DesktopPlaybackActions
 import app.campfire.sessions.ui.composables.PlaybackSpeedAction
-import app.campfire.sessions.ui.composables.RewindIcon
 import app.campfire.sessions.ui.composables.RunningTimerText
 import app.campfire.sessions.ui.sheets.bookmarks.BookmarkResult
 import app.campfire.sessions.ui.sheets.bookmarks.showBookmarksBottomSheet
@@ -93,11 +82,6 @@ import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.action_add_bookmark
 import campfire.features.sessions.ui.generated.resources.action_chapters
 import campfire.features.sessions.ui.generated.resources.action_equalizer
-import campfire.features.sessions.ui.generated.resources.action_forward
-import campfire.features.sessions.ui.generated.resources.action_play_pause
-import campfire.features.sessions.ui.generated.resources.action_rewind
-import campfire.features.sessions.ui.generated.resources.action_skip_next
-import campfire.features.sessions.ui.generated.resources.action_skip_previous
 import campfire.features.sessions.ui.generated.resources.action_sleep_timer
 import campfire.features.sessions.ui.generated.resources.bottom_bar_chapter_remaining
 import campfire.features.sessions.ui.generated.resources.bottom_bar_nothing_playing
@@ -287,7 +271,7 @@ internal fun PlaybackBottomBarContent(
           modifier = Modifier.weight(1f),
         )
 
-        PlaybackActions(
+        DesktopPlaybackActions(
           state = state,
           enabled = hasSession,
           onSkipPreviousClick = onSkipPreviousClick,
@@ -434,103 +418,6 @@ private fun NowPlayingInfo(
         overflow = TextOverflow.Ellipsis,
         modifier = Modifier.alpha(0.7f),
       )
-    }
-  }
-}
-
-@Composable
-private fun PlaybackActions(
-  state: AudioPlayer.State,
-  enabled: Boolean,
-  onSkipPreviousClick: () -> Unit,
-  onRewindClick: () -> Unit,
-  onPlayPauseClick: () -> Unit,
-  onForwardClick: () -> Unit,
-  onSkipNextClick: () -> Unit,
-  modifier: Modifier = Modifier,
-  actionSize: Dp = 26.dp,
-  playPauseSize: Dp = 44.dp,
-) {
-  Row(
-    modifier = modifier,
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
-  ) {
-    val skipPreviousLabel = stringResource(Res.string.action_skip_previous)
-    IconButtonTooltip(text = skipPreviousLabel) {
-      IconButton(onClick = onSkipPreviousClick, enabled = enabled) {
-        Icon(
-          CampfireIcons.Rounded.SkipPrevious,
-          modifier = Modifier.size(actionSize),
-          contentDescription = skipPreviousLabel,
-        )
-      }
-    }
-
-    val rewindLabel = stringResource(Res.string.action_rewind)
-    IconButtonTooltip(text = rewindLabel) {
-      IconButton(onClick = onRewindClick, enabled = enabled) {
-        RewindIcon(modifier = Modifier.size(actionSize))
-      }
-    }
-
-    val isPlayPauseEnabled = enabled &&
-      state != AudioPlayer.State.Finished &&
-      state != AudioPlayer.State.Buffering
-
-    val elevation by animateDpAsState(targetValue = if (isPlayPauseEnabled) 4.dp else 0.dp)
-
-    val playPauseLabel = stringResource(Res.string.action_play_pause)
-    IconButtonTooltip(text = playPauseLabel) {
-      Surface(
-        shape = CircleShape,
-        modifier = Modifier.size(playPauseSize),
-        shadowElevation = elevation,
-        onClick = onPlayPauseClick,
-        enabled = isPlayPauseEnabled,
-      ) {
-        Box(
-          modifier = Modifier.fillMaxSize(),
-          contentAlignment = Alignment.Center,
-        ) {
-          if (state != AudioPlayer.State.Buffering) {
-            Icon(
-              when {
-                state == AudioPlayer.State.Playing -> CampfireIcons.Rounded.Pause
-                state == AudioPlayer.State.Finished -> CampfireIcons.Rounded.EditAudio
-                else -> CampfireIcons.Rounded.PlayArrow
-              },
-              modifier = Modifier
-                .size(actionSize)
-                .alpha(if (isPlayPauseEnabled) 1f else 0.5f),
-              contentDescription = playPauseLabel,
-            )
-          } else {
-            CircularProgressIndicator(
-              modifier = Modifier.size(actionSize),
-              strokeWidth = 3.dp,
-            )
-          }
-        }
-      }
-    }
-
-    val forwardLabel = stringResource(Res.string.action_forward)
-    IconButtonTooltip(text = forwardLabel) {
-      IconButton(onClick = onForwardClick, enabled = enabled) {
-        ForwardIcon(modifier = Modifier.size(actionSize))
-      }
-    }
-
-    val skipNextLabel = stringResource(Res.string.action_skip_next)
-    IconButtonTooltip(text = skipNextLabel) {
-      IconButton(onClick = onSkipNextClick, enabled = enabled) {
-        Icon(
-          CampfireIcons.Rounded.SkipNext,
-          modifier = Modifier.size(actionSize),
-          contentDescription = skipNextLabel,
-        )
-      }
     }
   }
 }

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
@@ -4,9 +4,7 @@
 package app.campfire.sessions.ui
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -14,9 +12,6 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +19,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -34,31 +30,24 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import app.campfire.audioplayer.AudioPlayer
 import app.campfire.audioplayer.model.EqualizerState
 import app.campfire.audioplayer.model.Metadata
@@ -69,7 +58,6 @@ import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Bookmarks
 import app.campfire.common.compose.icons.rounded.EditAudio
 import app.campfire.common.compose.icons.rounded.Equalizer
-import app.campfire.common.compose.icons.rounded.KeyboardDoubleArrowRight
 import app.campfire.common.compose.icons.rounded.List
 import app.campfire.common.compose.icons.rounded.Pause
 import app.campfire.common.compose.icons.rounded.PlayArrow
@@ -79,11 +67,13 @@ import app.campfire.common.compose.icons.rounded.Timer
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.widgets.CoverImage
 import app.campfire.common.compose.widgets.IconButtonTooltip
-import app.campfire.core.extensions.fluentIf
+import app.campfire.core.di.ComponentHolder
+import app.campfire.core.di.UserScope
 import app.campfire.core.model.AudioTrack
 import app.campfire.core.model.Bookmark
 import app.campfire.core.model.Chapter
 import app.campfire.core.model.Session
+import app.campfire.sessions.ui.bottombar.BookTimeline
 import app.campfire.sessions.ui.composables.ForwardIcon
 import app.campfire.sessions.ui.composables.PlaybackSpeedAction
 import app.campfire.sessions.ui.composables.RewindIcon
@@ -98,62 +88,96 @@ import app.campfire.sessions.ui.sheets.sleeptimer.showSleepTimerBottomSheet
 import app.campfire.sessions.ui.sheets.speed.showPlaybackSpeedBottomSheet
 import app.campfire.sessions.ui.sheets.tracks.AudioTrackResult
 import app.campfire.sessions.ui.sheets.tracks.showAudioTrackBottomSheet
+import app.campfire.user.api.BookmarkRepository
 import campfire.features.sessions.ui.generated.resources.Res
 import campfire.features.sessions.ui.generated.resources.action_add_bookmark
 import campfire.features.sessions.ui.generated.resources.action_chapters
 import campfire.features.sessions.ui.generated.resources.action_equalizer
 import campfire.features.sessions.ui.generated.resources.action_forward
+import campfire.features.sessions.ui.generated.resources.action_play_pause
 import campfire.features.sessions.ui.generated.resources.action_rewind
 import campfire.features.sessions.ui.generated.resources.action_skip_next
 import campfire.features.sessions.ui.generated.resources.action_skip_previous
 import campfire.features.sessions.ui.generated.resources.action_sleep_timer
+import campfire.features.sessions.ui.generated.resources.bottom_bar_chapter_remaining
+import campfire.features.sessions.ui.generated.resources.bottom_bar_nothing_playing
+import campfire.features.sessions.ui.generated.resources.bottom_bar_nothing_playing_hint
 import campfire.features.sessions.ui.generated.resources.label_end_of_chapter_short
+import com.r0adkll.kimchi.annotations.ContributesTo
 import com.slack.circuit.overlay.LocalOverlayHost
-import ir.mahozad.multiplatform.wavyslider.WaveDirection
-import ir.mahozad.multiplatform.wavyslider.material3.WavySlider
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
+@ContributesTo(UserScope::class)
+interface PlaybackBottomBarComponent {
+  val bookmarkRepository: BookmarkRepository
+}
+
+@Composable
+private fun rememberPlaybackBottomBarComponent(): State<PlaybackBottomBarComponent> {
+  return remember {
+    ComponentHolder.subscribe<PlaybackBottomBarComponent>()
+  }.collectAsState(ComponentHolder.component<PlaybackBottomBarComponent>())
+}
+
+/**
+ * The always-visible desktop player, spanning the window's bottom edge. Two rows: a thin
+ * whole-book timeline with chapter and bookmark markers on top, and cover, titles, transport,
+ * and tools beneath. Renders a "nothing playing" state instead of disappearing, so the window
+ * layout stays put between sessions.
+ */
 @Composable
 fun PlaybackBottomBar(
   modifier: Modifier = Modifier,
+  component: State<PlaybackBottomBarComponent> = rememberPlaybackBottomBarComponent(),
 ) {
-  SessionHostLayout { currentSession, audioPlayer, clearSession, startSession ->
-    val currentTime = remember(audioPlayer) {
+  SessionHostLayout { currentSession, audioPlayer, _, startSession ->
+    val currentTime by remember(audioPlayer) {
       audioPlayer?.currentTime ?: emptyFlow()
     }.collectAsState(0.seconds)
 
-    val currentDuration = remember(audioPlayer) {
+    val bookTime by remember(audioPlayer) {
+      audioPlayer?.overallTime ?: emptyFlow()
+    }.collectAsState(0.seconds)
+
+    val currentDuration by remember(audioPlayer) {
       audioPlayer?.currentDuration ?: emptyFlow()
     }.collectAsState(0.seconds)
 
-    val currentMetadata = remember(audioPlayer) {
+    val currentMetadata by remember(audioPlayer) {
       audioPlayer?.currentMetadata ?: emptyFlow()
     }.collectAsState(Metadata())
 
-    val playerState = remember(audioPlayer) {
+    val playerState by remember(audioPlayer) {
       audioPlayer?.state ?: emptyFlow()
     }.collectAsState(AudioPlayer.State.Disabled)
 
-    val playbackSpeed = remember(audioPlayer) {
+    val playbackSpeed by remember(audioPlayer) {
       audioPlayer?.playbackSpeed ?: emptyFlow()
     }.collectAsState(1f)
 
-    val runningTimer = remember(audioPlayer) {
+    val runningTimer by remember(audioPlayer) {
       audioPlayer?.runningTimer ?: emptyFlow()
     }.collectAsState(null)
 
-    val equalizer = remember(audioPlayer) {
+    val equalizer by remember(audioPlayer) {
       audioPlayer?.equalizer ?: emptyFlow()
     }.collectAsState(EqualizerState.Unsupported)
+
+    val comp by component
+    val libraryItemId = currentSession?.libraryItem?.id
+    val bookmarks by remember(comp, libraryItemId) {
+      libraryItemId?.let { comp.bookmarkRepository.observeBookmarks(it) } ?: flowOf(emptyList())
+    }.collectAsState(emptyList())
 
     // Until an audio player is prepared for this session (service cold start, resume
     // priming), derive the same display values from the session row the player would seed
     // from — the handoff to live player state is value-identical
-    val placeholder = when (playerState.value) {
+    val placeholder = when (playerState) {
       AudioPlayer.State.Disabled,
       AudioPlayer.State.Initializing,
       -> currentSession?.placeholderDisplayState()
@@ -161,17 +185,19 @@ fun PlaybackBottomBar(
       else -> null
     }
 
-    PlaybackBottomBar(
+    PlaybackBottomBarContent(
       session = currentSession,
-      state = playerState.value,
-      playbackSpeed = playbackSpeed.value,
-      currentTime = placeholder?.time ?: currentTime.value,
-      currentDuration = placeholder?.duration ?: currentDuration.value,
-      currentMetadata = placeholder?.metadata ?: currentMetadata.value,
-      runningTimer = runningTimer.value,
-      equalizer = equalizer.value,
+      state = playerState,
+      playbackSpeed = playbackSpeed,
+      currentTime = placeholder?.time ?: currentTime,
+      currentDuration = placeholder?.duration ?: currentDuration,
+      bookTime = placeholder?.bookTime ?: bookTime,
+      currentMetadata = placeholder?.metadata ?: currentMetadata,
+      runningTimer = runningTimer,
+      equalizer = equalizer,
+      bookmarks = bookmarks,
       onPlayPauseClick = {
-        if (playerState.value == AudioPlayer.State.Disabled) {
+        if (playerState == AudioPlayer.State.Disabled) {
           startSession()
         } else {
           audioPlayer?.playPause()
@@ -181,38 +207,29 @@ fun PlaybackBottomBar(
       onForwardClick = { audioPlayer?.seekForward() },
       onSkipPreviousClick = { audioPlayer?.skipToPrevious() },
       onSkipNextClick = { audioPlayer?.skipToNext() },
-      onSeek = { progress ->
-        audioPlayer?.seekTo(progress)
-      },
-      onTimerCleared = {
-        audioPlayer?.clearTimer()
-      },
-      onTimerSelected = { timer ->
-        audioPlayer?.setTimer(timer)
-      },
-      onChapterSelected = { chapter ->
-        audioPlayer?.seekTo(chapter.id)
-      },
-      onAudioTrackSelected = { track ->
-        audioPlayer?.seekTo(track.index - 1)
-      },
-      onBookmarkSelected = { bookmark ->
-        audioPlayer?.seekTo(bookmark.time)
-      },
+      onSeekTo = { time -> audioPlayer?.seekTo(time) },
+      onTimerCleared = { audioPlayer?.clearTimer() },
+      onTimerSelected = { timer -> audioPlayer?.setTimer(timer) },
+      onChapterSelected = { chapter -> audioPlayer?.seekTo(chapter.id) },
+      onAudioTrackSelected = { track -> audioPlayer?.seekTo(track.index - 1) },
+      onBookmarkSelected = { bookmark -> audioPlayer?.seekTo(bookmark.time) },
       modifier = modifier,
     )
   }
 }
 
+/** The bar itself, driven by plain values so it can be previewed and rendered in tests. */
 @Composable
-private fun PlaybackBottomBar(
+internal fun PlaybackBottomBarContent(
   state: AudioPlayer.State,
   playbackSpeed: Float,
   currentTime: Duration,
   currentDuration: Duration,
+  bookTime: Duration,
   currentMetadata: Metadata,
   runningTimer: RunningTimer?,
   equalizer: EqualizerState,
+  bookmarks: List<Bookmark>,
 
   session: Session?,
   onPlayPauseClick: () -> Unit,
@@ -220,7 +237,7 @@ private fun PlaybackBottomBar(
   onForwardClick: () -> Unit,
   onSkipNextClick: () -> Unit,
   onSkipPreviousClick: () -> Unit,
-  onSeek: (Float) -> Unit,
+  onSeekTo: (Duration) -> Unit,
   onTimerSelected: (PlaybackTimer) -> Unit,
   onTimerCleared: () -> Unit,
   onChapterSelected: (Chapter) -> Unit,
@@ -230,60 +247,48 @@ private fun PlaybackBottomBar(
   modifier: Modifier = Modifier,
 ) {
   val scope = rememberCoroutineScope()
+  val hasSession = session != null
+  val chapters = session?.libraryItem?.media?.chapters.orEmpty()
+  val hasChapters = chapters.isNotEmpty() && session?.episodeId == null
 
   Surface(
     color = MaterialTheme.colorScheme.secondaryContainer,
     modifier = modifier,
   ) {
-    Row(
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      // Left Grouping of items, mainly the image, title, subtitle, and timer
+    Column {
+      BookTimeline(
+        position = bookTime,
+        duration = session?.duration ?: Duration.ZERO,
+        chapters = if (hasChapters) chapters else emptyList(),
+        bookmarks = bookmarks,
+        playbackSpeed = playbackSpeed,
+        enabled = hasSession && state != AudioPlayer.State.Initializing,
+        onSeek = onSeekTo,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 8.dp),
+      )
+
       Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.weight(1f),
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(ContentRowHeight)
+          .padding(start = 16.dp, end = 8.dp, bottom = 8.dp),
       ) {
-        ItemThumbnailImage(
+        NowPlayingInfo(
           session = session,
           currentMetadata = currentMetadata,
-          modifier = Modifier.padding(16.dp),
+          currentTime = currentTime,
+          currentDuration = currentDuration,
+          playbackSpeed = playbackSpeed,
+          hasChapters = hasChapters,
+          modifier = Modifier.weight(1f),
         )
 
-        Column(
-          verticalArrangement = Arrangement.Center,
-        ) {
-          Text(
-            text = currentMetadata.title ?: session?.title ?: "--",
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.SemiBold,
-            fontFamily = PaytoneOneFontFamily,
-            modifier = Modifier,
-          )
-
-          Text(
-            text = session?.libraryItem?.media?.metadata?.title ?: "--",
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.alpha(40f),
-          )
-        }
-      }
-
-      val interactionSource = remember { MutableInteractionSource() }
-      val isPressed by interactionSource.collectIsPressedAsState()
-      val isDragged by interactionSource.collectIsDraggedAsState()
-      val isInteracting = isPressed || isDragged
-
-      Column(
-        modifier = Modifier
-          .weight(3f)
-          .padding(
-            vertical = 8.dp,
-          ),
-        horizontalAlignment = Alignment.CenterHorizontally,
-      ) {
         PlaybackActions(
           state = state,
-          isInteracting = isInteracting,
+          enabled = hasSession,
           onSkipPreviousClick = onSkipPreviousClick,
           onRewindClick = onRewindClick,
           onPlayPauseClick = onPlayPauseClick,
@@ -291,132 +296,168 @@ private fun PlaybackBottomBar(
           onSkipNextClick = onSkipNextClick,
         )
 
-        PlaybackSeekBar(
-          state = state,
-          currentTime = currentTime,
-          currentDuration = currentDuration,
-          playbackSpeed = playbackSpeed,
-          onSeek = onSeek,
-          modifier = Modifier
-            .padding(horizontal = 24.dp),
-          interactionSource = interactionSource,
+        val overlayHost = LocalOverlayHost.current
+        ActionRow(
+          modifier = Modifier.weight(1f),
+          enabled = hasSession,
+          runningTimer = runningTimer,
+          onBookmarkAddClick = {
+            if (session == null) return@ActionRow
+            scope.launch {
+              when (val result = overlayHost.showBookmarksBottomSheet(session.libraryItem.id)) {
+                is BookmarkResult.Selected -> onBookmarkSelected(result.bookmark)
+                BookmarkResult.None -> Unit
+              }
+            }
+          },
+          speedContent = {
+            PlaybackSpeedAction(
+              playbackSpeed = playbackSpeed,
+              onClick = {
+                if (session == null) return@PlaybackSpeedAction
+                scope.launch {
+                  overlayHost.showPlaybackSpeedBottomSheet(session.libraryItem.id, playbackSpeed)
+                }
+              },
+            )
+          },
+          onTimerClick = {
+            if (session == null) return@ActionRow
+            scope.launch {
+              when (val result = overlayHost.showSleepTimerBottomSheet(runningTimer)) {
+                is TimerResult.Selected -> onTimerSelected(result.timer)
+                TimerResult.Cleared -> onTimerCleared()
+                else -> Unit
+              }
+            }
+          },
+          showEqualizer = equalizer !is EqualizerState.Unsupported,
+          onEqualizerClick = {
+            if (session == null) return@ActionRow
+            scope.launch {
+              overlayHost.showEqualizerBottomSheet(session.libraryItem.id)
+            }
+          },
+          showChapters = session?.episodeId == null,
+          onChapterListClick = {
+            if (session == null) return@ActionRow
+            if (session.libraryItem.media.chapters.isNotEmpty()) {
+              scope.launch {
+                val result = overlayHost.showChapterBottomSheet(
+                  chapters = session.libraryItem.media.chapters,
+                  currentChapter = session.chapter,
+                  playbackSpeed = playbackSpeed,
+                )
+                if (result is ChapterResult.Selected) {
+                  onChapterSelected(result.chapter)
+                }
+              }
+            } else if (session.libraryItem.media.tracks.isNotEmpty()) {
+              scope.launch {
+                val result = overlayHost.showAudioTrackBottomSheet(
+                  audioTracks = session.libraryItem.media.tracks,
+                  currentAudioTrack = session.audioTrack,
+                  playbackSpeed = playbackSpeed,
+                )
+                if (result is AudioTrackResult.Selected) {
+                  onAudioTrackSelected(result.audioTrack)
+                }
+              }
+            }
+          },
         )
       }
+    }
+  }
+}
 
-      val overlayHost = LocalOverlayHost.current
-      ActionRow(
-        modifier = Modifier.weight(1f),
-        runningTimer = runningTimer,
-        onBookmarkAddClick = {
-          if (session == null) return@ActionRow
-          scope.launch {
-            when (val result = overlayHost.showBookmarksBottomSheet(session.libraryItem.id)) {
-              is BookmarkResult.Selected -> onBookmarkSelected(result.bookmark)
-              BookmarkResult.None -> Unit
-            }
-          }
+/** Cover, current chapter (or track/episode) title, and the book title with chapter time left. */
+@Composable
+private fun NowPlayingInfo(
+  session: Session?,
+  currentMetadata: Metadata,
+  currentTime: Duration,
+  currentDuration: Duration,
+  playbackSpeed: Float,
+  hasChapters: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = modifier,
+  ) {
+    if (session != null) {
+      CoverImage(
+        imageUrl = currentMetadata.artworkUri ?: session.libraryItem.media.coverImageUrl ?: "",
+        contentDescription = session.libraryItem.media.metadata.title,
+        size = CoverSize,
+        shape = RoundedCornerShape(8.dp),
+      )
+    } else {
+      Box(
+        modifier = Modifier
+          .size(CoverSize)
+          .background(MaterialTheme.colorScheme.surfaceContainerHigh, RoundedCornerShape(8.dp)),
+      )
+    }
+
+    Spacer(Modifier.width(12.dp))
+
+    Column(verticalArrangement = Arrangement.Center) {
+      Text(
+        text = if (session == null) {
+          stringResource(Res.string.bottom_bar_nothing_playing)
+        } else {
+          currentMetadata.title ?: session.title
         },
-        speedContent = {
-          PlaybackSpeedAction(
-            playbackSpeed = playbackSpeed,
-            onClick = {
-              if (session == null) return@PlaybackSpeedAction
-              scope.launch {
-                overlayHost.showPlaybackSpeedBottomSheet(session.libraryItem.id, playbackSpeed)
-              }
-            },
-          )
-        },
-        onTimerClick = {
-          if (session == null) return@ActionRow
-          scope.launch {
-            when (val result = overlayHost.showSleepTimerBottomSheet(runningTimer)) {
-              is TimerResult.Selected -> onTimerSelected(result.timer)
-              TimerResult.Cleared -> onTimerCleared()
-              else -> Unit
-            }
-          }
-        },
-        showEqualizer = equalizer !is EqualizerState.Unsupported,
-        onEqualizerClick = {
-          if (session == null) return@ActionRow
-          scope.launch {
-            overlayHost.showEqualizerBottomSheet(session.libraryItem.id)
-          }
-        },
-        onChapterListClick = {
-          if (session == null) return@ActionRow
-          if (session.libraryItem.media.chapters.isNotEmpty()) {
-            scope.launch {
-              val result = overlayHost.showChapterBottomSheet(
-                chapters = session.libraryItem.media.chapters,
-                currentChapter = session.chapter,
-                playbackSpeed = playbackSpeed,
-              )
-              if (result is ChapterResult.Selected) {
-                onChapterSelected(result.chapter)
-              }
-            }
-          } else if (session.libraryItem.media.tracks.isNotEmpty()) {
-            scope.launch {
-              val result = overlayHost.showAudioTrackBottomSheet(
-                audioTracks = session.libraryItem.media.tracks,
-                currentAudioTrack = session.audioTrack,
-                playbackSpeed = playbackSpeed,
-              )
-              if (result is AudioTrackResult.Selected) {
-                onAudioTrackSelected(result.audioTrack)
-              }
-            }
-          }
-        },
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        fontFamily = PaytoneOneFontFamily,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+
+      val subtitle = when {
+        session == null -> stringResource(Res.string.bottom_bar_nothing_playing_hint)
+        hasChapters && currentDuration > Duration.ZERO -> {
+          val remaining = ((currentDuration - currentTime) / playbackSpeed.toDouble()).coerceAtLeast(Duration.ZERO)
+          "${session.libraryItem.media.metadata.title.orEmpty()} · " +
+            stringResource(Res.string.bottom_bar_chapter_remaining, remaining.readoutFormat().trim())
+        }
+        else -> session.libraryItem.media.metadata.title.orEmpty()
+      }
+      Text(
+        text = subtitle,
+        style = MaterialTheme.typography.labelSmall,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.alpha(0.7f),
       )
     }
   }
 }
 
 @Composable
-private fun ItemThumbnailImage(
-  session: Session?,
-  currentMetadata: Metadata,
-  modifier: Modifier = Modifier,
-) {
-  val imageSize = 88.dp
-  val mediaUrl = currentMetadata.artworkUri
-    ?: session?.libraryItem?.media?.coverImageUrl
-    ?: ""
-  CoverImage(
-    imageUrl = mediaUrl,
-    contentDescription = session?.libraryItem?.media?.metadata?.title,
-    size = imageSize,
-    shape = RoundedCornerShape(8.dp),
-    modifier = modifier,
-  )
-}
-
-@Composable
 private fun PlaybackActions(
   state: AudioPlayer.State,
-  isInteracting: Boolean,
+  enabled: Boolean,
   onSkipPreviousClick: () -> Unit,
   onRewindClick: () -> Unit,
   onPlayPauseClick: () -> Unit,
   onForwardClick: () -> Unit,
   onSkipNextClick: () -> Unit,
   modifier: Modifier = Modifier,
-  actionSize: Dp = 32.dp,
-  playPauseSize: Dp = 48.dp,
+  actionSize: Dp = 26.dp,
+  playPauseSize: Dp = 44.dp,
 ) {
   Row(
-    modifier = modifier.fillMaxWidth(),
+    modifier = modifier,
     verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
   ) {
     val skipPreviousLabel = stringResource(Res.string.action_skip_previous)
     IconButtonTooltip(text = skipPreviousLabel) {
-      IconButton(
-        onClick = onSkipPreviousClick,
-      ) {
+      IconButton(onClick = onSkipPreviousClick, enabled = enabled) {
         Icon(
           CampfireIcons.Rounded.SkipPrevious,
           modifier = Modifier.size(actionSize),
@@ -427,77 +468,62 @@ private fun PlaybackActions(
 
     val rewindLabel = stringResource(Res.string.action_rewind)
     IconButtonTooltip(text = rewindLabel) {
-      IconButton(
-        onClick = onRewindClick,
-      ) {
-        RewindIcon(
-          modifier = Modifier.size(actionSize),
-        )
+      IconButton(onClick = onRewindClick, enabled = enabled) {
+        RewindIcon(modifier = Modifier.size(actionSize))
       }
     }
 
-    val isPlayPauseEnabled = state != AudioPlayer.State.Finished &&
-      state != AudioPlayer.State.Buffering &&
-      !isInteracting
+    val isPlayPauseEnabled = enabled &&
+      state != AudioPlayer.State.Finished &&
+      state != AudioPlayer.State.Buffering
 
-    val elevation by animateDpAsState(
-      targetValue = if (isPlayPauseEnabled) {
-        6.dp
-      } else {
-        1.dp
-      },
-    )
+    val elevation by animateDpAsState(targetValue = if (isPlayPauseEnabled) 4.dp else 0.dp)
 
-    Surface(
-      shape = CircleShape,
-      modifier = Modifier.size(playPauseSize),
-      shadowElevation = elevation,
-      onClick = onPlayPauseClick,
-      enabled = isPlayPauseEnabled,
-    ) {
-      Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
+    val playPauseLabel = stringResource(Res.string.action_play_pause)
+    IconButtonTooltip(text = playPauseLabel) {
+      Surface(
+        shape = CircleShape,
+        modifier = Modifier.size(playPauseSize),
+        shadowElevation = elevation,
+        onClick = onPlayPauseClick,
+        enabled = isPlayPauseEnabled,
       ) {
-        if (state != AudioPlayer.State.Buffering) {
-          Icon(
-            if (isInteracting) {
-              CampfireIcons.Rounded.EditAudio
-            } else if (state == AudioPlayer.State.Playing) {
-              CampfireIcons.Rounded.Pause
-            } else {
-              CampfireIcons.Rounded.PlayArrow
-            },
-            modifier = Modifier
-              .size(actionSize)
-              .alpha(if (isPlayPauseEnabled) 1f else 0.5f),
-            contentDescription = null,
-          )
-        } else {
-          CircularProgressIndicator(
-            modifier = Modifier.size(actionSize),
-            strokeWidth = 4.dp,
-          )
+        Box(
+          modifier = Modifier.fillMaxSize(),
+          contentAlignment = Alignment.Center,
+        ) {
+          if (state != AudioPlayer.State.Buffering) {
+            Icon(
+              when {
+                state == AudioPlayer.State.Playing -> CampfireIcons.Rounded.Pause
+                state == AudioPlayer.State.Finished -> CampfireIcons.Rounded.EditAudio
+                else -> CampfireIcons.Rounded.PlayArrow
+              },
+              modifier = Modifier
+                .size(actionSize)
+                .alpha(if (isPlayPauseEnabled) 1f else 0.5f),
+              contentDescription = playPauseLabel,
+            )
+          } else {
+            CircularProgressIndicator(
+              modifier = Modifier.size(actionSize),
+              strokeWidth = 3.dp,
+            )
+          }
         }
       }
     }
 
     val forwardLabel = stringResource(Res.string.action_forward)
     IconButtonTooltip(text = forwardLabel) {
-      IconButton(
-        onClick = onForwardClick,
-      ) {
-        ForwardIcon(
-          modifier = Modifier.size(actionSize),
-        )
+      IconButton(onClick = onForwardClick, enabled = enabled) {
+        ForwardIcon(modifier = Modifier.size(actionSize))
       }
     }
 
     val skipNextLabel = stringResource(Res.string.action_skip_next)
     IconButtonTooltip(text = skipNextLabel) {
-      IconButton(
-        onClick = onSkipNextClick,
-      ) {
+      IconButton(onClick = onSkipNextClick, enabled = enabled) {
         Icon(
           CampfireIcons.Rounded.SkipNext,
           modifier = Modifier.size(actionSize),
@@ -509,139 +535,26 @@ private fun PlaybackActions(
 }
 
 @Composable
-private fun PlaybackSeekBar(
-  state: AudioPlayer.State,
-  currentTime: Duration,
-  currentDuration: Duration,
-  playbackSpeed: Float,
-  onSeek: (Float) -> Unit,
-  modifier: Modifier = Modifier,
-  interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-) {
-  val isPressed by interactionSource.collectIsPressedAsState()
-  val isDragged by interactionSource.collectIsDraggedAsState()
-  val isInteracting = isPressed || isDragged
-
-  fun calculateProgress(): Float = if (currentDuration.inWholeMilliseconds == 0L) {
-    0f
-  } else {
-    (currentTime / currentDuration).toFloat()
-  }
-
-  var sliderValue by remember { mutableStateOf(calculateProgress()) }
-  val softSliderValue by animateFloatAsState(sliderValue)
-  LaunchedEffect(isInteracting, state, currentTime, currentDuration) {
-    if (!isInteracting) {
-      sliderValue = calculateProgress()
-    }
-  }
-
-  val waveHeight = if (state == AudioPlayer.State.Playing) 16.dp else 0.dp
-  val waveVelocity = if (state == AudioPlayer.State.Playing) 40.dp else 0.dp
-  val waveThickness = if (state == AudioPlayer.State.Playing) 12.dp else 16.dp
-
-  Row(
-    modifier = modifier,
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.Center,
-  ) {
-    val currentTimeLabel = if (isInteracting) {
-      currentDuration.times(sliderValue.toDouble()).readoutFormat()
-    } else {
-      currentTime.readoutFormat()
-    }
-
-    Text(
-      text = currentTimeLabel,
-      textAlign = TextAlign.End,
-      style = MaterialTheme.typography.labelSmall,
-      fontFamily = FontFamily.Monospace,
-      modifier = Modifier
-        .width(100.dp),
-    )
-
-    val sliderColors = SliderDefaults.colors(
-      inactiveTrackColor = MaterialTheme.colorScheme.surfaceContainer,
-    )
-    WavySlider(
-      value = softSliderValue,
-      onValueChange = { sliderValue = it },
-      onValueChangeFinished = {
-        onSeek(sliderValue)
-      },
-      interactionSource = interactionSource,
-      colors = sliderColors,
-      waveLength = 50.dp,
-      waveHeight = waveHeight,
-      waveVelocity = waveVelocity to WaveDirection.TAIL,
-      waveThickness = waveThickness,
-      thumb = {
-        SliderDefaults.Thumb(
-          interactionSource = interactionSource,
-          colors = sliderColors,
-          enabled = true,
-          thumbSize = DpSize(4.dp, 36.dp),
-        )
-      },
-      modifier = Modifier
-        .width(640.dp)
-        .padding(horizontal = 24.dp),
-    )
-
-    val isAccelerated = playbackSpeed != 1f
-    AnimatedVisibility(
-      visible = isAccelerated,
-    ) {
-      Icon(
-        CampfireIcons.Rounded.KeyboardDoubleArrowRight,
-        contentDescription = null,
-        modifier = Modifier.size(16.dp),
-        tint = MaterialTheme.colorScheme.secondary,
-      )
-    }
-
-    val currentRemainingDuration = (currentDuration - currentTime).div(playbackSpeed.toDouble())
-    Text(
-      text = currentRemainingDuration.readoutFormat(),
-      textAlign = TextAlign.Start,
-      style = MaterialTheme.typography.labelSmall.fluentIf(isAccelerated) {
-        copy(
-          fontWeight = FontWeight.Bold,
-          fontStyle = FontStyle.Italic,
-          color = MaterialTheme.colorScheme.secondary,
-          fontSize = 12.sp,
-        )
-      },
-      fontFamily = FontFamily.Monospace,
-      modifier = Modifier
-        .width(100.dp),
-    )
-  }
-}
-
-@Composable
 private fun ActionRow(
+  enabled: Boolean,
   runningTimer: RunningTimer?,
   onBookmarkAddClick: () -> Unit,
   speedContent: @Composable () -> Unit,
   onTimerClick: () -> Unit,
   showEqualizer: Boolean,
   onEqualizerClick: () -> Unit,
+  showChapters: Boolean,
   onChapterListClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Row(
-    modifier = modifier.padding(
-      horizontal = 16.dp,
-    ),
+    modifier = modifier.padding(horizontal = 8.dp),
     verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
   ) {
     val bookmarkLabel = stringResource(Res.string.action_add_bookmark)
     IconButtonTooltip(text = bookmarkLabel) {
-      IconButton(
-        onClick = onBookmarkAddClick,
-      ) {
+      IconButton(onClick = onBookmarkAddClick, enabled = enabled) {
         Icon(CampfireIcons.Rounded.Bookmarks, contentDescription = bookmarkLabel)
       }
     }
@@ -666,9 +579,7 @@ private fun ActionRow(
       if (timer == null) {
         val timerLabel = stringResource(Res.string.action_sleep_timer)
         IconButtonTooltip(text = timerLabel) {
-          IconButton(
-            onClick = onTimerClick,
-          ) {
+          IconButton(onClick = onTimerClick, enabled = enabled) {
             Icon(CampfireIcons.Rounded.Timer, contentDescription = timerLabel)
           }
         }
@@ -677,9 +588,7 @@ private fun ActionRow(
           verticalAlignment = Alignment.CenterVertically,
           modifier = Modifier
             .clip(RoundedCornerShape(50))
-            .clickable {
-              onTimerClick()
-            }
+            .clickable { onTimerClick() }
             .background(
               color = MaterialTheme.colorScheme.primary,
               shape = RoundedCornerShape(50),
@@ -713,21 +622,22 @@ private fun ActionRow(
     if (showEqualizer) {
       val equalizerLabel = stringResource(Res.string.action_equalizer)
       IconButtonTooltip(text = equalizerLabel) {
-        IconButton(
-          onClick = onEqualizerClick,
-        ) {
+        IconButton(onClick = onEqualizerClick, enabled = enabled) {
           Icon(CampfireIcons.Rounded.Equalizer, contentDescription = equalizerLabel)
         }
       }
     }
 
-    val chaptersLabel = stringResource(Res.string.action_chapters)
-    IconButtonTooltip(text = chaptersLabel) {
-      IconButton(
-        onClick = onChapterListClick,
-      ) {
-        Icon(CampfireIcons.Rounded.List, contentDescription = chaptersLabel)
+    if (showChapters) {
+      val chaptersLabel = stringResource(Res.string.action_chapters)
+      IconButtonTooltip(text = chaptersLabel) {
+        IconButton(onClick = onChapterListClick, enabled = enabled) {
+          Icon(CampfireIcons.Rounded.List, contentDescription = chaptersLabel)
+        }
       }
     }
   }
 }
+
+private val CoverSize = 48.dp
+private val ContentRowHeight = 64.dp

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/PlaybackBottomBar.kt
@@ -266,6 +266,7 @@ internal fun PlaybackBottomBarContent(
         onSeek = onSeekTo,
         modifier = Modifier
           .fillMaxWidth()
+          .padding(top = TimelineTopPadding)
           .padding(horizontal = 8.dp),
       )
 
@@ -274,7 +275,7 @@ internal fun PlaybackBottomBarContent(
         modifier = Modifier
           .fillMaxWidth()
           .height(ContentRowHeight)
-          .padding(start = 16.dp, end = 8.dp, bottom = 8.dp),
+          .padding(start = 16.dp, end = 8.dp, top = TimelineBottomPadding, bottom = 8.dp),
       ) {
         NowPlayingInfo(
           session = session,
@@ -640,4 +641,6 @@ private fun ActionRow(
 }
 
 private val CoverSize = 48.dp
-private val ContentRowHeight = 64.dp
+private val ContentRowHeight = 68.dp
+private val TimelineTopPadding = 6.dp
+private val TimelineBottomPadding = 4.dp

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/bottombar/BookTimeline.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/bottombar/BookTimeline.kt
@@ -1,0 +1,341 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.sessions.ui.bottombar
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import app.campfire.common.compose.extensions.readoutFormat
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.rounded.KeyboardDoubleArrowRight
+import app.campfire.core.extensions.fluentIf
+import app.campfire.core.model.Bookmark
+import app.campfire.core.model.Chapter
+import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.timeline_content_description
+import campfire.features.sessions.ui.generated.resources.timeline_time_placeholder
+import kotlin.math.roundToInt
+import kotlin.time.Duration
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The whole book on one thin track. Chapter starts are ticks above the track and bookmarks are
+ * dots below it; hovering anywhere shows the time under the pointer (snapping to a nearby
+ * marker and naming it), clicking seeks there, and dragging scrubs. Elapsed and remaining
+ * (speed-adjusted) book time flank the track.
+ *
+ * With no duration yet, or when disabled, the track renders flat with placeholder times and no
+ * thumb, so the bar keeps its shape before a session is primed or when nothing is playing.
+ */
+@Composable
+internal fun BookTimeline(
+  position: Duration,
+  duration: Duration,
+  chapters: List<Chapter>,
+  bookmarks: List<Bookmark>,
+  playbackSpeed: Float,
+  enabled: Boolean,
+  onSeek: (Duration) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val interactive = enabled && duration > Duration.ZERO
+  val markers = remember(chapters, bookmarks) {
+    TimelineMath.chapterMarkers(chapters) + TimelineMath.bookmarkMarkers(bookmarks)
+  }
+
+  var scrubFraction by remember { mutableStateOf<Float?>(null) }
+  var hover by remember { mutableStateOf<Hover?>(null) }
+  var trackWidthPx by remember { mutableStateOf(0f) }
+
+  val displayed = scrubFraction?.let { TimelineMath.timeAt(it, duration) } ?: position
+  val placeholder = stringResource(Res.string.timeline_time_placeholder)
+
+  Row(
+    modifier = modifier,
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+      text = if (interactive) displayed.readoutFormat().trim() else placeholder,
+      textAlign = TextAlign.End,
+      style = MaterialTheme.typography.labelSmall,
+      fontFamily = FontFamily.Monospace,
+      modifier = Modifier.width(TimeLabelWidth),
+    )
+
+    val trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.16f)
+    val playedColor = MaterialTheme.colorScheme.primary
+    val tickColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
+    val bookmarkColor = MaterialTheme.colorScheme.tertiary
+    val hoverColor = MaterialTheme.colorScheme.onSurface
+    val snapThresholdPx = with(LocalDensity.current) { SnapThreshold.toPx() }
+
+    Box(
+      modifier = Modifier
+        .weight(1f)
+        .height(TrackAreaHeight)
+        .padding(horizontal = 8.dp)
+        .semantics {
+          progressBarRangeInfo = ProgressBarRangeInfo(TimelineMath.fraction(displayed, duration), 0f..1f)
+        }
+        .fluentIf(interactive) {
+          pointerHoverIcon(PointerIcon.Hand)
+            // Hover tracking through the common pointer API (onPointerEvent is desktop-only)
+            .pointerInput(duration, markers) {
+              awaitPointerEventScope {
+                while (true) {
+                  val event = awaitPointerEvent()
+                  when (event.type) {
+                    PointerEventType.Move,
+                    PointerEventType.Enter,
+                    -> if (event.changes.none { it.pressed }) {
+                      val x = event.changes.first().position.x
+                      hover = Hover(x, TimelineMath.snap(x, trackWidthPx, duration, markers, snapThresholdPx))
+                    }
+                    PointerEventType.Exit -> hover = null
+                  }
+                }
+              }
+            }
+            .pointerInput(duration, markers) {
+              awaitEachGesture {
+                val down = awaitFirstDown()
+                val width = size.width.toFloat()
+                var lastX = down.position.x
+                var dragged = false
+                drag(down.id) { change ->
+                  dragged = true
+                  lastX = change.position.x
+                  scrubFraction = TimelineMath.fractionAt(lastX, width)
+                  hover = Hover(lastX, null)
+                  change.consume()
+                }
+                val target = if (dragged) {
+                  TimelineMath.timeAt(TimelineMath.fractionAt(lastX, width), duration)
+                } else {
+                  TimelineMath.snap(lastX, width, duration, markers, snapThresholdPx)?.time
+                    ?: TimelineMath.timeAt(TimelineMath.fractionAt(lastX, width), duration)
+                }
+                scrubFraction = null
+                onSeek(target)
+              }
+            }
+        },
+    ) {
+      val description = stringResource(Res.string.timeline_content_description)
+      Canvas(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(TrackAreaHeight)
+          .semantics { contentDescription = description },
+      ) {
+        trackWidthPx = size.width
+        val centerY = size.height / 2f
+        val trackHeight = TrackHeight.toPx()
+        val radius = CornerRadius(trackHeight / 2f)
+
+        drawRoundRect(
+          color = trackColor,
+          topLeft = Offset(0f, centerY - trackHeight / 2f),
+          size = Size(size.width, trackHeight),
+          cornerRadius = radius,
+        )
+
+        if (!interactive) return@Canvas
+
+        val playedX = TimelineMath.xOf(displayed, duration, size.width)
+        drawRoundRect(
+          color = playedColor,
+          topLeft = Offset(0f, centerY - trackHeight / 2f),
+          size = Size(playedX, trackHeight),
+          cornerRadius = radius,
+        )
+
+        val hovered = hover?.marker
+        markers.forEach { marker ->
+          val x = TimelineMath.xOf(marker.time, duration, size.width)
+          val isHovered = marker == hovered
+          when (marker) {
+            is TimelineMarker.ChapterMarker -> {
+              val tickHeight = (if (isHovered) HoveredTickHeight else TickHeight).toPx()
+              val tickWidth = TickWidth.toPx()
+              drawRoundRect(
+                color = if (isHovered) hoverColor else tickColor,
+                topLeft = Offset(x - tickWidth / 2f, centerY - trackHeight / 2f - TickGap.toPx() - tickHeight),
+                size = Size(tickWidth, tickHeight),
+                cornerRadius = CornerRadius(tickWidth / 2f),
+              )
+            }
+            is TimelineMarker.BookmarkMarker -> {
+              drawCircle(
+                color = if (isHovered) hoverColor else bookmarkColor,
+                radius = (if (isHovered) HoveredBookmarkRadius else BookmarkRadius).toPx(),
+                center = Offset(x, centerY + trackHeight / 2f + BookmarkGap.toPx() + BookmarkRadius.toPx()),
+              )
+            }
+          }
+        }
+
+        drawCircle(
+          color = playedColor,
+          radius = ThumbRadius.toPx(),
+          center = Offset(playedX, centerY),
+        )
+      }
+
+      hover?.let { current ->
+        if (interactive) {
+          TimelineTooltip(
+            hover = current,
+            duration = duration,
+            trackWidthPx = trackWidthPx,
+          )
+        }
+      }
+    }
+
+    val isAccelerated = playbackSpeed != 1f
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.width(TimeLabelWidth),
+    ) {
+      AnimatedVisibility(visible = isAccelerated && interactive) {
+        Icon(
+          CampfireIcons.Rounded.KeyboardDoubleArrowRight,
+          contentDescription = null,
+          modifier = Modifier.size(14.dp),
+          tint = MaterialTheme.colorScheme.secondary,
+        )
+      }
+      val remaining = ((duration - displayed) / playbackSpeed.toDouble()).coerceAtLeast(Duration.ZERO)
+      Text(
+        text = if (interactive) remaining.readoutFormat().trim() else placeholder,
+        textAlign = TextAlign.Start,
+        style = MaterialTheme.typography.labelSmall.fluentIf(isAccelerated && interactive) {
+          copy(
+            fontWeight = FontWeight.Bold,
+            fontStyle = FontStyle.Italic,
+            color = MaterialTheme.colorScheme.secondary,
+            fontSize = 12.sp,
+          )
+        },
+        fontFamily = FontFamily.Monospace,
+        modifier = Modifier.fillMaxWidth(),
+      )
+    }
+  }
+}
+
+private data class Hover(val xPx: Float, val marker: TimelineMarker?)
+
+/** Time (and marker name) under the pointer, floating above the track at the pointer's x. */
+@Composable
+private fun TimelineTooltip(
+  hover: Hover,
+  duration: Duration,
+  trackWidthPx: Float,
+) {
+  val time = hover.marker?.time ?: TimelineMath.timeAt(TimelineMath.fractionAt(hover.xPx, trackWidthPx), duration)
+  Popup(
+    popupPositionProvider = remember(hover.xPx) { AboveAnchorAt(hover.xPx.roundToInt()) },
+  ) {
+    Surface(
+      color = MaterialTheme.colorScheme.inverseSurface,
+      contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+      shape = MaterialTheme.shapes.small,
+    ) {
+      Column(
+        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        hover.marker?.let { marker ->
+          Text(
+            text = marker.title,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+          )
+        }
+        Text(
+          text = time.readoutFormat(),
+          style = MaterialTheme.typography.labelSmall,
+          fontFamily = FontFamily.Monospace,
+        )
+      }
+    }
+  }
+}
+
+/** Centers the popup horizontally on [anchorX] within the anchor and sits it just above the anchor. */
+private class AboveAnchorAt(private val anchorX: Int) : PopupPositionProvider {
+  override fun calculatePosition(
+    anchorBounds: IntRect,
+    windowSize: IntSize,
+    layoutDirection: LayoutDirection,
+    popupContentSize: IntSize,
+  ): IntOffset {
+    val x = (anchorBounds.left + anchorX - popupContentSize.width / 2)
+      .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0))
+    val y = (anchorBounds.top - popupContentSize.height - TooltipGapPx).coerceAtLeast(0)
+    return IntOffset(x, y)
+  }
+}
+
+private val TimeLabelWidth = 96.dp
+private val TrackAreaHeight = 28.dp
+private val TrackHeight = 3.dp
+private val ThumbRadius = 5.dp
+private val TickWidth = 2.dp
+private val TickHeight = 7.dp
+private val HoveredTickHeight = 10.dp
+private val TickGap = 3.dp
+private val BookmarkRadius = 3.dp
+private val HoveredBookmarkRadius = 4.5.dp
+private val BookmarkGap = 3.dp
+private val SnapThreshold = 6.dp
+private const val TooltipGapPx = 6

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/bottombar/DesktopPlaybackActions.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/bottombar/DesktopPlaybackActions.kt
@@ -1,0 +1,176 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.sessions.ui.bottombar
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import app.campfire.audioplayer.AudioPlayer
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.rounded.Pause
+import app.campfire.common.compose.icons.rounded.PlayArrow
+import app.campfire.common.compose.icons.rounded.SkipNext
+import app.campfire.common.compose.icons.rounded.SkipPrevious
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.sessions.ui.composables.ForwardIcon
+import app.campfire.sessions.ui.composables.RewindIcon
+import app.campfire.sessions.ui.playback.expanded.composables.PlayButtonState
+import campfire.features.sessions.ui.generated.resources.Res
+import campfire.features.sessions.ui.generated.resources.action_forward
+import campfire.features.sessions.ui.generated.resources.action_play_pause
+import campfire.features.sessions.ui.generated.resources.action_rewind
+import campfire.features.sessions.ui.generated.resources.action_skip_next
+import campfire.features.sessions.ui.generated.resources.action_skip_previous
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The desktop transport: the same Material 3 Expressive treatment as the phone player — filled
+ * play button that morphs shape on press, tonal accessory buttons at a quarter of primary, skip
+ * buttons in the same tone — laid out in one row at desktop proportions.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun DesktopPlaybackActions(
+  state: AudioPlayer.State,
+  enabled: Boolean,
+  onSkipPreviousClick: () -> Unit,
+  onRewindClick: () -> Unit,
+  onPlayPauseClick: () -> Unit,
+  onForwardClick: () -> Unit,
+  onSkipNextClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  buttonSize: Dp = ButtonDefaults.MinHeight,
+  playButtonSize: Dp = 44.dp,
+  playButtonExtraWidth: Dp = 20.dp,
+) {
+  val accessoryColors = IconButtonDefaults.filledIconButtonColors(
+    containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f),
+    contentColor = MaterialTheme.colorScheme.onSurface,
+  )
+  val morphingShapes = IconButtonDefaults.shapes(
+    shape = MaterialTheme.shapes.extraLarge,
+    pressedShape = ButtonDefaults.shape,
+  )
+  val iconSize = ButtonDefaults.iconSizeFor(buttonSize)
+
+  Row(
+    modifier = modifier,
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
+  ) {
+    @Composable
+    fun Accessory(
+      label: String,
+      onClick: () -> Unit,
+      content: @Composable (iconSize: Dp) -> Unit,
+    ) {
+      IconButtonTooltip(text = label) {
+        FilledIconButton(
+          onClick = onClick,
+          enabled = enabled,
+          shapes = morphingShapes,
+          colors = accessoryColors,
+          modifier = Modifier.sizeIn(minWidth = buttonSize, minHeight = buttonSize),
+        ) {
+          content(iconSize)
+        }
+      }
+    }
+
+    @Composable
+    fun Skip(label: String, icon: ImageVector, onClick: () -> Unit) {
+      IconButtonTooltip(text = label) {
+        FilledIconButton(
+          onClick = onClick,
+          enabled = enabled,
+          shapes = IconButtonDefaults.shapes(),
+          colors = accessoryColors,
+          modifier = Modifier.sizeIn(minWidth = buttonSize, minHeight = buttonSize),
+        ) {
+          Icon(icon, contentDescription = label, modifier = Modifier.size(iconSize))
+        }
+      }
+    }
+
+    Skip(stringResource(Res.string.action_skip_previous), CampfireIcons.Rounded.SkipPrevious, onSkipPreviousClick)
+
+    Accessory(stringResource(Res.string.action_rewind), onRewindClick) { size ->
+      RewindIcon(modifier = Modifier.size(size))
+    }
+
+    val playPauseLabel = stringResource(Res.string.action_play_pause)
+    val isPlayPauseEnabled = enabled &&
+      state != AudioPlayer.State.Finished &&
+      state != AudioPlayer.State.Buffering
+    IconButtonTooltip(text = playPauseLabel) {
+      FilledIconButton(
+        onClick = onPlayPauseClick,
+        enabled = isPlayPauseEnabled,
+        shapes = morphingShapes,
+        modifier = Modifier.sizeIn(
+          minWidth = playButtonSize + playButtonExtraWidth,
+          minHeight = playButtonSize,
+        ),
+      ) {
+        AnimatedContent(
+          targetState = when (state) {
+            AudioPlayer.State.Buffering -> PlayButtonState.Buffering
+            AudioPlayer.State.Playing -> PlayButtonState.Playing
+            else -> PlayButtonState.Paused
+          },
+          transitionSpec = {
+            (fadeIn(initialAlpha = 0.4f) + expandIn(expandFrom = Alignment.Center)) togetherWith
+              (fadeOut(targetAlpha = 0.4f) + shrinkOut(shrinkTowards = Alignment.Center))
+          },
+          contentAlignment = Alignment.Center,
+        ) { playState ->
+          val playIconSize = ButtonDefaults.iconSizeFor(playButtonSize)
+          if (playState == PlayButtonState.Buffering) {
+            CircularProgressIndicator(
+              modifier = Modifier.size(playIconSize),
+              strokeWidth = 3.dp,
+            )
+          } else {
+            val icon = if (playState == PlayButtonState.Playing) {
+              CampfireIcons.Rounded.Pause
+            } else {
+              CampfireIcons.Rounded.PlayArrow
+            }
+            Icon(
+              icon,
+              modifier = Modifier.size(playIconSize),
+              contentDescription = playPauseLabel,
+            )
+          }
+        }
+      }
+    }
+
+    Accessory(stringResource(Res.string.action_forward), onForwardClick) { size ->
+      ForwardIcon(modifier = Modifier.size(size))
+    }
+
+    Skip(stringResource(Res.string.action_skip_next), CampfireIcons.Rounded.SkipNext, onSkipNextClick)
+  }
+}

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/bottombar/TimelineMath.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/bottombar/TimelineMath.kt
@@ -1,0 +1,83 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.sessions.ui.bottombar
+
+import app.campfire.core.extensions.seconds
+import app.campfire.core.model.Bookmark
+import app.campfire.core.model.Chapter
+import kotlin.math.abs
+import kotlin.time.Duration
+
+/** A point of interest on the whole-book timeline the listener can hover and jump to. */
+sealed interface TimelineMarker {
+  val time: Duration
+  val title: String
+
+  data class ChapterMarker(val chapter: Chapter) : TimelineMarker {
+    override val time: Duration get() = chapter.start.seconds
+    override val title: String get() = chapter.title
+  }
+
+  data class BookmarkMarker(val bookmark: Bookmark) : TimelineMarker {
+    override val time: Duration get() = bookmark.time
+    override val title: String get() = bookmark.title
+  }
+}
+
+/**
+ * Geometry for [BookTimeline]: absolute book time <-> track fraction <-> pixel, plus marker
+ * snapping. Pure so the hover/click behavior is unit-testable without a composition.
+ */
+object TimelineMath {
+
+  fun fraction(time: Duration, total: Duration): Float {
+    if (total <= Duration.ZERO || !time.isFinite()) return 0f
+    return (time / total).toFloat().coerceIn(0f, 1f)
+  }
+
+  fun timeAt(fraction: Float, total: Duration): Duration {
+    if (total <= Duration.ZERO) return Duration.ZERO
+    return total * fraction.coerceIn(0f, 1f).toDouble()
+  }
+
+  fun xOf(time: Duration, total: Duration, widthPx: Float): Float = fraction(time, total) * widthPx
+
+  fun fractionAt(xPx: Float, widthPx: Float): Float = if (widthPx <= 0f) 0f else (xPx / widthPx).coerceIn(0f, 1f)
+
+  /**
+   * Chapter boundaries worth marking: every chapter start except one at the very beginning of
+   * the book, which would only decorate the track's left edge.
+   */
+  fun chapterMarkers(chapters: List<Chapter>): List<TimelineMarker.ChapterMarker> {
+    return chapters
+      .filter { it.start > 0f }
+      .map { TimelineMarker.ChapterMarker(it) }
+  }
+
+  fun bookmarkMarkers(bookmarks: List<Bookmark>): List<TimelineMarker.BookmarkMarker> {
+    return bookmarks.map { TimelineMarker.BookmarkMarker(it) }
+  }
+
+  /**
+   * The marker under a pointer at [xPx], if one lies within [thresholdPx]. The closest wins;
+   * on a tie a bookmark beats a chapter because it's the rarer, deliberate mark.
+   */
+  fun snap(
+    xPx: Float,
+    widthPx: Float,
+    total: Duration,
+    markers: List<TimelineMarker>,
+    thresholdPx: Float,
+  ): TimelineMarker? {
+    if (widthPx <= 0f || total <= Duration.ZERO) return null
+    return markers
+      .map { marker -> marker to abs(xOf(marker.time, total, widthPx) - xPx) }
+      .filter { (_, distance) -> distance <= thresholdPx }
+      .minWithOrNull(
+        compareBy<Pair<TimelineMarker, Float>> { (_, distance) -> distance }
+          .thenBy { (marker, _) -> if (marker is TimelineMarker.BookmarkMarker) 0 else 1 },
+      )
+      ?.first
+  }
+}

--- a/features/sessions/ui/src/commonTest/kotlin/app/campfire/sessions/ui/bottombar/TimelineMathTest.kt
+++ b/features/sessions/ui/src/commonTest/kotlin/app/campfire/sessions/ui/bottombar/TimelineMathTest.kt
@@ -1,0 +1,77 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.sessions.ui.bottombar
+
+import app.campfire.core.model.Bookmark
+import app.campfire.core.model.Chapter
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.datetime.LocalDateTime
+
+class TimelineMathTest {
+
+  private val total = 10.hours
+  private val width = 1000f
+
+  private fun chapter(id: Int, startSeconds: Float, endSeconds: Float) =
+    Chapter(id = id, start = startSeconds, end = endSeconds, title = "Chapter ${id + 1}")
+
+  private fun bookmark(time: Duration, title: String = "Mark") = Bookmark(
+    userId = "u",
+    libraryItemId = "i",
+    title = title,
+    time = time,
+    createdAt = LocalDateTime(2026, 1, 1, 0, 0),
+  )
+
+  @Test
+  fun `fractions and times round-trip and clamp`() {
+    assertThat(TimelineMath.fraction(5.hours, total)).isEqualTo(0.5f)
+    assertThat(TimelineMath.fraction(12.hours, total)).isEqualTo(1f)
+    assertThat(TimelineMath.fraction(1.hours, Duration.ZERO)).isEqualTo(0f)
+    assertThat(TimelineMath.timeAt(0.25f, total)).isEqualTo(2.5.hours)
+    assertThat(TimelineMath.timeAt(1.5f, total)).isEqualTo(total)
+    assertThat(TimelineMath.xOf(2.5.hours, total, width)).isEqualTo(250f)
+    assertThat(TimelineMath.fractionAt(250f, width)).isEqualTo(0.25f)
+    assertThat(TimelineMath.fractionAt(250f, 0f)).isEqualTo(0f)
+  }
+
+  @Test
+  fun `the chapter starting at zero gets no marker`() {
+    val markers = TimelineMath.chapterMarkers(
+      listOf(chapter(0, 0f, 600f), chapter(1, 600f, 1800f), chapter(2, 1800f, 3600f)),
+    )
+    assertThat(markers.map { it.time }).isEqualTo(listOf(10.minutes, 30.minutes))
+    assertThat(markers.first().title).isEqualTo("Chapter 2")
+  }
+
+  @Test
+  fun `snapping picks the nearest marker inside the threshold, bookmarks winning ties`() {
+    val chapterAt5h = TimelineMarker.ChapterMarker(chapter(1, 18_000f, 20_000f))
+    val bookmarkAt5h = TimelineMarker.BookmarkMarker(bookmark(5.hours))
+    val bookmarkAt6h = TimelineMarker.BookmarkMarker(bookmark(6.hours, "Later"))
+    val markers = listOf(chapterAt5h, bookmarkAt5h, bookmarkAt6h)
+
+    // 5h is x=500; 6h is x=600
+    assertThat(TimelineMath.snap(504f, width, total, markers, thresholdPx = 6f)).isEqualTo(bookmarkAt5h)
+    assertThat(TimelineMath.snap(597f, width, total, markers, thresholdPx = 6f)).isEqualTo(bookmarkAt6h)
+    assertThat(TimelineMath.snap(550f, width, total, markers, thresholdPx = 6f)).isNull()
+    assertThat(TimelineMath.snap(504f, width, Duration.ZERO, markers, thresholdPx = 6f)).isNull()
+  }
+
+  @Test
+  fun `a chapter marker snaps when it is the only nearby mark`() {
+    val chapterAt5h = TimelineMarker.ChapterMarker(chapter(1, 18_000f, 20_000f))
+    val bookmarkAt6h = TimelineMarker.BookmarkMarker(bookmark(6.hours))
+    assertThat(TimelineMath.snap(497f, width, total, listOf(chapterAt5h, bookmarkAt6h), thresholdPx = 6f))
+      .isEqualTo(chapterAt5h)
+    assertThat(chapterAt5h.time).isEqualTo(18_000.seconds)
+  }
+}

--- a/features/sessions/ui/src/jvmTest/kotlin/app/campfire/sessions/ui/PlaybackBottomBarRenderTest.kt
+++ b/features/sessions/ui/src/jvmTest/kotlin/app/campfire/sessions/ui/PlaybackBottomBarRenderTest.kt
@@ -1,0 +1,152 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.sessions.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
+import app.campfire.audioplayer.AudioPlayer
+import app.campfire.audioplayer.model.EqualizerState
+import app.campfire.audioplayer.model.Metadata
+import app.campfire.audioplayer.test.fixtures.chapter
+import app.campfire.audioplayer.test.fixtures.session
+import app.campfire.audioplayer.test.fixtures.track
+import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.core.di.ComponentHolder
+import app.campfire.core.model.Bookmark
+import app.campfire.core.model.Session
+import app.campfire.sessions.ui.composables.PlaybackSettingsComponent
+import app.campfire.settings.api.PlaybackSettings
+import app.campfire.settings.test.FakePlaybackSettings
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import com.slack.circuit.overlay.ContentWithOverlays
+import com.slack.circuit.overlay.rememberOverlayHost
+import java.io.File
+import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.datetime.LocalDateTime
+import org.jetbrains.skia.EncodedImageFormat
+
+/**
+ * Renders the desktop bar off-screen in its main states and writes PNGs to `build/renders` for
+ * eyeballing; the assertions only guard that each state composes and paints. A hover render
+ * sends a pointer over the second chapter's tick so the tooltip path is exercised too.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class PlaybackBottomBarRenderTest {
+
+  private val renders = File("build/renders").apply { mkdirs() }
+
+  init {
+    // The skip icons read their seconds from the playback settings component
+    ComponentHolder.components += object : PlaybackSettingsComponent {
+      override val playbackSettings: PlaybackSettings = FakePlaybackSettings()
+    }
+  }
+
+  // Two tracks of 30min; three chapters at 0-10, 10-30, 30-60 minutes
+  private val book = session(
+    chapters = listOf(chapter(0, 0f, 600f), chapter(1, 600f, 1800f), chapter(2, 1800f, 3600f)),
+    tracks = listOf(track(1, 0f, 1800f), track(2, 1800f, 1800f)),
+    currentTime = 40.minutes,
+  )
+  private val bookmarks = listOf(
+    Bookmark("u", book.libraryItem.id, "Great line", 22.minutes, LocalDateTime(2026, 1, 1, 0, 0)),
+    Bookmark("u", book.libraryItem.id, "Plot twist", 51.minutes + 30.seconds, LocalDateTime(2026, 1, 1, 0, 0)),
+  )
+
+  @Test
+  fun `nothing playing`() {
+    render("bottom-bar-empty") {
+      Bar(session = null, state = AudioPlayer.State.Disabled, bookTime = Duration.ZERO)
+    }
+  }
+
+  @Test
+  fun `playing a chaptered book with bookmarks`() {
+    render("bottom-bar-playing") {
+      Bar(session = book, state = AudioPlayer.State.Playing, bookTime = 40.minutes, speed = 1.25f)
+    }
+  }
+
+  @Test
+  fun `hovering a chapter tick shows its tooltip`() {
+    render("bottom-bar-hover", beforeRender = { scene ->
+      // Track spans [labelWidth + 16, width - labelWidth - 16] in dp; chapter 2 starts at 30/60
+      val trackStart = (96 + 8 + 8) * 2f
+      val trackEnd = (WIDTH - (96 + 8 + 8)) * 2f
+      val x = trackStart + (trackEnd - trackStart) * 0.5f
+      scene.sendPointerEvent(PointerEventType.Enter, Offset(x - 40f, 14f * 2f))
+      scene.sendPointerEvent(PointerEventType.Move, Offset(x - 20f, 14f * 2f))
+      scene.sendPointerEvent(PointerEventType.Move, Offset(x, 14f * 2f))
+      println("hover sent at x=$x hasInvalidations=${scene.hasInvalidations()}")
+    }) {
+      Bar(session = book, state = AudioPlayer.State.Paused, bookTime = 40.minutes)
+    }
+  }
+
+  @Composable
+  private fun Bar(session: Session?, state: AudioPlayer.State, bookTime: Duration, speed: Float = 1f) {
+    CampfireTheme(useDarkColors = false) {
+      ContentWithOverlays(overlayHost = rememberOverlayHost()) {
+        Box(Modifier.fillMaxSize()) {
+          PlaybackBottomBarContent(
+            state = state,
+            playbackSpeed = speed,
+            currentTime = 10.minutes,
+            currentDuration = 30.minutes,
+            bookTime = bookTime,
+            currentMetadata = Metadata(title = if (session == null) null else "Chapter 3"),
+            runningTimer = null,
+            equalizer = EqualizerState.Unsupported,
+            bookmarks = if (session == null) emptyList() else bookmarks,
+            session = session,
+            onPlayPauseClick = {},
+            onRewindClick = {},
+            onForwardClick = {},
+            onSkipNextClick = {},
+            onSkipPreviousClick = {},
+            onSeekTo = {},
+            onTimerSelected = {},
+            onTimerCleared = {},
+            onChapterSelected = {},
+            onAudioTrackSelected = {},
+            onBookmarkSelected = {},
+          )
+        }
+      }
+    }
+  }
+
+  private fun render(
+    name: String,
+    beforeRender: (ImageComposeScene) -> Unit = {},
+    content: @Composable () -> Unit,
+  ) {
+    ImageComposeScene(width = WIDTH * 2, height = HEIGHT * 2, density = Density(2f), content = content).use { scene ->
+      scene.render()
+      beforeRender(scene)
+      val image = scene.render(nanoTime = 1_000_000_000L)
+      val bytes = image.encodeToData(EncodedImageFormat.PNG)!!.bytes
+      File(renders, "$name.png").writeBytes(bytes)
+      println("rendered ${File(renders, "$name.png").absolutePath}")
+      assertThat(bytes.size).isGreaterThan(1_000)
+    }
+  }
+
+  private companion object {
+    const val WIDTH = 1440
+    const val HEIGHT = 100
+  }
+}

--- a/features/sessions/ui/src/jvmTest/kotlin/app/campfire/sessions/ui/PlaybackBottomBarRenderTest.kt
+++ b/features/sessions/ui/src/jvmTest/kotlin/app/campfire/sessions/ui/PlaybackBottomBarRenderTest.kt
@@ -87,9 +87,9 @@ class PlaybackBottomBarRenderTest {
       val trackStart = (96 + 8 + 8) * 2f
       val trackEnd = (WIDTH - (96 + 8 + 8)) * 2f
       val x = trackStart + (trackEnd - trackStart) * 0.5f
-      scene.sendPointerEvent(PointerEventType.Enter, Offset(x - 40f, 14f * 2f))
-      scene.sendPointerEvent(PointerEventType.Move, Offset(x - 20f, 14f * 2f))
-      scene.sendPointerEvent(PointerEventType.Move, Offset(x, 14f * 2f))
+      scene.sendPointerEvent(PointerEventType.Enter, Offset(x - 40f, 20f * 2f))
+      scene.sendPointerEvent(PointerEventType.Move, Offset(x - 20f, 20f * 2f))
+      scene.sendPointerEvent(PointerEventType.Move, Offset(x, 20f * 2f))
       println("hover sent at x=$x hasInvalidations=${scene.hasInvalidations()}")
     }) {
       Bar(session = book, state = AudioPlayer.State.Paused, bookTime = 40.minutes)
@@ -147,6 +147,6 @@ class PlaybackBottomBarRenderTest {
 
   private companion object {
     const val WIDTH = 1440
-    const val HEIGHT = 100
+    const val HEIGHT = 110
   }
 }


### PR DESCRIPTION
## Summary

The desktop (extra-large width) bottom bar, redesigned.

**Layout.** Two rows, ~92dp tall (was ~120dp). Top: a thin whole-book timeline spanning the window. Bottom: cover (48dp), current chapter title, book title with time left in the chapter, transport (previous / rewind / play / forward / next), and the tools (bookmarks, speed, sleep timer, equalizer, chapters).

**Timeline.** 3dp track, played portion in primary, small thumb. Chapter starts are ticks above the track, bookmarks are dots below it. Hovering shows the time under the pointer in a tooltip; within 6dp of a marker it snaps to the marker and names it (chapter title / bookmark title). Clicking seeks — to the marker's exact time when snapped. Dragging scrubs with live labels. Elapsed and speed-adjusted remaining book time flank the track. `TimelineMath` keeps geometry and snapping pure (bookmarks win ties) and unit-tested. Hover uses the common `pointerInput` event loop so the file compiles for Android too.

**Empty states.**
- No session: the bar stays in place with "Nothing playing", a hint, a placeholder cover, `--:--` labels, and disabled controls (no more `session!!`).
- Unprimed player (Disabled/Initializing): the session's stored position and metadata render as before.
- No chapters or a podcast episode: no ticks, plain book subtitle.
- Zero duration: flat track, no thumb, placeholder times.

**Data.** Bookmarks observed from `BookmarkRepository` through a `UserScope` component; book position from the player's `overallTime`.

## Verification

- `TimelineMathTest` covers fractions, marker filtering, and snapping.
- `PlaybackBottomBarRenderTest` paints the bar off-screen with `ImageComposeScene` in the empty, playing, and hovered states (sending pointer events over a chapter tick) and writes PNGs to `features/sessions/ui/build/renders`. Reviewed all three renders.
- Ran the app under Compose Hot Reload with the MCP server (`.mcp.json` added): the semantic tree shows the bar at ~92dp with all nodes and disabled transport in the empty state; a hot reload applied cleanly.
- Desktop and Android compile; all sessions UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
