### PR TITLE
Add a collapsible wide navigation rail and dock the playback bar on desktop from Expanded up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop on macOS adds playback controls to the Dock icon's menu
 - Desktop plays through a built-in audio engine, so VLC no longer needs to be installed
 - Desktop can stream large audiobooks over HLS, with the Streaming method setting now available there
+- Desktop windows between tablet and ultra-wide sizes get a collapsible navigation rail listing every destination, with the account and library switcher in its header and its expanded or collapsed state remembered
 
 ### Changed
 
 - Screens shown in the side detail pane now close with an X instead of showing a back arrow
 - Desktop plays each audio file whole and navigates chapters within it, instead of re-opening the file at every chapter
 - Desktop playback bar is shorter and shows progress through the whole book, with chapter and bookmark markers you can hover and click
+- Desktop docks the playback bar along the bottom of any tablet-width or wider window instead of only ultra-wide ones
+- Desktop and tablet search results close once you pick one
 
 ### Deprecated
 

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
@@ -35,6 +35,7 @@ import app.campfire.account.ui.picker.AccountPickerResult
 import app.campfire.account.ui.picker.showAccountPicker
 import app.campfire.account.ui.switcher.AccountSwitcher
 import app.campfire.account.ui.switcher.AccountSwitcherUiEvent
+import app.campfire.account.ui.switcher.RailAccountSwitcher
 import app.campfire.analytics.Analytics
 import app.campfire.analytics.events.ActionEvent
 import app.campfire.analytics.events.ScreenType
@@ -45,7 +46,7 @@ import app.campfire.common.compose.extensions.shouldUseDarkColors
 import app.campfire.common.compose.layout.AdaptiveCampfireLayout
 import app.campfire.common.compose.layout.isLandscapePhone
 import app.campfire.common.compose.layout.isSupportingPaneEnabled
-import app.campfire.common.compose.layout.isWidthAtLeastExtraLarge
+import app.campfire.common.compose.layout.usesBottomPlaybackBar
 import app.campfire.common.compose.session.LocalPlaybackSession
 import app.campfire.common.compose.theme.CampfireTheme
 import app.campfire.common.compose.util.LocalThemeDispatcher
@@ -76,6 +77,7 @@ import app.campfire.ui.navigation.bar.LocalNavigationBarState
 import app.campfire.ui.navigation.bar.rememberCampfireNavigationBarState
 import app.campfire.ui.navigation.drawer.CampfireDrawer
 import app.campfire.ui.navigation.rail.CampfireNavigationRail
+import app.campfire.ui.navigation.rail.CampfireWideNavigationRail
 import app.campfire.ui.theming.api.AppThemeRepository
 import app.campfire.ui.theming.api.ThemeManager
 import app.campfire.ui.theming.api.colorScheme
@@ -340,6 +342,16 @@ private fun LoggedInUi(
     },
   )
 
+  // Shows the account picker and applies whatever the user chose to the switcher
+  val pickAccount: suspend (eventSink: (AccountSwitcherUiEvent) -> Unit) -> Unit = { eventSink ->
+    when (val result = overlayHost.showAccountPicker()) {
+      AccountPickerResult.AddAccount -> homeNavigator.goTo(LoginScreen.Additional)
+      is AccountPickerResult.SwitchAccount -> eventSink(AccountSwitcherUiEvent.SwitchAccount(result.server))
+      is AccountPickerResult.ReauthenticateAccount -> homeNavigator.goTo(LoginScreen.ReAuthentication(result.server))
+      else -> Unit
+    }
+  }
+
   // Search View wiring
   val navigationBarState = rememberCampfireNavigationBarState()
   AdaptiveCampfireLayout(
@@ -359,24 +371,8 @@ private fun LoggedInUi(
                 launch {
                   drawerState.close()
                 }
-                when (val result = overlayHost.showAccountPicker()) {
-                  AccountPickerResult.AddAccount -> {
-                    homeNavigator.goTo(LoginScreen.Additional)
-                    drawerState.close()
-                  }
-
-                  is AccountPickerResult.SwitchAccount -> {
-                    eventSink(AccountSwitcherUiEvent.SwitchAccount(result.server))
-                    drawerState.close()
-                  }
-
-                  is AccountPickerResult.ReauthenticateAccount -> {
-                    homeNavigator.goTo(LoginScreen.ReAuthentication(result.server))
-                    drawerState.close()
-                  }
-
-                  else -> Unit
-                }
+                pickAccount(eventSink)
+                drawerState.close()
               }
             },
           )
@@ -411,6 +407,25 @@ private fun LoggedInUi(
         modifier = Modifier.fillMaxHeight(),
       )
     },
+    wideRailNavigation = {
+      CampfireWideNavigationRail(
+        selectedNavigation = rootScreen,
+        onNavigationSelected = { homeNavigator.resetRoot(it) },
+        accountContent = {
+          RailAccountSwitcher(
+            expanded = expanded,
+            toggleLabel = toggleLabel,
+            onToggle = onToggle,
+            onSwitchAccount = { eventSink ->
+              coroutineScope.launch {
+                pickAccount(eventSink)
+              }
+            },
+          )
+        },
+        modifier = Modifier.fillMaxHeight(),
+      )
+    },
 
     content = {
       val searchEventHandler: (SearchResultNavEvent) -> Unit = remember(homeNavigator) {
@@ -433,7 +448,7 @@ private fun LoggedInUi(
       }
     },
     playbackBarContent = {
-      if (!windowSizeClass.isWidthAtLeastExtraLarge) {
+      if (!windowSizeClass.usesBottomPlaybackBar) {
         val bottomSystemInset = withDensity {
           WindowInsets.navigationBars.asPaddingValues()
             .calculateBottomPadding().toPx()

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/CampfireInsets.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/CampfireInsets.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.layout.ContentLayout
 import app.campfire.common.compose.layout.LocalContentLayout
 import app.campfire.common.compose.layout.isSupportingPaneEnabled
-import app.campfire.common.compose.layout.isWidthAtLeastExtraLarge
+import app.campfire.common.compose.layout.usesBottomPlaybackBar
 import app.campfire.common.compose.session.LocalPlaybackSession
 
 /**
@@ -29,10 +29,10 @@ val CampfireWindowInsets: WindowInsets
     val session by rememberUpdatedState(LocalPlaybackSession.current)
     val contentLayout = LocalContentLayout.current
 
-    // Inset content if not extra-large screen, the playback session is live, and this content is not in the
-    // supporting pane.
-    val isExtraLargeScreen = windowSizeClass.isWidthAtLeastExtraLarge
-    val playbackBarInsets = if (!isExtraLargeScreen && session != null && contentLayout == ContentLayout.Root) {
+    // Inset content if the playback bar floats over it (rather than docking below it), the playback
+    // session is live, and this content is not in the supporting pane.
+    val floatingPlaybackBar = !windowSizeClass.usesBottomPlaybackBar
+    val playbackBarInsets = if (floatingPlaybackBar && session != null && contentLayout == ContentLayout.Root) {
       WindowInsets(bottom = PlaybackBarInsetSize)
     } else {
       WindowInsets(0.dp)

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/AdaptiveCampfireLayout.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/AdaptiveCampfireLayout.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -45,6 +46,11 @@ import com.slack.circuit.overlay.OverlayHost
 /**
  * Our custom adaptive layout for organizing the root level content and navigation for various
  * screen classes and orientations.
+ *
+ * Navigation follows [WindowSizeClass.navigationType]: a bottom bar, a compact rail, a
+ * collapsible wide rail (desktop only), or a permanent drawer. The playback bar is either floated
+ * over the content or, when [WindowSizeClass.usesBottomPlaybackBar], docked full-width under
+ * everything else.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,6 +62,7 @@ fun AdaptiveCampfireLayout(
   drawerContent: @Composable () -> Unit,
   bottomBarNavigation: @Composable () -> Unit,
   railNavigation: @Composable () -> Unit,
+  wideRailNavigation: @Composable () -> Unit,
 
   content: @Composable () -> Unit,
   playbackBarContent: @Composable BoxScope.() -> Unit,
@@ -72,6 +79,9 @@ fun AdaptiveCampfireLayout(
   val isSupportingPaneEnabled = remember(windowSizeClass) {
     windowSizeClass.isSupportingPaneEnabled
   }
+  val usesBottomPlaybackBar = remember(windowSizeClass) {
+    windowSizeClass.usesBottomPlaybackBar
+  }
   val supportingContentState =
     if (
       (showSupportingContent || windowSizeClass.isWidthAtLeastExtraLarge) &&
@@ -86,129 +96,164 @@ fun AdaptiveCampfireLayout(
   ContentWithOverlays(
     overlayHost = overlayHost,
   ) {
-    // This wraps a ModalNavigationDrawer IF the navigationType is Rail or BottomNav
-    // otherwise, this just pass the content() block through
-    Column(modifier) {
-      DrawerWithContent(
-        navigationType = navigationType,
-        drawerState = drawerState,
-        drawerContent = drawerContent,
-        gesturesEnabled = isLoggedIn && drawerEnabled,
-        modifier = Modifier.weight(1f),
-      ) {
-        // Screens handle their own system-bar and window-chrome insets, so the root scaffold
-        // reserves nothing here. This keeps content edge-to-edge (the supporting pane starts at
-        // the very top) and avoids exposing a blank strip above app bars when content scrolls.
-        Scaffold(
-          contentWindowInsets = WindowInsets(0),
-        ) { paddingValues ->
-          Row(
+    val bottomPlaybackBar: @Composable ColumnScope.() -> Unit = {
+      if (usesBottomPlaybackBar && isLoggedIn) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+          playbackBarContent()
+        }
+      }
+    }
+
+    // Bottom bar and compact rail get a modal drawer, the permanent Drawer sits beside the content,
+    // and the wide rail has no drawer at all (its header carries the account switcher). The docked
+    // playback bar sits under the permanent drawer but inside the modal one, so the scrim covers it.
+    DrawerWithContent(
+      navigationType = navigationType,
+      drawerState = drawerState,
+      drawerContent = drawerContent,
+      gesturesEnabled = isLoggedIn && drawerEnabled,
+      bottomContent = bottomPlaybackBar,
+      modifier = modifier,
+    ) {
+      // Screens handle their own system-bar and window-chrome insets, so the root scaffold
+      // reserves nothing here. This keeps content edge-to-edge (the supporting pane starts at
+      // the very top) and avoids exposing a blank strip above app bars when content scrolls.
+      Scaffold(
+        contentWindowInsets = WindowInsets(0),
+      ) { paddingValues ->
+        Row(
+          modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues),
+        ) {
+          if (isLoggedIn) {
+            when (navigationType) {
+              NavigationType.Rail -> railNavigation()
+              NavigationType.WideRail -> wideRailNavigation()
+              NavigationType.BottomNavigation, NavigationType.Drawer -> Unit
+            }
+          }
+
+          val targetWidth = windowSizeClass.SupportingContentWidth
+          val supportingContentWidth by animateDpAsState(
+            if (supportingContentState == SupportingContentState.Open && isSupportingPaneEnabled) {
+              targetWidth
+            } else {
+              0.dp
+            },
+          )
+
+          Box(
             modifier = Modifier
-              .fillMaxSize()
-              .padding(paddingValues),
+              .weight(1f)
+              .fillMaxHeight(),
           ) {
-            if (navigationType == NavigationType.Rail && isLoggedIn) {
-              railNavigation()
+            Column(
+              modifier = Modifier.padding(end = supportingContentWidth),
+            ) {
+              CompositionLocalProvider(
+                LocalContentLayout provides ContentLayout.Root,
+                LocalSupportingContentState provides supportingContentState,
+              ) {
+                Box {
+                  content()
+
+                  if (!usesBottomPlaybackBar) {
+                    playbackBarContent()
+                  }
+                }
+              }
             }
 
-            val targetWidth = windowSizeClass.SupportingContentWidth
-            val supportingContentWidth by animateDpAsState(
-              if (supportingContentState == SupportingContentState.Open && isSupportingPaneEnabled) {
-                targetWidth
-              } else {
-                0.dp
-              },
-            )
+            if (navigationType == NavigationType.BottomNavigation) {
+              Box(
+                modifier = Modifier.align(Alignment.BottomCenter),
+              ) {
+                bottomBarNavigation()
+              }
+            }
 
-            Box(
-              modifier = Modifier
-                .weight(1f)
-                .fillMaxHeight(),
-            ) {
-              Column(
-                modifier = Modifier.padding(end = supportingContentWidth),
+            if (isSupportingPaneEnabled && isLoggedIn) {
+              val supportingContentShape = if (usesBottomPlaybackBar) {
+                RoundedCornerShape(
+                  topStart = SupportingContentCornerRadius,
+                )
+              } else {
+                RoundedCornerShape(
+                  topStart = SupportingContentCornerRadius,
+                  bottomStart = SupportingContentCornerRadius,
+                )
+              }
+              Surface(
+                modifier = Modifier
+                  .align(Alignment.CenterEnd)
+                  .width(windowSizeClass.SupportingContentWidth)
+                  .offset {
+                    IntOffset(
+                      (windowSizeClass.SupportingContentWidth - supportingContentWidth).roundToPx(),
+                      0,
+                    )
+                  },
+                shadowElevation = SupportingContentElevation,
+                tonalElevation = 1.dp,
+                shape = supportingContentShape,
               ) {
                 CompositionLocalProvider(
-                  LocalContentLayout provides ContentLayout.Root,
+                  LocalContentLayout provides ContentLayout.Supporting,
                   LocalSupportingContentState provides supportingContentState,
                 ) {
-                  Box {
-                    content()
-
-                    if (!windowSizeClass.isWidthAtLeastExtraLarge) {
-                      playbackBarContent()
-                    }
-                  }
-                }
-              }
-
-              if (navigationType == NavigationType.BottomNavigation) {
-                Box(
-                  modifier = Modifier.align(Alignment.BottomCenter),
-                ) {
-                  bottomBarNavigation()
-                }
-              }
-
-              if (isSupportingPaneEnabled && isLoggedIn) {
-                val supportingContentShape = if (windowSizeClass.isWidthAtLeastExtraLarge) {
-                  RoundedCornerShape(
-                    topStart = SupportingContentCornerRadius,
-                  )
-                } else {
-                  RoundedCornerShape(
-                    topStart = SupportingContentCornerRadius,
-                    bottomStart = SupportingContentCornerRadius,
-                  )
-                }
-                Surface(
-                  modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .width(windowSizeClass.SupportingContentWidth)
-                    .offset {
-                      IntOffset(
-                        (windowSizeClass.SupportingContentWidth - supportingContentWidth).roundToPx(),
-                        0,
-                      )
-                    },
-                  shadowElevation = SupportingContentElevation,
-                  tonalElevation = 1.dp,
-//                  tonalElevation = SupportingContentElevation,
-//                  color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                  shape = supportingContentShape,
-                ) {
-                  CompositionLocalProvider(
-                    LocalContentLayout provides ContentLayout.Supporting,
-                    LocalSupportingContentState provides supportingContentState,
-                  ) {
-                    supportingContent()
-                  }
+                  supportingContent()
                 }
               }
             }
           }
         }
       }
-
-      if (windowSizeClass.isWidthAtLeastExtraLarge && isLoggedIn) {
-        Box(modifier = Modifier.fillMaxWidth()) {
-          playbackBarContent()
-        }
-      }
     }
   }
 }
 
+/**
+ * Wraps [content] in the drawer that matches [navigationType]: a permanent drawer beside the
+ * content (with [bottomContent] docked full-width beneath both), no drawer for the wide rail, or
+ * a modal drawer over a column of the content and [bottomContent].
+ */
 @Composable
 private fun DrawerWithContent(
   navigationType: NavigationType,
+  bottomContent: @Composable ColumnScope.() -> Unit,
   modifier: Modifier = Modifier,
   gesturesEnabled: Boolean = true,
   drawerState: DrawerState = rememberDrawerState(DrawerValue.Closed),
   drawerContent: @Composable () -> Unit,
   content: @Composable () -> Unit,
 ) {
-  if (navigationType == NavigationType.BottomNavigation || navigationType == NavigationType.Rail) {
+  if (navigationType == NavigationType.Drawer) {
+    Column(modifier) {
+      if (gesturesEnabled) {
+        PermanentNavigationDrawer(
+          drawerContent = drawerContent,
+          modifier = Modifier.weight(1f),
+        ) {
+          content()
+        }
+      } else {
+        Box(Modifier.weight(1f)) {
+          content()
+        }
+      }
+
+      bottomContent()
+    }
+  } else if (navigationType == NavigationType.WideRail) {
+    Column(modifier) {
+      Box(Modifier.weight(1f)) {
+        content()
+      }
+
+      bottomContent()
+    }
+  } else {
     CompositionLocalProvider(
       LocalDrawerState provides drawerState,
     ) {
@@ -218,18 +263,15 @@ private fun DrawerWithContent(
         gesturesEnabled = gesturesEnabled,
         modifier = modifier,
       ) {
-        content()
+        Column {
+          Box(Modifier.weight(1f)) {
+            content()
+          }
+
+          bottomContent()
+        }
       }
     }
-  } else if (navigationType == NavigationType.Drawer && gesturesEnabled) {
-    PermanentNavigationDrawer(
-      drawerContent = drawerContent,
-      modifier = modifier,
-    ) {
-      content()
-    }
-  } else {
-    content()
   }
 }
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/NavigationType.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/NavigationType.kt
@@ -6,5 +6,11 @@ package app.campfire.common.compose.layout
 enum class NavigationType {
   BottomNavigation,
   Rail,
+
+  /**
+   * A collapsible wide navigation rail that carries every destination the permanent drawer
+   * would, for desktop windows that are wide enough for labels but not for a permanent drawer.
+   */
+  WideRail,
   Drawer,
 }

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/WindowSizeClass.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/WindowSizeClass.kt
@@ -7,6 +7,8 @@ import androidx.window.core.layout.WindowSizeClass
 import androidx.window.core.layout.WindowSizeClass.Companion.HEIGHT_DP_MEDIUM_LOWER_BOUND
 import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_EXPANDED_LOWER_BOUND
 import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
+import app.campfire.core.Platform
+import app.campfire.core.currentPlatform
 
 /**
  * Lower bound, in dp, of the Large width size class (desktop and web windows). Mirrors the
@@ -52,11 +54,21 @@ val WindowSizeClass.isLandscapePhone: Boolean
   get() = isWidthAtLeastExpanded && isHeightCompact
 
 /**
- * Return the main navigation type for this size class
+ * Return if the full-width bottom playback bar should be used instead of the floating
+ * playback bar. Desktop windows get it from the Expanded breakpoint up; mobile always uses the
+ * floating bar.
+ */
+val WindowSizeClass.usesBottomPlaybackBar: Boolean
+  get() = currentPlatform == Platform.DESKTOP && isWidthAtLeastExpanded
+
+/**
+ * Return the main navigation type for this size class. Desktop windows between the Expanded and
+ * Extra-Large breakpoints get the collapsible wide rail; mobile keeps the compact rail there.
  */
 val WindowSizeClass.navigationType: NavigationType
   get() = when {
     isWidthAtLeastExtraLarge -> NavigationType.Drawer
+    isWidthAtLeastExpanded && currentPlatform == Platform.DESKTOP -> NavigationType.WideRail
     isWidthAtLeastMedium -> NavigationType.Rail
     // TODO: This is essentially a phone portrait mode, What would be the optimal setup for this
     else -> NavigationType.BottomNavigation

--- a/data/account/ui/src/commonMain/kotlin/app/campfire/account/ui/switcher/AccountSwitcher.kt
+++ b/data/account/ui/src/commonMain/kotlin/app/campfire/account/ui/switcher/AccountSwitcher.kt
@@ -6,7 +6,6 @@ package app.campfire.account.ui.switcher
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -47,6 +46,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.LocalWindowSizeClass
@@ -56,7 +56,6 @@ import app.campfire.common.compose.icons.asComposeIcon
 import app.campfire.common.compose.icons.rounded.AccountSwitch
 import app.campfire.common.compose.icons.rounded.ArrowDropDown
 import app.campfire.common.compose.icons.rounded.Refresh
-import app.campfire.common.compose.icons.theme.rememberWallVectorPainter
 import app.campfire.common.compose.layout.isLandscapePhone
 import app.campfire.common.compose.theme.PaytoneOneFontFamily
 import app.campfire.common.compose.widgets.ConnectionIndicator
@@ -67,6 +66,7 @@ import app.campfire.core.di.UserScope
 import app.campfire.core.model.Library
 import app.campfire.socket.SocketState
 import app.campfire.ui.theming.api.AppTheme
+import app.campfire.ui.theming.api.AppThemeImage
 import campfire.data.account.ui.generated.resources.Res
 import campfire.data.account.ui.generated.resources.action_switch_account
 import campfire.data.account.ui.generated.resources.libraries_error_message
@@ -151,7 +151,7 @@ private fun AccountSwitcher(
 }
 
 @Composable
-private fun AccountCard(
+internal fun AccountCard(
   modifier: Modifier = Modifier,
   shape: Shape = MaterialTheme.shapes.large,
   content: @Composable ColumnScope.() -> Unit,
@@ -198,51 +198,14 @@ private fun AccountSwitcher(
         ),
       verticalAlignment = Alignment.CenterVertically,
     ) {
-      Box(
-        modifier = Modifier.size(switcherConfig.iconSize),
-      ) {
-        when (appTheme) {
-          AppTheme.Dynamic -> {
-            Image(
-              rememberWallVectorPainter(),
-              contentDescription = null,
-              modifier = Modifier
-                .size(switcherConfig.iconSize),
-            )
-          }
-
-          is AppTheme.Fixed -> {
-            Image(
-              appTheme.icon.icon(),
-              contentDescription = null,
-              modifier = Modifier
-                .size(switcherConfig.iconSize),
-            )
-          }
-        }
-
-        if (socketState !is SocketState.Disabled) {
-          ConnectionIndicator(
-            state = when (socketState) {
-              is SocketState.Authenticated -> ConnectionState.Connected
-              SocketState.Authenticating -> ConnectionState.Connecting
-              SocketState.Connecting -> ConnectionState.Connecting
-              SocketState.Disconnected -> ConnectionState.Disconnected
-              is SocketState.Failed -> ConnectionState.Disconnected
-              SocketState.Disabled -> error("guarded above")
-            },
-            size = switcherConfig.indicatorSize,
-            borderWidth = 3.dp,
-            borderColor = MaterialTheme.colorScheme.primaryContainer,
-            modifier = Modifier
-              .align(Alignment.TopEnd)
-              .padding(
-                top = switcherConfig.indicatorOffset,
-                end = switcherConfig.indicatorOffset,
-              ),
-          )
-        }
-      }
+      AccountIcon(
+        appTheme = appTheme,
+        socketState = socketState,
+        size = switcherConfig.iconSize,
+        indicatorSize = switcherConfig.indicatorSize,
+        indicatorOffset = switcherConfig.indicatorOffset,
+        indicatorBorderColor = MaterialTheme.colorScheme.primaryContainer,
+      )
 
       Spacer(Modifier.width(16.dp))
 
@@ -312,14 +275,60 @@ private fun AccountSwitcher(
   }
 }
 
+/**
+ * The theme icon for the current account with the socket connection dot in its corner.
+ */
 @Composable
-private fun LibraryPicker(
+internal fun AccountIcon(
+  appTheme: AppTheme,
+  socketState: SocketState,
+  size: Dp,
+  indicatorSize: Dp,
+  indicatorOffset: Dp,
+  indicatorBorderColor: Color,
+  modifier: Modifier = Modifier,
+) {
+  Box(
+    modifier = modifier.size(size),
+  ) {
+    AppThemeImage(
+      appTheme = appTheme,
+      modifier = Modifier.size(size),
+    )
+
+    if (socketState !is SocketState.Disabled) {
+      ConnectionIndicator(
+        state = when (socketState) {
+          is SocketState.Authenticated -> ConnectionState.Connected
+          SocketState.Authenticating -> ConnectionState.Connecting
+          SocketState.Connecting -> ConnectionState.Connecting
+          SocketState.Disconnected -> ConnectionState.Disconnected
+          is SocketState.Failed -> ConnectionState.Disconnected
+          SocketState.Disabled -> error("guarded above")
+        },
+        size = indicatorSize,
+        borderWidth = 3.dp,
+        borderColor = indicatorBorderColor,
+        modifier = Modifier
+          .align(Alignment.TopEnd)
+          .padding(
+            top = indicatorOffset,
+            end = indicatorOffset,
+          ),
+      )
+    }
+  }
+}
+
+@Composable
+internal fun LibraryPicker(
   state: LibraryState,
   onLibraryClick: (Library) -> Unit,
   modifier: Modifier = Modifier,
   containerColor: Color = MaterialTheme.colorScheme.primary,
   contentColor: Color = MaterialTheme.colorScheme.contentColorFor(containerColor),
   shape: Shape = MaterialTheme.shapes.large,
+  rowStyle: LibraryRowStyle = DefaultLibraryRowStyle,
 ) {
   var expanded by remember { mutableStateOf(false) }
   Column(
@@ -336,6 +345,7 @@ private fun LibraryPicker(
       LibraryRow(
         library = state.currentLibrary,
         onClick = { expanded = !expanded },
+        rowStyle = rowStyle,
         trailingContent = {
           val iconRotation by animateFloatAsState(if (expanded) 180f else 0f)
           Icon(
@@ -359,6 +369,7 @@ private fun LibraryPicker(
               onLibraryClick(library)
               expanded = false
             },
+            rowStyle = rowStyle,
           )
         }
       }
@@ -401,6 +412,7 @@ private fun LibrariesLoaded(
   libraries: List<Library>,
   onLibraryClick: (Library) -> Unit,
   modifier: Modifier = Modifier,
+  rowStyle: LibraryRowStyle = DefaultLibraryRowStyle,
 ) {
   Column(
     modifier = modifier,
@@ -421,6 +433,7 @@ private fun LibrariesLoaded(
           library = library,
           selected = selected,
           onClick = { onLibraryClick(library) },
+          rowStyle = rowStyle,
           trailingContent = {
             RadioButton(
               selected = selected,
@@ -443,6 +456,7 @@ private fun LibraryRow(
   modifier: Modifier = Modifier,
   selected: Boolean = false,
   onClick: (() -> Unit)? = null,
+  rowStyle: LibraryRowStyle = DefaultLibraryRowStyle,
   trailingContent: @Composable (() -> Unit)? = null,
 ) {
   Row(
@@ -450,17 +464,19 @@ private fun LibraryRow(
       .clickable(enabled = onClick != null) { onClick?.invoke() }
       .fillMaxWidth()
       .padding(
-        horizontal = 24.dp,
-        vertical = 16.dp,
+        horizontal = rowStyle.horizontalPadding,
+        vertical = rowStyle.verticalPadding,
       ),
     verticalAlignment = Alignment.CenterVertically,
   ) {
     Icon(library.icon.asComposeIcon(), contentDescription = null)
-    Spacer(Modifier.width(16.dp))
+    Spacer(Modifier.width(rowStyle.iconSpacing))
     Text(
       text = library.name,
-      style = MaterialTheme.typography.titleMedium,
+      style = rowStyle.textStyle,
       fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
       modifier = Modifier.weight(1f),
     )
 
@@ -470,6 +486,31 @@ private fun LibraryRow(
     }
   }
 }
+
+/** Sizing for the rows of a [LibraryPicker]. */
+data class LibraryRowStyle(
+  val horizontalPadding: Dp,
+  val verticalPadding: Dp,
+  val iconSpacing: Dp,
+  val textStyle: TextStyle,
+)
+
+val DefaultLibraryRowStyle: LibraryRowStyle
+  @Composable get() = LibraryRowStyle(
+    horizontalPadding = 24.dp,
+    verticalPadding = 16.dp,
+    iconSpacing = 16.dp,
+    textStyle = MaterialTheme.typography.titleMedium,
+  )
+
+/** Tighter rows for the account switcher in the wide navigation rail. */
+val CompactLibraryRowStyle: LibraryRowStyle
+  @Composable get() = LibraryRowStyle(
+    horizontalPadding = 16.dp,
+    verticalPadding = 12.dp,
+    iconSpacing = 12.dp,
+    textStyle = MaterialTheme.typography.titleSmall,
+  )
 
 data class SwitcherConfig(
   val iconSize: Dp,

--- a/data/account/ui/src/commonMain/kotlin/app/campfire/account/ui/switcher/RailAccountSwitcher.kt
+++ b/data/account/ui/src/commonMain/kotlin/app/campfire/account/ui/switcher/RailAccountSwitcher.kt
@@ -1,0 +1,221 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.account.ui.switcher
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.di.rememberComponent
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.rounded.AccountSwitch
+import app.campfire.common.compose.theme.PaytoneOneFontFamily
+import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.core.coroutines.LoadState
+import app.campfire.socket.SocketState
+import app.campfire.ui.theming.api.AppTheme
+import campfire.data.account.ui.generated.resources.Res
+import campfire.data.account.ui.generated.resources.action_switch_account
+import campfire.data.account.ui.generated.resources.server_name_error
+import campfire.data.account.ui.generated.resources.server_name_loading
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Width of the expanded switcher card. Wider than the rail's 220dp minimum would allow so a typical
+ * server name fits beside the icon and the switch-account button; the rail grows to match.
+ */
+val RailAccountSwitcherWidth = 232.dp
+
+private val CollapsedIconSize = 56.dp
+private val ExpandedIconSize = 40.dp
+
+/**
+ * The account switcher shaped for the header of the desktop wide navigation rail. Collapsed it is
+ * only the account icon; expanded it grows into a compact card with the server and user names, a
+ * switch-account button, and the library picker. In both states tapping the icon calls [onToggle]
+ * so the icon doubles as the rail's expand/collapse control.
+ *
+ * @param toggleLabel the accessible label for the icon, describing what [onToggle] will do
+ * @param onSwitchAccount called with the presenter's event sink when the switch-account button is
+ *   pressed, so the caller can show the account picker and feed the result back
+ */
+@Composable
+fun RailAccountSwitcher(
+  expanded: Boolean,
+  toggleLabel: String,
+  onToggle: () -> Unit,
+  onSwitchAccount: (eventSink: (AccountSwitcherUiEvent) -> Unit) -> Unit,
+  modifier: Modifier = Modifier,
+  component: AccountSwitcherComponent = rememberComponent(),
+) {
+  val presenter = remember(component) { component.accountSwitcherPresenterFactory() }
+  val state = presenter.present()
+  RailAccountSwitcher(
+    state = state,
+    expanded = expanded,
+    toggleLabel = toggleLabel,
+    onToggle = onToggle,
+    onSwitchAccount = { onSwitchAccount(state.eventSink) },
+    modifier = modifier,
+  )
+}
+
+@Composable
+internal fun RailAccountSwitcher(
+  state: AccountSwitcherUiState,
+  expanded: Boolean,
+  toggleLabel: String,
+  onToggle: () -> Unit,
+  onSwitchAccount: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val serverName = when (val currentAccount = state.currentAccount) {
+    is LoadState.Loaded -> currentAccount.data.name
+    LoadState.Loading -> stringResource(Res.string.server_name_loading)
+    LoadState.Error -> stringResource(Res.string.server_name_error)
+  }
+
+  val userName = when (val currentAccount = state.currentAccount) {
+    is LoadState.Loaded -> currentAccount.data.user.name
+    else -> null
+  }
+
+  AnimatedContent(
+    targetState = expanded,
+    transitionSpec = {
+      (fadeIn() togetherWith fadeOut()) using SizeTransform(clip = false)
+    },
+    modifier = modifier,
+  ) { isExpanded ->
+    if (isExpanded) {
+      AccountCard(
+        modifier = Modifier.width(RailAccountSwitcherWidth),
+      ) {
+        Row(
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+              start = 12.dp,
+              top = 12.dp,
+              end = 4.dp,
+              bottom = 12.dp,
+            ),
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          ToggleAccountIcon(
+            appTheme = state.theme,
+            socketState = state.socketState,
+            size = ExpandedIconSize,
+            indicatorSize = 8.dp,
+            indicatorOffset = 3.dp,
+            indicatorBorderColor = MaterialTheme.colorScheme.primaryContainer,
+            label = toggleLabel,
+            onClick = onToggle,
+          )
+
+          Spacer(Modifier.width(12.dp))
+
+          Column(
+            modifier = Modifier.weight(1f),
+          ) {
+            Text(
+              text = serverName,
+              style = MaterialTheme.typography.titleMedium.copy(fontFamily = PaytoneOneFontFamily),
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+            )
+            userName?.let {
+              Text(
+                text = it,
+                style = MaterialTheme.typography.labelMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+              )
+            }
+          }
+
+          val switchAccountLabel = stringResource(Res.string.action_switch_account)
+          IconButtonTooltip(text = switchAccountLabel) {
+            IconButton(onClick = onSwitchAccount) {
+              Icon(
+                CampfireIcons.Rounded.AccountSwitch,
+                contentDescription = switchAccountLabel,
+              )
+            }
+          }
+        }
+
+        if (state.libraryState != null) {
+          LibraryPicker(
+            state = state.libraryState,
+            onLibraryClick = { library ->
+              state.eventSink(AccountSwitcherUiEvent.SelectLibrary(library))
+            },
+            rowStyle = CompactLibraryRowStyle,
+          )
+        }
+      }
+    } else {
+      ToggleAccountIcon(
+        appTheme = state.theme,
+        socketState = state.socketState,
+        size = CollapsedIconSize,
+        indicatorSize = 12.dp,
+        indicatorOffset = 6.dp,
+        indicatorBorderColor = MaterialTheme.colorScheme.surface,
+        label = toggleLabel,
+        onClick = onToggle,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ToggleAccountIcon(
+  appTheme: AppTheme,
+  socketState: SocketState,
+  size: Dp,
+  indicatorSize: Dp,
+  indicatorOffset: Dp,
+  indicatorBorderColor: Color,
+  label: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  IconButtonTooltip(text = label) {
+    AccountIcon(
+      appTheme = appTheme,
+      socketState = socketState,
+      size = size,
+      indicatorSize = indicatorSize,
+      indicatorOffset = indicatorOffset,
+      indicatorBorderColor = indicatorBorderColor,
+      modifier = modifier
+        .clip(RoundedCornerShape(8.dp))
+        .clickable(onClick = onClick),
+    )
+  }
+}

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/CampfireSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/CampfireSettings.kt
@@ -74,6 +74,10 @@ interface CampfireSettings {
   var showTimeInBook: Boolean
   fun observeShowTimeInBook(): StateFlow<Boolean>
 
+  /** Whether the desktop wide navigation rail shows labels beside its icons (expanded) or only icons. */
+  var wideNavigationRailExpanded: Boolean
+  fun observeWideNavigationRailExpanded(): StateFlow<Boolean>
+
   var lastSeenVersion: String?
   fun observeLastSeenVersion(): StateFlow<String?>
 

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/CampfireSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/CampfireSettingsImpl.kt
@@ -120,6 +120,10 @@ class CampfireSettingsImpl(
   override var showTimeInBook: Boolean by showTimeInBookProperty
   override fun observeShowTimeInBook(): StateFlow<Boolean> = showTimeInBookProperty.observe()
 
+  private val wideNavigationRailExpandedProperty = booleanSetting(KEY_WIDE_NAVIGATION_RAIL_EXPANDED, true)
+  override var wideNavigationRailExpanded: Boolean by wideNavigationRailExpandedProperty
+  override fun observeWideNavigationRailExpanded(): StateFlow<Boolean> = wideNavigationRailExpandedProperty.observe()
+
   private val lastSeenVersionProperty = stringOrNullSetting(KEY_LAST_SEEN_WHATS_NEW)
   override var lastSeenVersion: String? by lastSeenVersionProperty
   override fun observeLastSeenVersion(): StateFlow<String?> = lastSeenVersionProperty.observe()
@@ -160,6 +164,7 @@ internal const val KEY_CURRENT_USER_ID = "pref_current_user_id"
 internal const val KEY_SHOW_CONFIRM_DOWNLOAD = "pref_show_confirm_download"
 internal const val KEY_SHOW_WIDGET_PINNING = "pref_show_widget_pinning"
 internal const val KEY_SHOW_TIME_IN_BOOK = "pref_show_time_in_book"
+internal const val KEY_WIDE_NAVIGATION_RAIL_EXPANDED = "pref_wide_navigation_rail_expanded"
 internal const val KEY_LAST_SEEN_WHATS_NEW = "pref_last_seen_whats_new"
 internal const val KEY_SOCKET_ENABLED = "pref_socket_enabled"
 internal const val KEY_APP_UPDATE_SIGN_IN_DISMISSED = "pref_app_update_sign_in_dismissed"

--- a/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/TestCampfireSettings.kt
+++ b/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/TestCampfireSettings.kt
@@ -125,6 +125,11 @@ class TestCampfireSettings(
     observeBoolean(::showTimeInBook)
       .stateIn(testScope, SharingStarted.Lazily, showTimeInBook)
 
+  override var wideNavigationRailExpanded: Boolean by boolean()
+  override fun observeWideNavigationRailExpanded(): StateFlow<Boolean> =
+    observeBoolean(::wideNavigationRailExpanded)
+      .stateIn(testScope, SharingStarted.Lazily, wideNavigationRailExpanded)
+
   override var lastSeenVersion: String? by stringOrNull()
   override fun observeLastSeenVersion(): StateFlow<String?> =
     observeStringOrNull(::lastSeenVersion)

--- a/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireDockedSearchBar.kt
+++ b/ui/appbar/src/commonMain/kotlin/app/campfire/ui/appbar/CampfireDockedSearchBar.kt
@@ -26,7 +26,11 @@ import androidx.compose.material3.SearchBarValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.LocalWindowChromeInsets
@@ -35,7 +39,9 @@ import app.campfire.common.compose.icons.CampfireIcons
 import app.campfire.common.compose.icons.rounded.Close
 import app.campfire.common.compose.icons.rounded.Search
 import app.campfire.common.compose.widgets.IconButtonTooltip
+import app.campfire.search.api.ui.LocalSearchEventHandler
 import app.campfire.search.api.ui.SearchComponent
+import app.campfire.search.api.ui.SearchResultNavEvent
 import campfire.ui.appbar.generated.resources.Res
 import campfire.ui.appbar.generated.resources.action_clear_search
 import campfire.ui.appbar.generated.resources.search_placeholder_text
@@ -70,6 +76,17 @@ private fun CampfireDockedSearchBar(
 ) {
   val scope = rememberCoroutineScope()
   val searchBarState = rememberSearchBarState()
+
+  // Picking a result navigates somewhere else, so the docked results should get out of the way.
+  // The query is kept so re-expanding the bar brings the same results back.
+  val searchEventHandler by rememberUpdatedState(LocalSearchEventHandler.current)
+  val collapsingSearchEventHandler = remember {
+    { event: SearchResultNavEvent ->
+      searchEventHandler(event)
+      scope.launch { searchBarState.animateToCollapsed() }
+      Unit
+    }
+  }
 
   val inputField = @Composable {
     SearchBarDefaults.InputField(
@@ -127,6 +144,10 @@ private fun CampfireDockedSearchBar(
     state = searchBarState,
     inputField = inputField,
   ) {
-    resultContent()
+    CompositionLocalProvider(
+      LocalSearchEventHandler provides collapsingSearchEventHandler,
+    ) {
+      resultContent()
+    }
   }
 }

--- a/ui/navigation/ui/build.gradle.kts
+++ b/ui/navigation/ui/build.gradle.kts
@@ -25,5 +25,11 @@ kotlin {
         implementation(libs.reorderable)
       }
     }
+
+    jvmTest {
+      dependencies {
+        implementation(compose.desktop.currentOs)
+      }
+    }
   }
 }

--- a/ui/navigation/ui/src/commonMain/composeResources/values/ui_drawer_strings.xml
+++ b/ui/navigation/ui/src/commonMain/composeResources/values/ui_drawer_strings.xml
@@ -38,4 +38,6 @@
 
   <string name="action_change_theme">Change theme</string>
   <string name="action_change_theme_mode">Change theme mode</string>
+  <string name="action_expand_navigation">Expand navigation</string>
+  <string name="action_collapse_navigation">Collapse navigation</string>
 </resources>

--- a/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/NavigationPresenter.kt
+++ b/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/NavigationPresenter.kt
@@ -33,6 +33,8 @@ import app.campfire.podcasts.api.RemoteEpisodeDownloadTracker
 import app.campfire.settings.api.CampfireSettings
 import app.campfire.ui.navigation.drawer.DrawerUiEvent
 import app.campfire.ui.navigation.drawer.DrawerUiState
+import app.campfire.ui.navigation.rail.WideNavigationRailUiEvent
+import app.campfire.ui.navigation.rail.WideNavigationRailUiState
 import campfire.ui.navigation.ui.generated.resources.Res
 import campfire.ui.navigation.ui.generated.resources.nav_collections_content_description
 import campfire.ui.navigation.ui.generated.resources.nav_collections_label
@@ -62,8 +64,64 @@ class NavigationPresenter(
   private val settings: CampfireSettings,
 ) {
 
+  /**
+   * The primary destinations shown in the bottom navigation bar and the compact navigation rail.
+   */
   @Composable
-  fun present(): List<HomeNavigationItem> {
+  fun present(): List<HomeNavigationItem> = primaryNavigationItems()
+
+  /**
+   * Every destination, primary and secondary, for the collapsible wide navigation rail along with
+   * its persisted expansion.
+   */
+  @Composable
+  fun presentWideRail(): WideNavigationRailUiState {
+    val items = primaryNavigationItems() + secondaryNavigationItems()
+    val expanded by remember {
+      settings.observeWideNavigationRailExpanded()
+    }.collectAsState()
+
+    return WideNavigationRailUiState(
+      navigationItems = items,
+      expanded = expanded,
+    ) { event ->
+      when (event) {
+        WideNavigationRailUiEvent.ToggleExpanded -> {
+          settings.wideNavigationRailExpanded = !expanded
+        }
+      }
+    }
+  }
+
+  @Composable
+  fun presentDrawer(): DrawerUiState {
+    val items = when (LocalWindowSizeClass.current.navigationType) {
+      // The permanent drawer is the only navigation, so it carries every destination
+      NavigationType.Drawer -> primaryNavigationItems() + secondaryNavigationItems()
+      // The wide rail lists every destination itself and has no drawer
+      NavigationType.WideRail -> emptyList()
+      // The bottom bar / compact rail carry the primary destinations
+      NavigationType.Rail, NavigationType.BottomNavigation -> secondaryNavigationItems()
+    }
+
+    val themeMode by remember {
+      settings.observeTheme()
+    }.collectAsState()
+
+    return DrawerUiState(
+      themeMode = themeMode,
+      navigationItems = items,
+    ) { event ->
+      when (event) {
+        DrawerUiEvent.CycleThemeMode -> {
+          settings.themeMode = themeMode.next()
+        }
+      }
+    }
+  }
+
+  @Composable
+  private fun primaryNavigationItems(): List<HomeNavigationItem> {
     val currentLibrary by remember {
       libraryRepository.observeCurrentLibrary()
     }.collectAsState(null)
@@ -80,27 +138,12 @@ class NavigationPresenter(
   }
 
   @Composable
-  fun presentDrawer(): DrawerUiState {
-    val items = buildList {
-      val currentLibrary by remember {
-        libraryRepository.observeCurrentLibrary()
-      }.collectAsState(null)
-      val downloadQueueCount by remember {
-        remoteEpisodeDownloadTracker.state
-      }.collectAsState()
+  private fun secondaryNavigationItems(): List<HomeNavigationItem> {
+    val currentLibrary by remember {
+      libraryRepository.observeCurrentLibrary()
+    }.collectAsState(null)
 
-      val navigationType = LocalWindowSizeClass.current.navigationType
-      if (navigationType == NavigationType.Drawer) {
-        addAll(
-          when (currentLibrary?.mediaType) {
-            MediaType.Podcast -> buildPodcastLibraryNavigationItems(
-              downloadQueueCount = downloadQueueCount.values.sumOf { it.size },
-            )
-            else -> buildBookLibraryNavigationItems()
-          },
-        )
-      }
-
+    return buildList {
       if (currentLibrary?.mediaType != MediaType.Podcast) {
         add(
           HomeNavigationItem(
@@ -152,21 +195,6 @@ class NavigationPresenter(
           selectedImageVector = CampfireIcons.Filled.Settings,
         ),
       )
-    }
-
-    val themeMode by remember {
-      settings.observeTheme()
-    }.collectAsState()
-
-    return DrawerUiState(
-      themeMode = themeMode,
-      navigationItems = items,
-    ) { event ->
-      when (event) {
-        DrawerUiEvent.CycleThemeMode -> {
-          settings.themeMode = themeMode.next()
-        }
-      }
     }
   }
 }

--- a/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/rail/CampfireWideNavigationRail.kt
+++ b/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/rail/CampfireWideNavigationRail.kt
@@ -1,0 +1,144 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.ui.navigation.rail
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.material3.WideNavigationRail
+import androidx.compose.material3.WideNavigationRailItem
+import androidx.compose.material3.WideNavigationRailValue
+import androidx.compose.material3.rememberWideNavigationRailState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.di.rememberComponent
+import app.campfire.ui.navigation.HomeNavigationItemIcon
+import app.campfire.ui.navigation.NavigationComponent
+import campfire.ui.navigation.ui.generated.resources.Res
+import campfire.ui.navigation.ui.generated.resources.action_collapse_navigation
+import campfire.ui.navigation.ui.generated.resources.action_expand_navigation
+import com.slack.circuit.runtime.screen.Screen
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * What the rail header slot is given: whether the rail is expanded, the accessible label for the
+ * control that toggles it, and the toggle itself. The slot content is expected to make its account
+ * icon call [onToggle], so the icon is the rail's expand/collapse control.
+ */
+@Stable
+data class WideNavigationRailHeaderScope(
+  val expanded: Boolean,
+  val toggleLabel: String,
+  val onToggle: () -> Unit,
+)
+
+/**
+ * The collapsible wide navigation rail used on desktop windows between the Expanded and
+ * Extra-Large breakpoints. It lists every destination the permanent drawer would, and its header
+ * hosts the account switcher, whose icon expands and collapses the rail.
+ */
+@Composable
+fun CampfireWideNavigationRail(
+  selectedNavigation: Screen,
+  onNavigationSelected: (Screen) -> Unit,
+  accountContent: @Composable WideNavigationRailHeaderScope.() -> Unit,
+  modifier: Modifier = Modifier,
+  navigationComponent: NavigationComponent = rememberComponent(),
+) {
+  val presenter = remember(navigationComponent) {
+    navigationComponent.navigationPresenterFactory()
+  }
+  val state = presenter.presentWideRail()
+
+  CampfireWideNavigationRailContent(
+    state = state,
+    selectedNavigation = selectedNavigation,
+    onNavigationSelected = onNavigationSelected,
+    accountContent = accountContent,
+    modifier = modifier,
+  )
+}
+
+@Composable
+fun CampfireWideNavigationRailContent(
+  state: WideNavigationRailUiState,
+  selectedNavigation: Screen,
+  onNavigationSelected: (Screen) -> Unit,
+  accountContent: @Composable WideNavigationRailHeaderScope.() -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val railState = rememberWideNavigationRailState(
+    initialValue = if (state.expanded) WideNavigationRailValue.Expanded else WideNavigationRailValue.Collapsed,
+  )
+  LaunchedEffect(state.expanded) {
+    if (state.expanded) railState.expand() else railState.collapse()
+  }
+  val expanded = railState.targetValue == WideNavigationRailValue.Expanded
+
+  // Mirror the rail's own item spacing, which it only applies to direct children
+  val itemSpacing by animateDpAsState(if (expanded) 0.dp else CollapsedItemSpacing)
+  // Centre the collapsed icon in the collapsed rail; hug the start edge once expanded
+  val headerStartPadding by animateDpAsState(if (expanded) ExpandedHeaderPadding else CollapsedHeaderPadding)
+
+  val toggleLabel = stringResource(
+    if (expanded) Res.string.action_collapse_navigation else Res.string.action_expand_navigation,
+  )
+  val headerScope = remember(expanded, toggleLabel, state.eventSink) {
+    WideNavigationRailHeaderScope(
+      expanded = expanded,
+      toggleLabel = toggleLabel,
+      onToggle = { state.eventSink(WideNavigationRailUiEvent.ToggleExpanded) },
+    )
+  }
+
+  WideNavigationRail(
+    state = railState,
+    modifier = modifier,
+    header = {
+      Box(Modifier.padding(start = headerStartPadding, end = ExpandedHeaderPadding)) {
+        headerScope.accountContent()
+      }
+    },
+  ) {
+    // The rail neither scrolls nor wraps, so a long destination list scrolls inside one child
+    Column(
+      modifier = Modifier.verticalScroll(rememberScrollState()),
+      verticalArrangement = Arrangement.spacedBy(itemSpacing),
+    ) {
+      for (item in state.navigationItems) {
+        val selected = item.screen == selectedNavigation
+        WideNavigationRailItem(
+          selected = selected,
+          onClick = { onNavigationSelected(item.screen) },
+          icon = {
+            HomeNavigationItemIcon(
+              item = item,
+              selected = selected,
+            )
+          },
+          label = { Text(text = item.label) },
+          railExpanded = expanded,
+        )
+      }
+    }
+  }
+}
+
+private val CollapsedItemSpacing = 4.dp
+
+/** Centres a 56dp icon inside the 96dp collapsed rail. */
+private val CollapsedHeaderPadding = 20.dp
+
+/** Insets the expanded switcher card inside the 220dp minimum expanded rail. */
+private val ExpandedHeaderPadding = 12.dp

--- a/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/rail/WideNavigationRailUiState.kt
+++ b/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/rail/WideNavigationRailUiState.kt
@@ -1,0 +1,20 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.ui.navigation.rail
+
+import androidx.compose.runtime.Stable
+import app.campfire.ui.navigation.HomeNavigationItem
+import com.slack.circuit.runtime.CircuitUiState
+
+@Stable
+data class WideNavigationRailUiState(
+  val navigationItems: List<HomeNavigationItem>,
+  val expanded: Boolean,
+  val eventSink: (WideNavigationRailUiEvent) -> Unit,
+) : CircuitUiState
+
+@Stable
+sealed interface WideNavigationRailUiEvent {
+  data object ToggleExpanded : WideNavigationRailUiEvent
+}

--- a/ui/navigation/ui/src/jvmTest/kotlin/app/campfire/ui/navigation/rail/CampfireWideNavigationRailRenderTest.kt
+++ b/ui/navigation/ui/src/jvmTest/kotlin/app/campfire/ui/navigation/rail/CampfireWideNavigationRailRenderTest.kt
@@ -1,0 +1,139 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.ui.navigation.rail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
+import app.campfire.common.compose.icons.CampfireIcons
+import app.campfire.common.compose.icons.filled.Home
+import app.campfire.common.compose.icons.outline.Author
+import app.campfire.common.compose.icons.outline.Collections
+import app.campfire.common.compose.icons.outline.Home
+import app.campfire.common.compose.icons.outline.Library
+import app.campfire.common.compose.icons.outline.Playlists
+import app.campfire.common.compose.icons.outline.Series
+import app.campfire.common.compose.icons.rounded.CloudDownload
+import app.campfire.common.compose.icons.rounded.Event
+import app.campfire.common.compose.icons.rounded.QueryStats
+import app.campfire.common.compose.icons.rounded.Settings
+import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.screens.AuthorsScreen
+import app.campfire.common.screens.CollectionsScreen
+import app.campfire.common.screens.HomeScreen
+import app.campfire.common.screens.SeriesScreen
+import app.campfire.common.screens.SettingsScreen
+import app.campfire.common.screens.StatisticsScreen
+import app.campfire.discover.api.screen.UpcomingScreen
+import app.campfire.libraries.api.screen.LibraryScreen
+import app.campfire.playlists.api.screen.PlaylistsScreen
+import app.campfire.ui.navigation.HomeNavigationItem
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.jetbrains.skia.EncodedImageFormat
+
+/**
+ * Renders the desktop wide navigation rail off-screen in its collapsed and expanded states and
+ * writes PNGs to `build/renders` for eyeballing; the assertions only guard that each state
+ * composes and paints. The short render checks that a full book-library destination list still
+ * fits (by scrolling) in a window shorter than the list.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class CampfireWideNavigationRailRenderTest {
+
+  private val renders = File("build/renders").apply { mkdirs() }
+
+  private val items = listOf(
+    HomeNavigationItem(HomeScreen, "Home", "Home", CampfireIcons.Outline.Home, CampfireIcons.Filled.Home),
+    HomeNavigationItem(LibraryScreen(), "Library", "Library", CampfireIcons.Outline.Library),
+    HomeNavigationItem(SeriesScreen, "Series", "Series", CampfireIcons.Outline.Series),
+    HomeNavigationItem(AuthorsScreen, "Authors", "Authors", CampfireIcons.Outline.Author),
+    HomeNavigationItem(PlaylistsScreen, "Playlists", "Playlists", CampfireIcons.Outline.Playlists),
+    HomeNavigationItem(CollectionsScreen, "Collections", "Collections", CampfireIcons.Outline.Collections),
+    HomeNavigationItem(UpcomingScreen, "Upcoming", "Upcoming", CampfireIcons.Rounded.Event),
+    HomeNavigationItem(StatisticsScreen, "Statistics", "Statistics", CampfireIcons.Rounded.QueryStats),
+    HomeNavigationItem(
+      SettingsScreen(SettingsScreen.Page.Downloads),
+      "Downloads",
+      "Downloads",
+      CampfireIcons.Rounded.CloudDownload,
+      badgeCount = 3,
+    ),
+    HomeNavigationItem(SettingsScreen(), "Settings", "Settings", CampfireIcons.Rounded.Settings),
+  )
+
+  @Test
+  fun `collapsed rail`() {
+    render("wide-rail-collapsed", height = 900) {
+      Rail(expanded = false)
+    }
+  }
+
+  @Test
+  fun `expanded rail`() {
+    render("wide-rail-expanded", height = 900) {
+      Rail(expanded = true)
+    }
+  }
+
+  @Test
+  fun `collapsed rail in a short window scrolls its destinations`() {
+    render("wide-rail-collapsed-short", height = 600) {
+      Rail(expanded = false)
+    }
+  }
+
+  @Composable
+  private fun Rail(expanded: Boolean) {
+    CampfireTheme(useDarkColors = false) {
+      Row(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
+        CampfireWideNavigationRailContent(
+          state = WideNavigationRailUiState(
+            navigationItems = items,
+            expanded = expanded,
+            eventSink = {},
+          ),
+          selectedNavigation = HomeScreen,
+          onNavigationSelected = {},
+          accountContent = {
+            // Stand-in for the account switcher: an icon collapsed, a card expanded
+            Box(
+              Modifier
+                .size(width = if (expanded) 232.dp else 56.dp, height = if (expanded) 120.dp else 56.dp)
+                .background(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.shapes.large),
+            )
+          },
+          modifier = Modifier.fillMaxHeight(),
+        )
+      }
+    }
+  }
+
+  private fun render(name: String, height: Int, content: @Composable () -> Unit) {
+    ImageComposeScene(width = WIDTH * 2, height = height * 2, density = Density(2f), content = content).use { scene ->
+      scene.render()
+      val image = scene.render(nanoTime = 1_000_000_000L)
+      val bytes = image.encodeToData(EncodedImageFormat.PNG)!!.bytes
+      File(renders, "$name.png").writeBytes(bytes)
+      println("rendered ${File(renders, "$name.png").absolutePath}")
+      assertTrue(bytes.size > 1_000)
+    }
+  }
+
+  private companion object {
+    const val WIDTH = 420
+  }
+}


### PR DESCRIPTION
## Summary
- Desktop windows between the Expanded (840dp) and Extra-Large (1600dp) breakpoints get a collapsible Material 3 wide navigation rail listing every destination the permanent drawer would. Its header is a rail-shaped account switcher: the account icon expands/collapses the rail, and when expanded it shows the server, user, a switch-account button and the library picker. The expanded state is remembered in settings. The wide rail has no drawer at all (theme, changelog and update entry points stay reachable from Settings).
- The full-width docked playback bar now shows on desktop from Expanded up (new `WindowSizeClass.usesBottomPlaybackBar`) instead of only at Extra-Large; mobile keeps the floating bar everywhere. It docks under the permanent drawer but inside the modal one so the scrim still covers it.
- Picking a result in the docked search bar collapses the results popup and keeps the query.

## Test plan
- [x] `:app:desktop:compileKotlin`, `:app:android:compileAlphaDebugKotlin`, `:app:common:compileKotlinIosSimulatorArm64`, ktlint
- [x] New `CampfireWideNavigationRailRenderTest` (jvmTest, `ui/navigation/ui/build/renders/*.png`): collapsed, expanded, and a 600dp-tall window scrolling ten destinations
- [x] Live desktop app via hot reload: 800dp → compact rail + floating bar; 1000dp → wide rail + docked bar; 1700dp → permanent drawer + docked bar
- [x] Rail toggles via the account icon, the collapsed/expanded state survives a restart (`pref_wide_navigation_rail_expanded` in `~/.config/Campfire/config.properties`), library picker unfolds inline, switch-account opens the picker
- [x] Docked search: type a query, click a result → popup closes, query kept, item opens in the detail pane
- [ ] Reviewer: sanity-check the wide rail on a podcast library (8 destinations) and with a long server name (ellipsizes in the 232dp card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

