### PR TITLE
Fix desktop navigation chrome: bottom bar strip, app bar margin, drawer selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Desktop app freezing while opening a chapter, bookmark, or track, and while starting playback
+- Desktop showing a blank strip under the bottom navigation bar in narrow windows
+- Search bar sitting flush against the top of the window on wide desktop layouts
+- Expanded search results on wide layouts spilling past the search bar's edge instead of lining up under it
+- Navigation drawer always highlighting Home instead of the section being viewed
 - Desktop resuming up to a second before the saved position
 - Desktop playback of streamed audiobooks failing because track requests were not authenticated
 - Desktop app crashing on launch, and again on every launch after the first

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/CampfireContent.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/CampfireContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import app.campfire.account.api.UserSessionManager
+import app.campfire.common.compose.LocalWindowChromeInsets
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.currentWindowSizeClass
 import app.campfire.common.root.automation.AutomationDeepLinks
@@ -63,6 +64,7 @@ fun CampfireContentWithInsets(
 
   CompositionLocalProvider(
     LocalWindowSizeClass provides currentWindowSizeClass(),
+    LocalWindowChromeInsets provides windowInsets,
     LocalRetainedStateRegistry provides lifecycleRetainedStateRegistry(),
     LocalUriHandler provides appUriHandler,
   ) {
@@ -91,7 +93,6 @@ fun CampfireContentWithInsets(
           userComponent = userComponent,
           onRootPop = onRootPop,
           onOpenUrl = onOpenUrl,
-          windowInsets = windowInsets,
           deepLink = deepLink,
           settings = settings,
           themeManager = themeManager,

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
@@ -104,7 +104,6 @@ internal fun LoggedInWindow(
   userComponent: UserComponent,
   onRootPop: () -> Unit,
   onOpenUrl: (String) -> Unit,
-  windowInsets: WindowInsets,
   deepLink: DeepLink,
   settings: CampfireSettings,
   themeManager: ThemeManager,
@@ -177,7 +176,6 @@ internal fun LoggedInWindow(
           LoggedInUi(
             backstack = backStack,
             navigator = urlNavigator,
-            windowInsets = windowInsets,
             navigationEventListeners = userComponent.navigationEventListeners,
             deepLink = deepLink,
             modifier = modifier,
@@ -194,7 +192,6 @@ private fun LoggedInUi(
   backstack: SaveableBackStack,
   navigator: Navigator,
   navigationEventListeners: ImmutableList<NavigationEventListener>,
-  windowInsets: WindowInsets,
   deepLink: DeepLink,
   modifier: Modifier = Modifier,
 ) {
@@ -214,6 +211,15 @@ private fun LoggedInUi(
   val currentPresentation by remember(backstack) {
     derivedStateOf {
       (backstack.topRecord?.screen as? BaseScreen)?.presentation
+    }
+  }
+
+  // The section the drawer should highlight: the top-most screen that isn't a detail
+  // screen. Drawer destinations are pushed on phones and reset on desktop, so the root
+  // of the back stack alone doesn't describe where the user is.
+  val currentSectionScreen by remember(backstack) {
+    derivedStateOf {
+      backstack.firstOrNull { it.screen !is DetailScreen }?.screen ?: backstack.last().screen
     }
   }
 
@@ -340,12 +346,10 @@ private fun LoggedInUi(
     overlayHost = overlayHost,
     drawerState = drawerState,
     drawerEnabled = !playbackBarExpanded,
-    windowInsets = windowInsets,
-    hideBottomNav = currentPresentation?.hideBottomNav == true || playbackBarExpanded,
 
     drawerContent = {
       CampfireDrawer(
-        rootScreen = rootScreen,
+        currentScreen = currentSectionScreen,
         drawerState = drawerState,
         navigator = homeNavigator,
         accountSwitcher = {

--- a/app/desktop/src/main/kotlin/app/campfire/Main.kt
+++ b/app/desktop/src/main/kotlin/app/campfire/Main.kt
@@ -114,10 +114,7 @@ fun main() = application {
       component.campfireContent(
         { exitApplication() },
         uriHandler::openUri,
-        WindowInsets(
-          top = 24.dp,
-          bottom = 24.dp,
-        ),
+        WindowInsets(top = 12.dp),
         DeepLink.None,
         Modifier,
       )

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/CampfireTopAppBarInsets.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/CampfireTopAppBarInsets.kt
@@ -5,6 +5,7 @@ package app.campfire.common.compose
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.only
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
@@ -23,10 +24,11 @@ val CampfireTopAppBarInsets: WindowInsets
   @Composable get() {
     val windowSizeClass = LocalWindowSizeClass.current
     val contentLayout = LocalContentLayout.current
+    val chromeInsets = LocalWindowChromeInsets.current
 
     return if (windowSizeClass.isSupportingPaneEnabled && contentLayout == ContentLayout.Root) {
-      TopAppBarDefaults.windowInsets.only(WindowInsetsSides.Vertical)
+      TopAppBarDefaults.windowInsets.add(chromeInsets).only(WindowInsetsSides.Vertical)
     } else {
-      TopAppBarDefaults.windowInsets.only(WindowInsetsSides.Vertical)
+      TopAppBarDefaults.windowInsets.add(chromeInsets).only(WindowInsetsSides.Vertical)
     }
   }

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/WindowChromeInsets.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/WindowChromeInsets.kt
@@ -1,0 +1,17 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Insets the host window reserves that the platform does not report as system bars.
+ *
+ * Desktop has no status bar, so it provides a small top inset here to keep app bars from
+ * sitting flush against the title bar; mobile platforms provide none. App bars consume it the
+ * same way they consume the status bar inset, so it stays inside their background rather than
+ * padding the content around them.
+ */
+val LocalWindowChromeInsets = staticCompositionLocalOf<WindowInsets> { WindowInsets(0) }

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/AdaptiveCampfireLayout.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/AdaptiveCampfireLayout.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DrawerState
@@ -39,7 +38,6 @@ import androidx.window.core.layout.WindowSizeClass
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.navigation.LocalDrawerState
 import app.campfire.common.compose.navigation.LocalUserSession
-import app.campfire.core.extensions.fluentIf
 import app.campfire.core.session.isLoggedIn
 import com.slack.circuit.overlay.ContentWithOverlays
 import com.slack.circuit.overlay.OverlayHost
@@ -65,8 +63,6 @@ fun AdaptiveCampfireLayout(
   showSupportingContent: Boolean,
 
   modifier: Modifier = Modifier,
-  hideBottomNav: Boolean = false,
-  windowInsets: WindowInsets = WindowInsets.systemBars,
 ) {
   val isLoggedIn by rememberUpdatedState(LocalUserSession.current.isLoggedIn)
   val windowSizeClass by rememberUpdatedState(LocalWindowSizeClass.current)
@@ -100,18 +96,16 @@ fun AdaptiveCampfireLayout(
         gesturesEnabled = isLoggedIn && drawerEnabled,
         modifier = Modifier.weight(1f),
       ) {
+        // Screens handle their own system-bar and window-chrome insets, so the root scaffold
+        // reserves nothing here. This keeps content edge-to-edge (the supporting pane starts at
+        // the very top) and avoids exposing a blank strip above app bars when content scrolls.
         Scaffold(
-          contentWindowInsets = windowInsets,
+          contentWindowInsets = WindowInsets(0),
         ) { paddingValues ->
-
           Row(
             modifier = Modifier
               .fillMaxSize()
-              .fluentIf(
-                navigationType == NavigationType.BottomNavigation && !hideBottomNav,
-              ) {
-                padding(paddingValues)
-              },
+              .padding(paddingValues),
           ) {
             if (navigationType == NavigationType.Rail && isLoggedIn) {
               railNavigation()

--- a/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireDockedSearchBar.kt
+++ b/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireDockedSearchBar.kt
@@ -6,14 +6,13 @@ package app.campfire.ui.appbar
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -30,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.LocalWindowChromeInsets
 import app.campfire.common.compose.extensions.plus
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Close
@@ -108,27 +108,25 @@ private fun CampfireDockedSearchBar(
     )
   }
 
-  BoxWithConstraints(
+  AppBarWithSearch(
+    state = searchBarState,
+    inputField = inputField,
+    scrollBehavior = scrollBehavior,
     modifier = modifier.fillMaxWidth(),
-  ) {
-    AppBarWithSearch(
-      state = searchBarState,
-      inputField = inputField,
-      scrollBehavior = scrollBehavior,
-      modifier = Modifier.fillMaxWidth(),
-      windowInsets = WindowInsets(),
-      contentPadding = SearchBarDefaults.windowInsets
-        .only(WindowInsetsSides.Top)
-        .asPaddingValues() + PaddingValues(horizontal = 8.dp),
-    )
+    windowInsets = WindowInsets(),
+    contentPadding = SearchBarDefaults.windowInsets
+      .add(LocalWindowChromeInsets.current)
+      .only(WindowInsetsSides.Top)
+      .asPaddingValues() + PaddingValues(horizontal = 8.dp),
+  )
 
-    ExpandedDockedSearchBar(
-      state = searchBarState,
-      inputField = inputField,
-      modifier = Modifier
-        .width(maxWidth - 32.dp),
-    ) {
-      resultContent()
-    }
+  // The expanded sheet is a popup anchored to the collapsed pill's top-left corner and sized
+  // to the pill's width. Forcing a wider size here makes it grow past the pill's right edge,
+  // so leave the width to the search bar state.
+  ExpandedDockedSearchBar(
+    state = searchBarState,
+    inputField = inputField,
+  ) {
+    resultContent()
   }
 }

--- a/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireSearchAppBar.kt
+++ b/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireSearchAppBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
@@ -41,6 +42,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.LocalWindowChromeInsets
 import app.campfire.common.compose.extensions.plus
 import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.ArrowBack
@@ -172,6 +174,7 @@ private fun CampfireSearchAppBar(
     scrollBehavior = scrollBehavior,
     windowInsets = WindowInsets(),
     contentPadding = SearchBarDefaults.windowInsets
+      .add(LocalWindowChromeInsets.current)
       .only(WindowInsetsSides.Top)
       .asPaddingValues() + PaddingValues(horizontal = 8.dp),
   )

--- a/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/drawer/CampfireDrawer.kt
+++ b/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/drawer/CampfireDrawer.kt
@@ -84,7 +84,7 @@ interface CampfireDrawerComponent {
 
 @Composable
 fun CampfireDrawer(
-  rootScreen: Screen,
+  currentScreen: Screen,
   drawerState: DrawerState,
   navigator: Navigator,
   accountSwitcher: @Composable () -> Unit,
@@ -97,6 +97,12 @@ fun CampfireDrawer(
   }
   val state = presenter.presentDrawer()
   val windowSizeClass = LocalWindowSizeClass.current
+  val isPermanentDrawer = windowSizeClass.navigationType == NavigationType.Drawer
+
+  // Prefer an exact match so sibling items sharing a screen class (e.g. Settings and
+  // Downloads) don't both light up; fall back to the class for parameterised screens.
+  val selectedScreen = state.navigationItems.firstOrNull { it.screen == currentScreen }?.screen
+    ?: state.navigationItems.firstOrNull { it.screen.instanceOf(currentScreen::class) }?.screen
 
   DrawerSheet(
     modifier = modifier,
@@ -141,11 +147,17 @@ fun CampfireDrawer(
       state.navigationItems.forEach { item ->
         DestinationListItem(
           item = item,
-          rootScreen = rootScreen,
+          selected = item.screen == selectedScreen,
           onClick = {
-            navigator.goTo(item.screen)
-            scope.launch {
-              drawerState.close()
+            if (isPermanentDrawer) {
+              // A permanent drawer is the top-level switcher, like the bottom bar and rail:
+              // swap the root instead of stacking destinations on top of each other.
+              navigator.resetRoot(item.screen)
+            } else {
+              navigator.goTo(item.screen)
+              scope.launch {
+                drawerState.close()
+              }
             }
           },
         )
@@ -251,7 +263,7 @@ fun CampfireDrawer(
 @Composable
 private fun DestinationListItem(
   item: HomeNavigationItem,
-  rootScreen: Screen,
+  selected: Boolean,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -263,7 +275,7 @@ private fun DestinationListItem(
       )
     },
     label = { Text(text = item.label) },
-    selected = item.screen.instanceOf(rootScreen::class),
+    selected = selected,
     onClick = onClick,
     modifier = modifier
       .padding(


### PR DESCRIPTION
## Summary

Four desktop UI fixes noticed while using the app at different window sizes.

- **Blank strip under the bottom navigation bar** in phone-width windows. The desktop entry point passed an artificial 24dp bottom inset that the root layout applied as content padding.
- **Search bar flush against the window's top** in rail and drawer layouts. The same artificial inset was only applied in bottom-nav mode, so wide layouts got nothing.
- **Expanded search results spilling past the search bar.** The docked sheet was forced to `content width - 32dp`, but M3 anchors the popup to the collapsed pill's top-left corner and sizes it to the pill, so anything wider grew off to the right (off-screen on smaller windows, off-centre on larger ones).
- **Navigation drawer always highlighting Home.** Selection came from the bottom of the back stack while drawer items push rather than reset.

## Approach

- The desktop top inset now travels through a new `LocalWindowChromeInsets` composition local and is consumed by the app bars (`CampfireSearchAppBar`, `CampfireDockedSearchBar`, and `CampfireTopAppBarInsets`) the same way they consume the status bar inset. It stays inside the app bar's background, so scrolling no longer exposes a blank margin, and the supporting pane starts at the very top. Desktop provides 12dp, which lands the search pill and title-bar titles at the drawer's 16dp margin. Android and iOS provide an empty inset and are unaffected.
- `AdaptiveCampfireLayout` no longer takes `windowInsets`/`hideBottomNav`; its scaffold reserves nothing.
- `ExpandedDockedSearchBar` uses the search bar state's own bounds.
- `CampfireDrawer` derives its selection from the top-most non-detail screen, with an exact match preferred so Settings and Downloads (both `SettingsScreen`) don't light up together. The permanent drawer now calls `resetRoot` like the bottom bar and rail instead of stacking destinations. This also applies to XL Android tablets, where back after picking a drawer item now exits, matching the existing rail/bottom-bar behaviour.

## Verification

Checked in the running desktop app via the Compose hot-reload semantic tree at 1800dp (drawer), 800dp (rail), and 420dp (bottom nav):

| Layout | Search pill top | Drawer header top | Content / supporting pane top |
|---|---|---|---|
| Drawer (1800dp) | 16dp | 16dp | 0dp |
| Phone (420dp) | 16dp | n/a | 0dp, bottom bar flush with window bottom |
| Settings title bar | title centre 44dp (same as pill centre) | | 0dp |

Expanded search sheet at 1800dp: x=940px, width 1440px, identical to the collapsed pill (was 1816px wide). Drawer selection verified for Settings, Downloads, Home, and the modal drawer on phone width.

UI-only changes with no unit test coverage, hence `skip-coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
