### PR TITLE
Show a close icon instead of a back arrow for screens in the detail pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Screens shown in the side detail pane now close with an X instead of showing a back arrow
 - Desktop plays each audio file whole and navigates chapters within it, instead of re-opening the file at every chapter
 
 ### Deprecated

--- a/common/compose/src/commonMain/composeResources/values/common_compose_strings.xml
+++ b/common/compose/src/commonMain/composeResources/values/common_compose_strings.xml
@@ -56,4 +56,6 @@
   <string name="playback_speed_dialog_error">Enter a value between %1$s and %2$s</string>
   <string name="playback_speed_dialog_apply">Apply</string>
   <string name="playback_speed_dialog_cancel">Cancel</string>
+  <string name="action_back">Back</string>
+  <string name="action_close">Close</string>
 </resources>

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/NavigationBackButton.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/NavigationBackButton.kt
@@ -1,0 +1,41 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.widgets
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.rounded.ArrowBack
+import app.campfire.common.compose.icons.rounded.Close
+import app.campfire.common.compose.layout.ContentLayout
+import app.campfire.common.compose.layout.LocalContentLayout
+import campfire.common.compose.generated.resources.Res
+import campfire.common.compose.generated.resources.action_back
+import campfire.common.compose.generated.resources.action_close
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The top app bar's leading navigation action: a back arrow in a stacked navigation flow, or a
+ * close cross when the screen sits in the supporting (detail) pane on wide windows, where there is
+ * nothing behind it to go back to.
+ * The label follows the glyph for tooltips and accessibility.
+ */
+@Composable
+fun NavigationBackButton(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val inDetailPane = LocalContentLayout.current == ContentLayout.Supporting
+  val label = stringResource(if (inDetailPane) Res.string.action_close else Res.string.action_back)
+  IconButtonTooltip(text = label, modifier = modifier) {
+    IconButton(onClick = onClick) {
+      Icon(
+        if (inDetailPane) CampfireIcons.Rounded.Close else CampfireIcons.Rounded.ArrowBack,
+        contentDescription = label,
+      )
+    }
+  }
+}

--- a/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUi.kt
+++ b/features/auth/ui/src/commonMain/kotlin/app/campfire/auth/ui/login/LoginUi.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -54,21 +53,19 @@ import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.currentWindowSizeClass
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Add
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.IdBadge
 import app.campfire.common.compose.layout.ContentLayout
 import app.campfire.common.compose.layout.LocalContentLayout
 import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.theme.LocalUseDarkColors
 import app.campfire.common.compose.widgets.CampfireTopAppBar
-import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.common.screens.LoginScreen
 import app.campfire.core.di.UserScope
 import app.campfire.ui.theming.api.AppTheme
 import app.campfire.ui.theming.api.colorScheme
 import campfire.features.auth.ui.generated.resources.Res
 import campfire.features.auth.ui.generated.resources.action_add_campsite
-import campfire.features.auth.ui.generated.resources.action_back
 import campfire.features.auth.ui.generated.resources.action_login_openid
 import campfire.features.auth.ui.generated.resources.label_authenticating_loading_message
 import campfire.features.auth.ui.generated.resources.login_add_account_title
@@ -123,14 +120,7 @@ private fun LoginContent(
             },
             navigationIcon = {
               if (screen is LoginScreen.Additional) {
-                val backLabel = stringResource(Res.string.action_back)
-                IconButtonTooltip(text = backLabel) {
-                  IconButton(
-                    onClick = { state.eventSink(LoginUiEvent.NavigateBack) },
-                  ) {
-                    Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-                  }
-                }
+                NavigationBackButton(onClick = { state.eventSink(LoginUiEvent.NavigateBack) })
               }
             },
           )

--- a/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailUi.kt
+++ b/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailUi.kt
@@ -19,8 +19,6 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -34,14 +32,12 @@ import app.campfire.author.ui.detail.composables.AuthorDetailHeader
 import app.campfire.author.ui.detail.composables.AuthorHeader
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.extensions.plus
-import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.widgets.AuthorSharedTransitionKey
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.ErrorListState
-import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LibraryItemCard
 import app.campfire.common.compose.widgets.LoadingListState
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.common.screens.AuthorDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -50,7 +46,6 @@ import app.campfire.core.model.LibraryItem
 import app.campfire.core.model.LibraryItemId
 import app.campfire.core.offline.OfflineStatus
 import campfire.features.author.ui.generated.resources.Res
-import campfire.features.author.ui.generated.resources.action_back
 import campfire.features.author.ui.generated.resources.author_books_empty_message
 import campfire.features.author.ui.generated.resources.author_books_header
 import campfire.features.author.ui.generated.resources.error_author_message
@@ -75,14 +70,7 @@ fun AuthorDetail(
         windowInsets = WindowInsets(),
         contentPadding = WindowInsets.statusBars.asPaddingValues(),
         navigationIcon = {
-          val backLabel = stringResource(Res.string.action_back)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(
-              onClick = { state.eventSink(AuthorDetailUiEvent.Back) },
-            ) {
-              Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-            }
-          }
+          NavigationBackButton(onClick = { state.eventSink(AuthorDetailUiEvent.Back) })
         },
       )
     },

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/composables/CollectionDetailTopAppBar.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/detail/composables/CollectionDetailTopAppBar.kt
@@ -11,12 +11,11 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.Delete
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import campfire.features.collections.ui.generated.resources.Res
-import campfire.features.collections.ui.generated.resources.action_back
 import campfire.features.collections.ui.generated.resources.action_delete_collection
 import org.jetbrains.compose.resources.stringResource
 
@@ -34,14 +33,7 @@ fun CollectionDetailTopAppBar(
     title = { Text(name) },
     scrollBehavior = scrollBehavior,
     navigationIcon = {
-      val backLabel = stringResource(Res.string.action_back)
-      IconButtonTooltip(text = backLabel) {
-        IconButton(
-          onClick = onBack,
-        ) {
-          Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-        }
-      }
+      NavigationBackButton(onClick = onBack)
     },
     actions = {
       if (canEdit) {

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUi.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUi.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -24,8 +22,6 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.extensions.plus
-import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.layout.DefaultAdaptiveColumnSize
 import app.campfire.common.compose.layout.LargeAdaptiveColumnSize
 import app.campfire.common.compose.layout.LazyCampfireGrid
@@ -33,10 +29,10 @@ import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.ErrorListState
 import app.campfire.common.compose.widgets.FilterBar
-import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemCollectionCard
 import app.campfire.common.compose.widgets.ItemCollectionGridCard
 import app.campfire.common.compose.widgets.LoadingListState
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.common.screens.CollectionsScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -44,7 +40,6 @@ import app.campfire.core.model.Collection
 import app.campfire.core.settings.GroupDisplayState
 import app.campfire.core.settings.ItemDisplayState
 import campfire.features.collections.ui.generated.resources.Res
-import campfire.features.collections.ui.generated.resources.action_back
 import campfire.features.collections.ui.generated.resources.collections_title
 import campfire.features.collections.ui.generated.resources.empty_collection_items_message
 import campfire.features.collections.ui.generated.resources.error_collection_items_message
@@ -68,14 +63,7 @@ fun Collections(
         title = { Text(stringResource(Res.string.collections_title)) },
         scrollBehavior = scrollBehavior,
         navigationIcon = {
-          val backLabel = stringResource(Res.string.action_back)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(
-              onClick = { state.eventSink(CollectionsUiEvent.Back) },
-            ) {
-              Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-            }
-          }
+          NavigationBackButton(onClick = { state.eventSink(CollectionsUiEvent.Back) })
         },
       )
     },

--- a/features/discover/ui/src/commonMain/kotlin/app/campfire/discover/ui/UpcomingUi.kt
+++ b/features/discover/ui/src/commonMain/kotlin/app/campfire/discover/ui/UpcomingUi.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -49,7 +48,6 @@ import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.currentWindowSizeClass
 import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.Radar
 import app.campfire.common.compose.layout.ContentLayout
 import app.campfire.common.compose.layout.LocalContentLayout
@@ -59,13 +57,12 @@ import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.util.withDensity
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
-import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.core.di.UserScope
 import app.campfire.discover.api.DiscoverScanState
 import app.campfire.discover.api.screen.UpcomingScreen
 import app.campfire.discover.ui.composables.UpcomingTimeline
 import campfire.features.discover.ui.generated.resources.Res
-import campfire.features.discover.ui.generated.resources.action_back
 import campfire.features.discover.ui.generated.resources.discover_cancel_scan
 import campfire.features.discover.ui.generated.resources.discover_empty_upcoming
 import campfire.features.discover.ui.generated.resources.discover_scan_action
@@ -93,12 +90,7 @@ fun UpcomingUi(
       CampfireTopAppBar(
         title = { Text(stringResource(Res.string.upcoming_title)) },
         navigationIcon = {
-          val backLabel = stringResource(Res.string.action_back)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(onClick = { state.eventSink(UpcomingUiEvent.Back) }) {
-              Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-            }
-          }
+          NavigationBackButton(onClick = { state.eventSink(UpcomingUiEvent.Back) })
         },
         windowInsets = WindowInsets(),
         contentPadding = WindowInsets.statusBars.asPaddingValues(),

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
@@ -57,7 +57,6 @@ import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.currentWindowSizeClass
 import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.DeleteForever
 import app.campfire.common.compose.icons.rounded.LibraryAdd
 import app.campfire.common.compose.icons.rounded.MoreVert
@@ -71,6 +70,7 @@ import app.campfire.common.compose.widgets.ErrorListState
 import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LibraryItemSharedTransitionKey
 import app.campfire.common.compose.widgets.LoadingListState
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryId
@@ -103,7 +103,6 @@ import app.campfire.libraries.ui.detail.composables.slots.TitleSlot
 import app.campfire.playlists.api.dialog.AddToPlaylistDialog
 import campfire.features.libraries.ui.generated.resources.Res
 import campfire.features.libraries.ui.generated.resources.cd_add_to_collection
-import campfire.features.libraries.ui.generated.resources.cd_back_arrow
 import campfire.features.libraries.ui.generated.resources.cd_more_actions
 import campfire.features.libraries.ui.generated.resources.error_library_item_message
 import campfire.features.libraries.ui.generated.resources.genres_title
@@ -179,19 +178,9 @@ fun LibraryItemContent(
         contentPadding = WindowInsets.statusBars
           .asPaddingValues(),
         navigationIcon = {
-          val backLabel = stringResource(Res.string.cd_back_arrow)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(
-              onClick = {
-                state.eventSink(LibraryItemUiEvent.OnBack)
-              },
-            ) {
-              Icon(
-                CampfireIcons.Rounded.ArrowBack,
-                contentDescription = backLabel,
-              )
-            }
-          }
+          NavigationBackButton(onClick = {
+            state.eventSink(LibraryItemUiEvent.OnBack)
+          })
         },
         actions = {
           AnimatedVisibility(

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUi.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUi.kt
@@ -23,8 +23,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FabPosition
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -49,16 +47,14 @@ import androidx.compose.ui.unit.dp
 import app.campfire.audioplayer.offline.asWidgetStatus
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.extensions.plus
-import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.permission.PermissionState
 import app.campfire.common.compose.permission.rememberPostNotificationPermissionState
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.ErrorListState
-import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemCollectionSharedTransitionKey
 import app.campfire.common.compose.widgets.LoadingListState
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.common.compose.widgets.dialog.ConfirmDownloadDialog
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -72,7 +68,6 @@ import app.campfire.playlists.ui.detail.composables.PlaylistListItem
 import app.campfire.playlists.ui.sheets.EditPlaylistModel
 import app.campfire.playlists.ui.sheets.showEditPlaylistBottomSheet
 import campfire.features.playlists.ui.generated.resources.Res
-import campfire.features.playlists.ui.generated.resources.action_back
 import campfire.features.playlists.ui.generated.resources.dialog_confirm_delete_action_cancel
 import campfire.features.playlists.ui.generated.resources.dialog_confirm_delete_action_delete
 import campfire.features.playlists.ui.generated.resources.dialog_confirm_delete_message
@@ -250,17 +245,7 @@ private fun PlaylistTopBar(
     windowInsets = WindowInsets(),
     contentPadding = WindowInsets.statusBars.asPaddingValues(),
     navigationIcon = {
-      val backLabel = stringResource(Res.string.action_back)
-      IconButtonTooltip(text = backLabel) {
-        IconButton(
-          onClick = onBack,
-        ) {
-          Icon(
-            CampfireIcons.Rounded.ArrowBack,
-            contentDescription = backLabel,
-          )
-        }
-      }
+      NavigationBackButton(onClick = onBack)
     },
   )
 }

--- a/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/builder/AddPodcastBuilderUi.kt
+++ b/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/builder/AddPodcastBuilderUi.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -25,10 +23,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.widgets.CampfireTopAppBar
-import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.core.di.UserScope
 import app.campfire.podcasts.api.screen.AddPodcastBuilderScreen
 import app.campfire.podcasts.ui.AddPodcastSharedTransitionKey
@@ -42,7 +38,6 @@ import app.campfire.podcasts.ui.builder.composables.SubmitBar
 import app.campfire.podcasts.ui.builder.composables.episodesSection
 import app.campfire.ui.navigation.bar.CampfireNavigationBarWindowInsets
 import campfire.features.podcasts.ui.generated.resources.Res
-import campfire.features.podcasts.ui.generated.resources.add_podcast_builder_back
 import campfire.features.podcasts.ui.generated.resources.add_podcast_builder_field_author
 import campfire.features.podcasts.ui.generated.resources.add_podcast_builder_field_description
 import campfire.features.podcasts.ui.generated.resources.add_podcast_builder_field_title
@@ -79,12 +74,7 @@ fun AddPodcastBuilderUi(
       CampfireTopAppBar(
         title = { Text(stringResource(Res.string.add_podcast_builder_title)) },
         navigationIcon = {
-          val backLabel = stringResource(Res.string.add_podcast_builder_back)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(onClick = { state.eventSink(AddPodcastBuilderUiEvent.Back) }) {
-              Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-            }
-          }
+          NavigationBackButton(onClick = { state.eventSink(AddPodcastBuilderUiEvent.Back) })
         },
         scrollBehavior = scrollBehavior,
       )

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUi.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUi.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -34,15 +32,13 @@ import androidx.compose.ui.unit.dp
 import app.campfire.audioplayer.offline.asWidgetStatus
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.extensions.plus
-import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.ErrorListState
-import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.ItemCollectionSharedTransitionKey
 import app.campfire.common.compose.widgets.LibraryItemCard
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.MaxBookDisplay
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -51,7 +47,6 @@ import app.campfire.core.model.LibraryItemId
 import app.campfire.core.offline.OfflineStatus
 import app.campfire.series.ui.detail.composables.MissingSeriesBookCard
 import campfire.features.series.ui.generated.resources.Res
-import campfire.features.series.ui.generated.resources.action_back
 import campfire.features.series.ui.generated.resources.error_series_detail_message
 import campfire.features.series.ui.generated.resources.missing_section_title
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
@@ -76,14 +71,7 @@ fun SeriesDetail(
         contentPadding = WindowInsets.statusBars
           .asPaddingValues(),
         navigationIcon = {
-          val backLabel = stringResource(Res.string.action_back)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(
-              onClick = { state.eventSink(SeriesDetailUiEvent.Back) },
-            ) {
-              Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-            }
-          }
+          NavigationBackButton(onClick = { state.eventSink(SeriesDetailUiEvent.Back) })
         },
       )
     },

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUi.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/SettingsUi.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -40,7 +39,6 @@ import app.campfire.common.compose.extensions.thenIf
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.outline.Library
 import app.campfire.common.compose.icons.rounded.AccountCircle
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.DeveloperMode
 import app.campfire.common.compose.icons.rounded.DirectionsCar
 import app.campfire.common.compose.icons.rounded.Download
@@ -53,7 +51,7 @@ import app.campfire.common.compose.layout.SupportingContentState
 import app.campfire.common.compose.layout.isSupportingPaneEnabled
 import app.campfire.common.compose.layout.isWidthAtLeastExtraLarge
 import app.campfire.common.compose.widgets.CampfireTopAppBar
-import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.common.screens.SettingsScreen
 import app.campfire.core.di.UserScope
 import app.campfire.ui.settings.composables.SettingPaneListItem
@@ -69,7 +67,6 @@ import app.campfire.ui.settings.panes.PaneState
 import app.campfire.ui.settings.panes.PlaybackPane
 import app.campfire.ui.settings.panes.SleepPane
 import campfire.features.settings.ui.generated.resources.Res
-import campfire.features.settings.ui.generated.resources.action_back
 import campfire.features.settings.ui.generated.resources.setting_about_subtitle
 import campfire.features.settings.ui.generated.resources.setting_about_title
 import campfire.features.settings.ui.generated.resources.setting_account_subtitle
@@ -268,17 +265,7 @@ private fun SettingsRootPane(
           navigationIcon = {
             val windowSizeClass = LocalWindowSizeClass.current
             if (!windowSizeClass.isSupportingPaneEnabled) {
-              val backLabel = stringResource(Res.string.action_back)
-              IconButtonTooltip(text = backLabel) {
-                IconButton(
-                  onClick = onBackClick,
-                ) {
-                  Icon(
-                    CampfireIcons.Rounded.ArrowBack,
-                    contentDescription = backLabel,
-                  )
-                }
-              }
+              NavigationBackButton(onClick = onBackClick)
             }
           },
         )

--- a/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/SettingPaneLayout.kt
+++ b/features/settings/ui/src/commonMain/kotlin/app/campfire/ui/settings/panes/SettingPaneLayout.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
@@ -25,13 +23,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.CampfireTopAppBarInsets
 import app.campfire.common.compose.CampfireWindowInsets
-import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.widgets.CampfireTopAppBar
-import app.campfire.common.compose.widgets.IconButtonTooltip
-import campfire.features.settings.ui.generated.resources.Res
-import campfire.features.settings.ui.generated.resources.action_back
-import org.jetbrains.compose.resources.stringResource
+import app.campfire.common.compose.widgets.NavigationBackButton
 
 enum class PaneState {
   Single, Double,
@@ -62,17 +55,7 @@ internal fun SettingPaneLayout(
         ?: WindowInsets(0.dp),
       navigationIcon = {
         if (paneState == PaneState.Single) {
-          val backLabel = stringResource(Res.string.action_back)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(
-              onClick = onBackClick,
-            ) {
-              Icon(
-                CampfireIcons.Rounded.ArrowBack,
-                contentDescription = backLabel,
-              )
-            }
-          }
+          NavigationBackButton(onClick = onBackClick)
         }
       },
     )

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.Refresh
 import app.campfire.common.compose.layout.LocalSupportingContentState
 import app.campfire.common.compose.layout.SupportingContentState
@@ -52,6 +51,7 @@ import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LoadingState
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.common.screens.StatisticsScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -80,7 +80,6 @@ import app.campfire.stats.ui.composables.TotalStatsCard
 import app.campfire.stats.ui.composables.WeeklyListeningCard
 import app.campfire.stats.ui.composables.showFinishedThisYearBottomSheet
 import campfire.features.stats.ui.generated.resources.Res
-import campfire.features.stats.ui.generated.resources.action_back
 import campfire.features.stats.ui.generated.resources.action_refresh
 import campfire.features.stats.ui.generated.resources.stats_library
 import campfire.features.stats.ui.generated.resources.stats_user
@@ -130,14 +129,7 @@ fun StatsUi(
             }
           },
           navigationIcon = {
-            val backLabel = stringResource(Res.string.action_back)
-            IconButtonTooltip(text = backLabel) {
-              IconButton(
-                onClick = { state.eventSink(StatsUiEvent.Back) },
-              ) {
-                Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-              }
-            }
+            NavigationBackButton(onClick = { state.eventSink(StatsUiEvent.Back) })
           },
           actions = {
             RefreshAction(
@@ -157,14 +149,7 @@ fun StatsUi(
             }
           },
           navigationIcon = {
-            val backLabel = stringResource(Res.string.action_back)
-            IconButtonTooltip(text = backLabel) {
-              IconButton(
-                onClick = { state.eventSink(StatsUiEvent.Back) },
-              ) {
-                Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-              }
-            }
+            NavigationBackButton(onClick = { state.eventSink(StatsUiEvent.Back) })
           },
           actions = {
             RefreshAction(

--- a/features/stats/ui/src/jvmMain/kotlin/app/campfire/stats/ui/composables/PreviewScaffold.kt
+++ b/features/stats/ui/src/jvmMain/kotlin/app/campfire/stats/ui/composables/PreviewScaffold.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.DarkMode
 import app.campfire.common.compose.icons.rounded.LightMode
 import app.campfire.common.compose.layout.ContentLayout
@@ -29,8 +28,8 @@ import app.campfire.common.compose.layout.LocalContentLayout
 import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import campfire.features.stats.ui.generated.resources.Res
-import campfire.features.stats.ui.generated.resources.action_back
 import campfire.features.stats.ui.generated.resources.action_toggle_dark_mode
 import org.jetbrains.compose.resources.stringResource
 
@@ -52,14 +51,7 @@ internal fun PreviewScaffold(
           CampfireTopAppBar(
             title = { Text("User statistics") },
             navigationIcon = {
-              val backLabel = stringResource(Res.string.action_back)
-              IconButtonTooltip(text = backLabel) {
-                IconButton(
-                  onClick = {},
-                ) {
-                  Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-                }
-              }
+              NavigationBackButton(onClick = {})
             },
             actions = {
               val toggleDarkLabel = stringResource(Res.string.action_toggle_dark_mode)

--- a/ui/attribution/src/commonMain/kotlin/app/campfire/attribution/AttributionUi.kt
+++ b/ui/attribution/src/commonMain/kotlin/app/campfire/attribution/AttributionUi.kt
@@ -5,8 +5,6 @@ package app.campfire.attribution
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -14,17 +12,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import app.campfire.common.compose.CampfireWindowInsets
-import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
-import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LoadingState
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.common.screens.AttributionScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import campfire.ui.attribution.generated.resources.Res
-import campfire.ui.attribution.generated.resources.action_back
 import campfire.ui.attribution.generated.resources.attributions_error_message
 import campfire.ui.attribution.generated.resources.attributions_title
 import com.mikepenz.aboutlibraries.Libs
@@ -45,14 +40,7 @@ fun Attribution(
         scrollBehavior = scrollBehavior,
         title = { Text(stringResource(Res.string.attributions_title)) },
         navigationIcon = {
-          val backLabel = stringResource(Res.string.action_back)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(
-              onClick = { state.eventSink(AttributionUiEvent.Back) },
-            ) {
-              Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-            }
-          }
+          NavigationBackButton(onClick = { state.eventSink(AttributionUiEvent.Back) })
         },
       )
     },

--- a/ui/theming/ai/src/commonMain/kotlin/app/campfire/ui/theming/ai/ui/AiThemeBuilderUi.kt
+++ b/ui/theming/ai/src/commonMain/kotlin/app/campfire/ui/theming/ai/ui/AiThemeBuilderUi.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -51,13 +50,12 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.ArrowDropDown
 import app.campfire.common.compose.icons.rounded.AutoAwesome
 import app.campfire.common.compose.icons.rounded.Save
 import app.campfire.common.compose.theme.LocalUseDarkColors
 import app.campfire.common.compose.widgets.CampfireTopAppBar
-import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.core.di.UserScope
 import app.campfire.ui.theming.ai.ui.composables.AppPreview
 import app.campfire.ui.theming.ai.ui.emptystate.ShapeParticleEmptyState
@@ -66,11 +64,8 @@ import app.campfire.ui.theming.api.HalogenStyle
 import app.campfire.ui.theming.api.colorScheme
 import app.campfire.ui.theming.api.screen.AiThemeBuilderScreen
 import app.campfire.ui.theming.ui.builder.composables.IconPicker
-import campfire.ui.theming.ai.generated.resources.Res
-import campfire.ui.theming.ai.generated.resources.action_back
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import kotlin.time.Duration.Companion.nanoseconds
-import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @CircuitInject(AiThemeBuilderScreen::class, UserScope::class)
@@ -92,12 +87,7 @@ fun AiThemeBuilder(
       CampfireTopAppBar(
         title = { Text("AI Theme Builder") },
         navigationIcon = {
-          val backLabel = stringResource(Res.string.action_back)
-          IconButtonTooltip(text = backLabel) {
-            IconButton(onClick = { state.eventSink(AiThemeBuilderUiEvent.Back) }) {
-              Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-            }
-          }
+          NavigationBackButton(onClick = { state.eventSink(AiThemeBuilderUiEvent.Back) })
         },
         scrollBehavior = scrollBehavior,
         containerColor = Color.Transparent,

--- a/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/builder/ThemeBuilderUi.kt
+++ b/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/builder/ThemeBuilderUi.kt
@@ -52,7 +52,6 @@ import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.currentWindowSizeClass
 import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.DarkMode
 import app.campfire.common.compose.icons.rounded.Delete
 import app.campfire.common.compose.icons.rounded.LightMode
@@ -63,6 +62,7 @@ import app.campfire.common.compose.theme.LocalUseDarkColors
 import app.campfire.common.compose.theme.alt.AltRedColorPalette
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.core.di.UserScope
 import app.campfire.ui.theming.api.AppTheme
 import app.campfire.ui.theming.api.colorScheme
@@ -74,7 +74,6 @@ import app.campfire.ui.theming.ui.builder.composables.ContrastPicker
 import app.campfire.ui.theming.ui.builder.composables.Header
 import app.campfire.ui.theming.ui.builder.composables.IconPicker
 import campfire.ui.theming.ui.generated.resources.Res
-import campfire.ui.theming.ui.generated.resources.action_back
 import campfire.ui.theming.ui.generated.resources.action_delete_theme
 import com.r0adkll.kimchi.circuit.annotations.CircuitInject
 import com.r0adkll.swatchbuckler.color.dynamiccolor.ColorSpec.SpecVersion
@@ -101,14 +100,7 @@ fun ThemeBuilder(
             Text("Theme Builder")
           },
           navigationIcon = {
-            val backLabel = stringResource(Res.string.action_back)
-            IconButtonTooltip(text = backLabel) {
-              IconButton(
-                onClick = { state.eventSink(ThemeBuilderUiEvent.Back) },
-              ) {
-                Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-              }
-            }
+            NavigationBackButton(onClick = { state.eventSink(ThemeBuilderUiEvent.Back) })
           },
           actions = {
             var showDeleteConfirmation by remember { mutableStateOf(false) }

--- a/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/picker/ThemePickerUi.kt
+++ b/ui/theming/ui/src/commonMain/kotlin/app/campfire/ui/theming/ui/picker/ThemePickerUi.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.CampfireWindowInsets
 import app.campfire.common.compose.icons.CampfireIcons
-import app.campfire.common.compose.icons.rounded.ArrowBack
 import app.campfire.common.compose.icons.rounded.AutoAwesome
 import app.campfire.common.compose.icons.rounded.Edit
 import app.campfire.common.compose.icons.rounded.FormatPaint
@@ -60,6 +59,7 @@ import app.campfire.common.compose.icons.theme.Ai
 import app.campfire.common.compose.icons.theme.Palette
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.common.compose.widgets.NavigationBackButton
 import app.campfire.core.coroutines.onError
 import app.campfire.core.coroutines.onLoaded
 import app.campfire.core.coroutines.onLoading
@@ -69,7 +69,6 @@ import app.campfire.ui.theming.api.AppThemeImage
 import app.campfire.ui.theming.api.colorScheme
 import app.campfire.ui.theming.api.screen.ThemePickerScreen
 import campfire.ui.theming.ui.generated.resources.Res
-import campfire.ui.theming.ui.generated.resources.action_back
 import campfire.ui.theming.ui.generated.resources.action_edit_theme
 import campfire.ui.theming.ui.generated.resources.theme_name_dynamic
 import campfire.ui.theming.ui.generated.resources.theme_name_forest
@@ -99,14 +98,7 @@ fun ThemePicker(
             Text("Theme")
           },
           navigationIcon = {
-            val backLabel = stringResource(Res.string.action_back)
-            IconButtonTooltip(text = backLabel) {
-              IconButton(
-                onClick = { state.eventSink(ThemePickerUiEvent.Back) },
-              ) {
-                Icon(CampfireIcons.Rounded.ArrowBack, contentDescription = backLabel)
-              }
-            }
+            NavigationBackButton(onClick = { state.eventSink(ThemePickerUiEvent.Back) })
           },
           scrollBehavior = scrollBehavior,
           containerColor = MaterialTheme.colorScheme.surfaceContainer,


### PR DESCRIPTION
## Summary

- Screens shown in the supporting (detail) pane on wide windows now show a close **X** in the top app bar instead of a back arrow, on both desktop and mobile layouts. The action was already "close the pane"; the glyph and label now say so.
- Adds a `NavigationBackButton` widget in `common/compose` that reads the existing `LocalContentLayout` (`Supporting` → close icon + "Close" label, otherwise back arrow + "Back" label) and replaces the hand-rolled back buttons in 17 screens with it.
- Stacked navigation on phones is unchanged: the root pane still shows the back arrow.

## Test plan

- [x] `./scripts/ktlint --check`
- [x] `:app:desktop:compileKotlin`, `:app:android:compileAlphaDebugKotlin`
- [x] `:features:libraries:ui:jvmTest`, `:common:compose:jvmTest`
- [ ] Open a book, series, author, collection, or settings page in the side pane on desktop and confirm the X closes it; confirm phones still show the back arrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)