### PR TITLE
Render built-in themes on neutral surfaces with a vibrant accent on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop playback bar is shorter and shows progress through the whole book, with chapter and bookmark markers you can hover and click
 - Desktop docks the playback bar along the bottom of any tablet-width or wider window instead of only ultra-wide ones
 - Desktop and tablet search results close once you pick one
+- Desktop renders the built-in themes on neutral cool-grey surfaces with a bolder version of the theme's colour as the accent, instead of tinting every surface
 
 ### Deprecated
 

--- a/common/compose/build.gradle.kts
+++ b/common/compose/build.gradle.kts
@@ -41,6 +41,12 @@ kotlin {
       }
     }
 
+    commonTest {
+      dependencies {
+        implementation(libs.bundles.test.common)
+      }
+    }
+
     val skikoMain by creating {
       dependsOn(commonMain.get())
     }

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/theme/desktop/DesktopColorPalette.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/theme/desktop/DesktopColorPalette.kt
@@ -1,0 +1,175 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.theme.desktop
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+import app.campfire.common.compose.extensions.asHct
+import app.campfire.common.compose.theme.ColorPalette
+import com.r0adkll.swatchbuckler.color.dynamiccolor.ColorSpec
+import com.r0adkll.swatchbuckler.color.dynamiccolor.ColorSpecs
+import com.r0adkll.swatchbuckler.color.dynamiccolor.DynamicScheme
+import com.r0adkll.swatchbuckler.color.dynamiccolor.Variant
+import com.r0adkll.swatchbuckler.color.hct.Hct
+import com.r0adkll.swatchbuckler.color.palettes.TonalPalette
+import com.r0adkll.swatchbuckler.color.utils.MathUtils
+import com.r0adkll.swatchbuckler.compose.util.asColorScheme
+
+/**
+ * HCT hue of the shared neutral ramp. Sits at the blue end so surfaces read as a cool
+ * grey (light surface #F8F9FB, dark surface #111415), the conventional default for
+ * desktop and web interfaces.
+ */
+const val DesktopNeutralHue: Double = 230.0
+
+/**
+ * HCT chroma of the neutral ramp. Material's own neutrals follow the accent hue at
+ * around 6, which is what produces the visible tint on surfaces; this keeps just enough
+ * colour to avoid a dead grey. The neutral-variant ramp (outlines, secondary text) uses
+ * double this.
+ */
+const val DesktopNeutralChroma: Double = 4.0
+
+private const val SecondaryChroma = 16.0
+private const val TertiaryChroma = 24.0
+private const val TertiaryHueShift = 60.0
+
+/**
+ * How the primary accent is rendered on desktop.
+ *
+ * Material's own tones put the dark-mode primary at tone 80, a pastel that reads as washed
+ * out next to the saturated mid-tone accents desktop and web UIs use. [Punchy] raises the
+ * accent's chroma to at least [minChroma] and moves the four primary roles to desktop-style
+ * tones; [Material] keeps the stock tones and only applies the seed as-is.
+ *
+ * [variant] hands the accent palettes to one of swatchbuckler's scheme styles instead: with
+ * [Variant.VIBRANT] the primary takes the maximum chroma its hue can hold and the secondary
+ * and tertiary get the style's hue rotations. Null keeps the seed's own chroma for primary
+ * and calm same-hue derivatives for the other two.
+ *
+ * `primary` doubles as text and icon colour on surfaces in Material, so the dark primary tone
+ * cannot drop to the ~50 a web button would use without failing as text on a tone-6 surface;
+ * the high 60s are the compromise a palette alone can reach.
+ */
+data class DesktopAccent(
+  val minChroma: Double,
+  val light: Tones,
+  val dark: Tones,
+  val variant: Variant? = null,
+) {
+  /** Tones (0-100) of the four primary roles for one colour mode. */
+  data class Tones(
+    val primary: Int,
+    val onPrimary: Int,
+    val container: Int,
+    val onContainer: Int,
+  )
+
+  companion object {
+    val Material = DesktopAccent(
+      minChroma = 0.0,
+      light = Tones(primary = 40, onPrimary = 100, container = 90, onContainer = 10),
+      dark = Tones(primary = 80, onPrimary = 20, container = 30, onContainer = 90),
+    )
+
+    val Punchy = DesktopAccent(
+      minChroma = 56.0,
+      light = Tones(primary = 45, onPrimary = 100, container = 92, onContainer = 10),
+      dark = Tones(primary = 68, onPrimary = 10, container = 35, onContainer = 95),
+    )
+
+    val Vibrant = Material.copy(variant = Variant.VIBRANT)
+
+    /** The desktop default: maximum-chroma accent family on desktop-style tones. */
+    val VibrantPunchy = Punchy.copy(variant = Variant.VIBRANT)
+  }
+}
+
+/**
+ * Builds the desktop flavour of a theme from its accent [seed].
+ *
+ * The seed's hue and chroma are kept intact as the primary accent, the secondary and
+ * tertiary roles are calm derivatives of that same hue, and every neutral role
+ * (backgrounds, surfaces, containers, outlines, text) comes from one shared grey ramp
+ * instead of a tint of the accent. Tonal elevation also tints towards that grey rather
+ * than the accent, so elevated surfaces stay neutral.
+ */
+fun desktopColorPalette(
+  seed: Color,
+  neutralHue: Double = DesktopNeutralHue,
+  neutralChroma: Double = DesktopNeutralChroma,
+  accent: DesktopAccent = DesktopAccent.VibrantPunchy,
+): ColorPalette {
+  val seedHct = seed.asHct()
+  return ColorPalette(
+    lightColorScheme = desktopColorScheme(seedHct, neutralHue, neutralChroma, accent, isDark = false),
+    darkColorScheme = desktopColorScheme(seedHct, neutralHue, neutralChroma, accent, isDark = true),
+  )
+}
+
+private fun desktopColorScheme(
+  seed: Hct,
+  neutralHue: Double,
+  neutralChroma: Double,
+  accent: DesktopAccent,
+  isDark: Boolean,
+): ColorScheme {
+  val specVersion = ColorSpec.SpecVersion.SPEC_2021
+  val platform = DynamicScheme.Platform.PHONE
+  val contrastLevel = 0.0
+  val spec = ColorSpecs.get(specVersion)
+  val neutralPalette = TonalPalette.fromHueAndChroma(neutralHue, neutralChroma)
+  val tones = if (isDark) accent.dark else accent.light
+  val variant = accent.variant
+
+  val basePrimary = if (variant == null) {
+    TonalPalette.fromHct(seed)
+  } else {
+    spec.getPrimaryPalette(variant, seed, isDark, platform, contrastLevel)
+  }
+  val primaryPalette = if (basePrimary.chroma < accent.minChroma) {
+    TonalPalette.fromHueAndChroma(basePrimary.hue, accent.minChroma)
+  } else {
+    basePrimary
+  }
+  val secondaryPalette = if (variant == null) {
+    TonalPalette.fromHueAndChroma(seed.hue, SecondaryChroma)
+  } else {
+    spec.getSecondaryPalette(variant, seed, isDark, platform, contrastLevel)
+  }
+  val tertiaryPalette = if (variant == null) {
+    TonalPalette.fromHueAndChroma(MathUtils.sanitizeDegreesDouble(seed.hue + TertiaryHueShift), TertiaryChroma)
+  } else {
+    spec.getTertiaryPalette(variant, seed, isDark, platform, contrastLevel)
+  }
+
+  val scheme = DynamicScheme(
+    sourceColorHct = seed,
+    variant = variant ?: Variant.TONAL_SPOT,
+    isDark = isDark,
+    contrastLevel = contrastLevel,
+    platform = platform,
+    specVersion = specVersion,
+    primaryPalette = primaryPalette,
+    secondaryPalette = secondaryPalette,
+    tertiaryPalette = tertiaryPalette,
+    neutralPalette = neutralPalette,
+    neutralVariantPalette = TonalPalette.fromHueAndChroma(neutralHue, neutralChroma * 2),
+    errorPalette = spec.getErrorPalette(
+      variant = variant ?: Variant.TONAL_SPOT,
+      sourceColorHct = seed,
+      isDark = isDark,
+      platform = platform,
+      contrastLevel = contrastLevel,
+    ),
+  )
+
+  return scheme.asColorScheme().copy(
+    primary = Color(primaryPalette.tone(tones.primary)),
+    onPrimary = Color(primaryPalette.tone(tones.onPrimary)),
+    primaryContainer = Color(primaryPalette.tone(tones.container)),
+    onPrimaryContainer = Color(primaryPalette.tone(tones.onContainer)),
+    surfaceTint = Color(neutralPalette.tone(if (isDark) 80 else 40)),
+  )
+}

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/theme/desktop/DesktopColorPalettes.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/theme/desktop/DesktopColorPalettes.kt
@@ -1,0 +1,33 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.theme.desktop
+
+import androidx.compose.ui.graphics.Color
+import app.campfire.common.compose.theme.ColorPalette
+import app.campfire.common.compose.theme.alt.AltBlueColorPalette
+import app.campfire.common.compose.theme.alt.AltGreenColorPalette
+import app.campfire.common.compose.theme.alt.AltOrangeColorPalette
+import app.campfire.common.compose.theme.alt.AltPurpleColorPalette
+import app.campfire.common.compose.theme.alt.AltYellowColorPalette
+import app.campfire.common.compose.theme.tents.RedColorPalette
+
+/**
+ * Accent seeds for the desktop palettes. Each is the light primary of the palette it
+ * mirrors, and only its hue survives: the vibrant accent takes the maximum chroma that hue
+ * can hold. Swap any of these for a hand-picked hex to retune a single theme.
+ */
+private val TentAccent: Color get() = RedColorPalette.lightColorScheme.primary
+private val RucksackAccent: Color get() = AltYellowColorPalette.lightColorScheme.primary
+private val WaterBottleAccent: Color get() = AltBlueColorPalette.lightColorScheme.primary
+private val ForestAccent: Color get() = AltGreenColorPalette.lightColorScheme.primary
+private val MountainAccent: Color get() = AltPurpleColorPalette.lightColorScheme.primary
+private val LifeFloatAccent: Color get() = AltOrangeColorPalette.lightColorScheme.primary
+
+/** Desktop counterparts of the built-in palettes. */
+val RedDesktopColorPalette: ColorPalette by lazy { desktopColorPalette(TentAccent) }
+val AltYellowDesktopColorPalette: ColorPalette by lazy { desktopColorPalette(RucksackAccent) }
+val AltBlueDesktopColorPalette: ColorPalette by lazy { desktopColorPalette(WaterBottleAccent) }
+val AltGreenDesktopColorPalette: ColorPalette by lazy { desktopColorPalette(ForestAccent) }
+val AltPurpleDesktopColorPalette: ColorPalette by lazy { desktopColorPalette(MountainAccent) }
+val AltOrangeDesktopColorPalette: ColorPalette by lazy { desktopColorPalette(LifeFloatAccent) }

--- a/common/compose/src/jvmTest/kotlin/app/campfire/common/compose/theme/desktop/DesktopColorPaletteTest.kt
+++ b/common/compose/src/jvmTest/kotlin/app/campfire/common/compose/theme/desktop/DesktopColorPaletteTest.kt
@@ -1,0 +1,223 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.theme.desktop
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+import app.campfire.common.compose.extensions.asHct
+import app.campfire.common.compose.theme.alt.AltBlueColorPalette
+import app.campfire.common.compose.theme.alt.AltGreenColorPalette
+import app.campfire.common.compose.theme.alt.AltOrangeColorPalette
+import app.campfire.common.compose.theme.alt.AltPurpleColorPalette
+import app.campfire.common.compose.theme.alt.AltYellowColorPalette
+import app.campfire.common.compose.theme.tents.RedColorPalette
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isBetween
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotEqualTo
+import com.r0adkll.swatchbuckler.color.contrast.Contrast
+import com.r0adkll.swatchbuckler.color.utils.MathUtils
+import kotlin.test.Test
+
+class DesktopColorPaletteTest {
+
+  private val builtIns = mapOf(
+    "Red" to (RedColorPalette to RedDesktopColorPalette),
+    "Yellow" to (AltYellowColorPalette to AltYellowDesktopColorPalette),
+    "Blue" to (AltBlueColorPalette to AltBlueDesktopColorPalette),
+    "Green" to (AltGreenColorPalette to AltGreenDesktopColorPalette),
+    "Purple" to (AltPurpleColorPalette to AltPurpleDesktopColorPalette),
+    "Orange" to (AltOrangeColorPalette to AltOrangeDesktopColorPalette),
+  )
+
+  @Test
+  fun `neutral roles stay close to grey in both modes`() {
+    assertAll {
+      builtIns.forEach { (name, palettes) ->
+        val (_, desktop) = palettes
+        listOf("light" to desktop.lightColorScheme, "dark" to desktop.darkColorScheme).forEach { (mode, scheme) ->
+          scheme.neutralRoles().forEach { (role, color) ->
+            assertThat(color.asHct().chroma, "$name $mode $role chroma").isLessThan(DesktopNeutralChroma * 2 + 1)
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `neutral roles keep a cool cast`() {
+    assertAll {
+      builtIns.forEach { (name, palettes) ->
+        val (_, desktop) = palettes
+        listOf("light" to desktop.lightColorScheme, "dark" to desktop.darkColorScheme).forEach { (mode, scheme) ->
+          scheme.neutralRoles().forEach { (role, color) ->
+            val hct = color.asHct()
+            // Tones pinned to black or white clip to the sRGB gamut and carry no meaningful hue.
+            if (hct.tone < 99.0 && hct.chroma > 2.0) {
+              assertThat(hct.hue, "$name $mode $role hue").isBetween(DesktopNeutralHue - 25, DesktopNeutralHue + 25)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `primary keeps the accent hue of the source palette`() {
+    assertAll {
+      builtIns.forEach { (name, palettes) ->
+        val (source, desktop) = palettes
+        val seedHue = source.lightColorScheme.primary.asHct().hue
+        val desktopHue = desktop.lightColorScheme.primary.asHct().hue
+        assertThat(
+          MathUtils.differenceDegrees(seedHue, desktopHue),
+          "$name primary hue drift",
+        ).isLessThan(5.0)
+        assertThat(desktop.lightColorScheme.primary.asHct().chroma, "$name primary chroma").isGreaterThan(20.0)
+      }
+    }
+  }
+
+  @Test
+  fun `light and dark surfaces sit at the expected tones`() {
+    assertAll {
+      builtIns.forEach { (name, palettes) ->
+        val (_, desktop) = palettes
+        assertThat(desktop.lightColorScheme.surface.asHct().tone, "$name light surface tone").isGreaterThan(95.0)
+        assertThat(desktop.darkColorScheme.surface.asHct().tone, "$name dark surface tone").isLessThan(10.0)
+        assertThat(desktop.lightColorScheme.onSurface.asHct().tone, "$name light onSurface tone").isLessThan(15.0)
+        assertThat(desktop.darkColorScheme.onSurface.asHct().tone, "$name dark onSurface tone").isGreaterThan(85.0)
+      }
+    }
+  }
+
+  @Test
+  fun `tonal elevation tints towards grey rather than the accent`() {
+    assertAll {
+      builtIns.forEach { (name, palettes) ->
+        val (_, desktop) = palettes
+        listOf("light" to desktop.lightColorScheme, "dark" to desktop.darkColorScheme).forEach { (mode, scheme) ->
+          assertThat(scheme.surfaceTint, "$name $mode surfaceTint").isNotEqualTo(scheme.primary)
+          assertThat(scheme.surfaceTint.asHct().chroma, "$name $mode surfaceTint chroma").isLessThan(
+            DesktopNeutralChroma + 1,
+          )
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `built-ins use the vibrant punchy accent`() {
+    assertAll {
+      builtIns.forEach { (name, palettes) ->
+        val (source, desktop) = palettes
+        val expected = desktopColorPalette(seed = source.lightColorScheme.primary, accent = DesktopAccent.VibrantPunchy)
+        assertThat(desktop.lightColorScheme.primary, "$name light primary").isEqualTo(expected.lightColorScheme.primary)
+        assertThat(desktop.darkColorScheme.primary, "$name dark primary").isEqualTo(expected.darkColorScheme.primary)
+        assertThat(desktop.lightColorScheme.tertiary, "$name light tertiary").isEqualTo(
+          expected.lightColorScheme.tertiary,
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `punchy accent raises chroma to the floor`() {
+    assertAll {
+      builtIns.forEach { (name, palettes) ->
+        val (_, desktop) = palettes
+        listOf("light" to desktop.lightColorScheme, "dark" to desktop.darkColorScheme).forEach { (mode, scheme) ->
+          // Yellow and orange hues cannot hold the full floor at these tones; the gamut clips them.
+          val floor = if (name == "Yellow" || name == "Orange") 30.0 else DesktopAccent.Punchy.minChroma - 12.0
+          assertThat(scheme.primary.asHct().chroma, "$name $mode primary chroma").isGreaterThan(floor)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `accent roles keep readable contrast`() {
+    assertAll {
+      builtIns.forEach { (name, palettes) ->
+        val (_, desktop) = palettes
+        listOf("light" to desktop.lightColorScheme, "dark" to desktop.darkColorScheme).forEach { (mode, scheme) ->
+          assertThat(contrast(scheme.onPrimary, scheme.primary), "$name $mode onPrimary/primary")
+            .isGreaterThanOrEqualTo(4.5)
+          assertThat(contrast(scheme.onPrimaryContainer, scheme.primaryContainer), "$name $mode onPrimaryContainer")
+            .isGreaterThanOrEqualTo(4.5)
+          assertThat(contrast(scheme.primary, scheme.surface), "$name $mode primary/surface")
+            .isGreaterThanOrEqualTo(3.0)
+          assertThat(contrast(scheme.primary, scheme.surfaceContainerHighest), "$name $mode primary/containerHighest")
+            .isGreaterThanOrEqualTo(3.0)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `every accent preset keeps readable contrast`() {
+    val presets = mapOf(
+      "Material" to DesktopAccent.Material,
+      "Punchy" to DesktopAccent.Punchy,
+      "Vibrant" to DesktopAccent.Vibrant,
+      "VibrantPunchy" to DesktopAccent.VibrantPunchy,
+    )
+    assertAll {
+      presets.forEach { (presetName, preset) ->
+        builtIns.forEach { (name, palettes) ->
+          val (source, _) = palettes
+          val desktop = desktopColorPalette(seed = source.lightColorScheme.primary, accent = preset)
+          listOf("light" to desktop.lightColorScheme, "dark" to desktop.darkColorScheme).forEach { (mode, scheme) ->
+            assertThat(contrast(scheme.onPrimary, scheme.primary), "$presetName $name $mode onPrimary/primary")
+              .isGreaterThanOrEqualTo(4.5)
+            assertThat(contrast(scheme.primary, scheme.surface), "$presetName $name $mode primary/surface")
+              .isGreaterThanOrEqualTo(3.0)
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `material accent keeps stock tones`() {
+    val stock = desktopColorPalette(seed = Color(0xFF904B3C), accent = DesktopAccent.Material)
+    assertThat(stock.lightColorScheme.primary.asHct().tone).isBetween(38.0, 42.0)
+    assertThat(stock.darkColorScheme.primary.asHct().tone).isBetween(78.0, 82.0)
+  }
+
+  @Test
+  fun `custom neutral ramps are honoured`() {
+    val warm = desktopColorPalette(seed = Color(0xFF904B3C), neutralHue = 70.0, neutralChroma = 6.0)
+    // A mid tone keeps its requested chroma; near-white surfaces clip towards grey.
+    val outline = warm.lightColorScheme.outline.asHct()
+    assertThat(outline.hue).isBetween(45.0, 95.0)
+    assertThat(outline.chroma).isBetween(6.0, 14.0)
+  }
+
+  private fun contrast(a: Color, b: Color): Double = Contrast.ratioOfTones(a.asHct().tone, b.asHct().tone)
+
+  private fun ColorScheme.neutralRoles(): Map<String, Color> = mapOf(
+    "background" to background,
+    "onBackground" to onBackground,
+    "surface" to surface,
+    "onSurface" to onSurface,
+    "surfaceVariant" to surfaceVariant,
+    "onSurfaceVariant" to onSurfaceVariant,
+    "surfaceDim" to surfaceDim,
+    "surfaceBright" to surfaceBright,
+    "surfaceContainerLowest" to surfaceContainerLowest,
+    "surfaceContainerLow" to surfaceContainerLow,
+    "surfaceContainer" to surfaceContainer,
+    "surfaceContainerHigh" to surfaceContainerHigh,
+    "surfaceContainerHighest" to surfaceContainerHighest,
+    "inverseSurface" to inverseSurface,
+    "inverseOnSurface" to inverseOnSurface,
+    "outline" to outline,
+    "outlineVariant" to outlineVariant,
+  )
+}

--- a/ui/theming/api/src/commonMain/kotlin/app/campfire/ui/theming/api/AppTheme.kt
+++ b/ui/theming/api/src/commonMain/kotlin/app/campfire/ui/theming/api/AppTheme.kt
@@ -62,7 +62,15 @@ import app.campfire.common.compose.theme.alt.AltOrangeColorPalette
 import app.campfire.common.compose.theme.alt.AltPurpleColorPalette
 import app.campfire.common.compose.theme.alt.AltYellowColorPalette
 import app.campfire.common.compose.theme.colorScheme
+import app.campfire.common.compose.theme.desktop.AltBlueDesktopColorPalette
+import app.campfire.common.compose.theme.desktop.AltGreenDesktopColorPalette
+import app.campfire.common.compose.theme.desktop.AltOrangeDesktopColorPalette
+import app.campfire.common.compose.theme.desktop.AltPurpleDesktopColorPalette
+import app.campfire.common.compose.theme.desktop.AltYellowDesktopColorPalette
+import app.campfire.common.compose.theme.desktop.RedDesktopColorPalette
 import app.campfire.common.compose.theme.tents.RedColorPalette
+import app.campfire.core.Platform
+import app.campfire.core.currentPlatform
 import com.r0adkll.swatchbuckler.color.dynamiccolor.ColorSpec
 import com.r0adkll.swatchbuckler.color.dynamiccolor.Variant
 
@@ -72,13 +80,18 @@ sealed interface AppTheme {
     open val id: String,
     open val icon: Icon,
     open val colorPalette: ColorPalette,
+    /**
+     * Neutral-surface variant applied on desktop, where Material's accent-tinted surfaces
+     * look out of place. User-authored themes keep their palette as-is on every platform.
+     */
+    open val desktopColorPalette: ColorPalette = colorPalette,
   ) : AppTheme {
-    data object Tent : Fixed("Tent", Icon.Tent, RedColorPalette)
-    data object Rucksack : Fixed("Rucksack", Icon.Rucksack, AltYellowColorPalette)
-    data object WaterBottle : Fixed("WaterBottle", Icon.WaterBottle, AltBlueColorPalette)
-    data object Forest : Fixed("Forest", Icon.Forest, AltGreenColorPalette)
-    data object Mountain : Fixed("Mountain", Icon.Mountain, AltPurpleColorPalette)
-    data object LifeFloat : Fixed("LifeFloat", Icon.LifeFloat, AltOrangeColorPalette)
+    data object Tent : Fixed("Tent", Icon.Tent, RedColorPalette, RedDesktopColorPalette)
+    data object Rucksack : Fixed("Rucksack", Icon.Rucksack, AltYellowColorPalette, AltYellowDesktopColorPalette)
+    data object WaterBottle : Fixed("WaterBottle", Icon.WaterBottle, AltBlueColorPalette, AltBlueDesktopColorPalette)
+    data object Forest : Fixed("Forest", Icon.Forest, AltGreenColorPalette, AltGreenDesktopColorPalette)
+    data object Mountain : Fixed("Mountain", Icon.Mountain, AltPurpleColorPalette, AltPurpleDesktopColorPalette)
+    data object LifeFloat : Fixed("LifeFloat", Icon.LifeFloat, AltOrangeColorPalette, AltOrangeDesktopColorPalette)
 
     data class Custom(
       override val id: String,
@@ -155,17 +168,25 @@ sealed interface AppTheme {
   }
 }
 
+/**
+ * The palette to render this theme with on the current platform.
+ */
+val AppTheme.Fixed.platformColorPalette: ColorPalette
+  get() = when (currentPlatform) {
+    Platform.DESKTOP -> desktopColorPalette
+    Platform.ANDROID, Platform.IOS -> colorPalette
+  }
+
 @Composable
 fun colorScheme(
   theme: AppTheme,
   useDarkColors: Boolean = LocalUseDarkColors.current,
 ): ColorScheme = when (theme) {
   is AppTheme.Fixed -> {
-    val palette = theme.colorPalette
-    colorScheme(palette, useDarkColors, false)
+    colorScheme(theme.platformColorPalette, useDarkColors, false)
   }
   is AppTheme.Dynamic -> {
-    val backupPalette = AppTheme.Fixed.Tent.colorPalette
+    val backupPalette = AppTheme.Fixed.Tent.platformColorPalette
     colorScheme(backupPalette, useDarkColors, true)
   }
 }


### PR DESCRIPTION
## Summary

Material's accent-tinted surfaces look out of place on desktop, where UIs conventionally sit on a neutral cool grey and use one or two accent colours. This gives every built-in theme a desktop palette that follows that convention while keeping the theme's identity as the accent.

- **Neutral surfaces**: all neutral roles (background, surfaces, containers, outlines, text) come from one shared cool-grey ramp (HCT hue 230, chroma 4). Light surface is `#F8F9FB`, dark surface `#111415`. Tonal elevation tints towards grey instead of the accent.
- **Vibrant accent**: the primary keeps the theme's hue but takes the maximum chroma that hue can hold (swatchbuckler `Variant.VIBRANT`), and secondary/tertiary get VIBRANT's hue rotations so the scheme reads as one colour family.
- **Desktop tones**: the four primary roles use desktop-style tones (light primary 45, dark primary 68 with dark text, containers 92/35). Material's stock dark primary at tone 80 is a pastel that reads washed out next to typical desktop accents.
- **Scope**: only the six built-ins get desktop palettes. `AppTheme.Fixed.desktopColorPalette` defaults to the normal palette, so custom and AI themes are untouched on every platform. `colorScheme(theme)` picks by `currentPlatform`; Android and iOS are unchanged.

`DesktopAccent` keeps `Material`, `Punchy`, `Vibrant` and `VibrantPunchy` presets, and the per-theme accent seeds are named constants, so retuning a theme (Rucksack's yellow is the obvious candidate for a hand-picked amber seed) is a one-line change.

## Testing

- New JVM tests in `common/compose` check that neutral roles stay low-chroma with a cool cast, primaries keep their source hue, surfaces sit at the expected tones, surface tint is not the accent, and WCAG contrast holds (text on primary ≥ 4.5:1, primary on surface ≥ 3:1) for every preset and theme in both modes.
- Off-screen renders of the navigation rail plus cards, buttons, switch, chips and a text field for each preset, light and dark, were compared side by side before settling on `VibrantPunchy`.
- `:app:desktop:compileKotlin` and `:app:android:compileAlphaDebugKotlin` pass; ktlint clean.

`skip-coverage` is on because `AppTheme.kt` is mostly declarations plus a composable that the unit tests do not exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
