### PR TITLE
Make the desktop supporting pane resizable with a drag handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop plays through a built-in audio engine, so VLC no longer needs to be installed
 - Desktop can stream large audiobooks over HLS, with the Streaming method setting now available there
 - Desktop windows between tablet and ultra-wide sizes get a collapsible navigation rail listing every destination, with the account and library switcher in its header and its expanded or collapsed state remembered
+- Desktop detail pane can be resized by dragging the handle on its edge, and the chosen width is remembered
 
 ### Changed
 

--- a/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
+++ b/app/common/src/commonMain/kotlin/app/campfire/common/root/ui/LoggedIn.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastRoundToInt
@@ -167,6 +168,10 @@ internal fun LoggedInWindow(
         settings.observeLibraryItemMarqueeEnabled()
       }.collectAsState()
 
+      val supportingPaneWidth by remember {
+        settings.observeSupportingPaneWidth()
+      }.collectAsState()
+
       CompositionLocalProvider(
         LocalPlaybackSession provides currentSession,
         LocalThemeDispatcher provides themeManagerDispatcher,
@@ -180,6 +185,8 @@ internal fun LoggedInWindow(
             navigator = urlNavigator,
             navigationEventListeners = userComponent.navigationEventListeners,
             deepLink = deepLink,
+            supportingPaneWidth = supportingPaneWidth.takeIf { it > 0f }?.dp,
+            onSupportingPaneWidthChange = { settings.supportingPaneWidth = it.value },
             modifier = modifier,
           )
         }
@@ -195,6 +202,8 @@ private fun LoggedInUi(
   navigator: Navigator,
   navigationEventListeners: ImmutableList<NavigationEventListener>,
   deepLink: DeepLink,
+  supportingPaneWidth: Dp?,
+  onSupportingPaneWidthChange: (Dp) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()
@@ -488,6 +497,8 @@ private fun LoggedInUi(
       }
     },
     showSupportingContent = detailRootScreen !is EmptyScreen,
+    supportingContentWidth = supportingPaneWidth,
+    onSupportingContentWidthChange = onSupportingPaneWidthChange,
     supportingContent = {
       SharedElementTransitionLayout {
         NavigableCircuitContent(

--- a/common/compose/build.gradle.kts
+++ b/common/compose/build.gradle.kts
@@ -64,6 +64,13 @@ kotlin {
       dependsOn(jvmCommon)
     }
 
+    jvmTest {
+      dependencies {
+        implementation(compose.desktop.currentOs)
+        implementation(projects.common.test)
+      }
+    }
+
     androidMain {
       dependsOn(jvmCommon)
 

--- a/common/compose/src/androidMain/kotlin/app/campfire/common/compose/layout/ResizePointerIcon.android.kt
+++ b/common/compose/src/androidMain/kotlin/app/campfire/common/compose/layout/ResizePointerIcon.android.kt
@@ -1,0 +1,8 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.layout
+
+import androidx.compose.ui.input.pointer.PointerIcon
+
+internal actual val horizontalResizePointerIcon: PointerIcon = PointerIcon.Default

--- a/common/compose/src/appleMain/kotlin/app/campfire/common/compose/layout/ResizePointerIcon.apple.kt
+++ b/common/compose/src/appleMain/kotlin/app/campfire/common/compose/layout/ResizePointerIcon.apple.kt
@@ -1,0 +1,8 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.layout
+
+import androidx.compose.ui.input.pointer.PointerIcon
+
+internal actual val horizontalResizePointerIcon: PointerIcon = PointerIcon.Default

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/AdaptiveCampfireLayout.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/AdaptiveCampfireLayout.kt
@@ -3,9 +3,16 @@
 
 package app.campfire.common.compose.layout
 
-import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.DraggableState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -24,14 +31,19 @@ import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.PermanentNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.VerticalDragHandle
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -39,6 +51,8 @@ import androidx.window.core.layout.WindowSizeClass
 import app.campfire.common.compose.LocalWindowSizeClass
 import app.campfire.common.compose.navigation.LocalDrawerState
 import app.campfire.common.compose.navigation.LocalUserSession
+import app.campfire.core.Platform
+import app.campfire.core.currentPlatform
 import app.campfire.core.session.isLoggedIn
 import com.slack.circuit.overlay.ContentWithOverlays
 import com.slack.circuit.overlay.OverlayHost
@@ -51,6 +65,11 @@ import com.slack.circuit.overlay.OverlayHost
  * collapsible wide rail (desktop only), or a permanent drawer. The playback bar is either floated
  * over the content or, when [WindowSizeClass.usesBottomPlaybackBar], docked full-width under
  * everything else.
+ *
+ * On desktop the supporting pane can be resized by dragging the handle on its leading edge.
+ * [supportingContentWidth] is the user's last chosen width (`null` for the size-class default)
+ * and [onSupportingContentWidthChange] is called with the new width once a drag ends; both are
+ * ignored on other platforms, which keep the fixed [SupportingContentWidth].
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,6 +87,8 @@ fun AdaptiveCampfireLayout(
   playbackBarContent: @Composable BoxScope.() -> Unit,
   supportingContent: @Composable () -> Unit,
   showSupportingContent: Boolean,
+  supportingContentWidth: Dp?,
+  onSupportingContentWidthChange: (Dp) -> Unit,
 
   modifier: Modifier = Modifier,
 ) {
@@ -134,22 +155,47 @@ fun AdaptiveCampfireLayout(
             }
           }
 
-          val targetWidth = windowSizeClass.SupportingContentWidth
-          val supportingContentWidth by animateDpAsState(
-            if (supportingContentState == SupportingContentState.Open && isSupportingPaneEnabled) {
-              targetWidth
-            } else {
-              0.dp
-            },
-          )
-
-          Box(
+          BoxWithConstraints(
             modifier = Modifier
               .weight(1f)
               .fillMaxHeight(),
           ) {
+            // Desktop lets the user drag the pane between a fixed minimum and the smaller of a
+            // fixed maximum or a fraction of the content area; everything else keeps the
+            // size-class default. Drags edit a local override that is dropped once the
+            // persisted width catches up.
+            val isSupportingPaneResizable = currentPlatform == Platform.DESKTOP
+            val maxPaneWidth = maxOf(
+              SupportingContentMinWidth,
+              minOf(SupportingContentMaxWidth, maxWidth * SupportingContentMaxWidthFraction),
+            )
+            val basePaneWidth = if (isSupportingPaneResizable) {
+              (supportingContentWidth ?: windowSizeClass.SupportingContentWidth)
+                .coerceIn(SupportingContentMinWidth, maxPaneWidth)
+            } else {
+              windowSizeClass.SupportingContentWidth
+            }
+            var draggedPaneWidth by remember(supportingContentWidth) { mutableStateOf<Dp?>(null) }
+            val paneWidth = draggedPaneWidth ?: basePaneWidth
+
+            val density = LocalDensity.current
+            val resizeState = rememberDraggableState { deltaPx ->
+              // The pane hangs off the trailing edge, so dragging towards the start widens it.
+              val delta = with(density) { deltaPx.toDp() }
+              draggedPaneWidth = (paneWidth - delta).coerceIn(SupportingContentMinWidth, maxPaneWidth)
+            }
+
+            val openFraction by animateFloatAsState(
+              if (supportingContentState == SupportingContentState.Open && isSupportingPaneEnabled) {
+                1f
+              } else {
+                0f
+              },
+            )
+            val visiblePaneWidth = paneWidth * openFraction
+
             Column(
-              modifier = Modifier.padding(end = supportingContentWidth),
+              modifier = Modifier.padding(end = visiblePaneWidth),
             ) {
               CompositionLocalProvider(
                 LocalContentLayout provides ContentLayout.Root,
@@ -184,25 +230,39 @@ fun AdaptiveCampfireLayout(
                   bottomStart = SupportingContentCornerRadius,
                 )
               }
-              Surface(
+              Box(
                 modifier = Modifier
                   .align(Alignment.CenterEnd)
-                  .width(windowSizeClass.SupportingContentWidth)
+                  .width(paneWidth)
+                  .fillMaxHeight()
                   .offset {
-                    IntOffset(
-                      (windowSizeClass.SupportingContentWidth - supportingContentWidth).roundToPx(),
-                      0,
-                    )
+                    IntOffset((paneWidth - visiblePaneWidth).roundToPx(), 0)
                   },
-                shadowElevation = SupportingContentElevation,
-                tonalElevation = 1.dp,
-                shape = supportingContentShape,
               ) {
-                CompositionLocalProvider(
-                  LocalContentLayout provides ContentLayout.Supporting,
-                  LocalSupportingContentState provides supportingContentState,
+                Surface(
+                  modifier = Modifier.fillMaxSize(),
+                  shadowElevation = SupportingContentElevation,
+                  tonalElevation = 1.dp,
+                  shape = supportingContentShape,
                 ) {
-                  supportingContent()
+                  CompositionLocalProvider(
+                    LocalContentLayout provides ContentLayout.Supporting,
+                    LocalSupportingContentState provides supportingContentState,
+                  ) {
+                    supportingContent()
+                  }
+                }
+
+                if (isSupportingPaneResizable) {
+                  SupportingPaneResizeHandle(
+                    state = resizeState,
+                    onDragStopped = {
+                      draggedPaneWidth?.let(onSupportingContentWidthChange)
+                    },
+                    modifier = Modifier
+                      .align(Alignment.CenterStart)
+                      .fillMaxHeight(),
+                  )
                 }
               }
             }
@@ -275,8 +335,49 @@ private fun DrawerWithContent(
   }
 }
 
+/**
+ * The grab area straddling the supporting pane's leading edge. A Material [VerticalDragHandle]
+ * sits in its centre so the affordance is visible; the whole strip is draggable and shows the
+ * horizontal resize cursor.
+ */
+@Composable
+private fun SupportingPaneResizeHandle(
+  state: DraggableState,
+  onDragStopped: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val interactionSource = remember { MutableInteractionSource() }
+  Box(
+    modifier = modifier
+      .width(SupportingPaneResizeHitWidth)
+      .offset(x = -SupportingPaneResizeHitWidth / 2)
+      .hoverable(interactionSource)
+      .pointerHoverIcon(horizontalResizePointerIcon)
+      .draggable(
+        state = state,
+        orientation = Orientation.Horizontal,
+        interactionSource = interactionSource,
+        onDragStopped = { onDragStopped() },
+      ),
+    contentAlignment = Alignment.Center,
+  ) {
+    VerticalDragHandle(interactionSource = interactionSource)
+  }
+}
+
 val SupportingContentElevation = 6.dp
 val SupportingContentCornerRadius = 32.dp
+
+/** Narrowest the desktop supporting pane can be dragged to. */
+val SupportingContentMinWidth = 320.dp
+
+/** Widest the desktop supporting pane can be dragged to, before the window-fraction cap. */
+val SupportingContentMaxWidth = 640.dp
+
+/** The desktop supporting pane never takes more than this share of the content area. */
+const val SupportingContentMaxWidthFraction = 0.5f
+
+private val SupportingPaneResizeHitWidth = 24.dp
 
 val SupportingContentWidthExpanded = 360.dp
 val SupportingContentWidthLarge = 400.dp

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/ResizePointerIcon.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/ResizePointerIcon.kt
@@ -1,0 +1,12 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.layout
+
+import androidx.compose.ui.input.pointer.PointerIcon
+
+/**
+ * The cursor shown while hovering a horizontal resize handle: a left-right arrow on desktop,
+ * the default pointer everywhere else (touch platforms never show one).
+ */
+internal expect val horizontalResizePointerIcon: PointerIcon

--- a/common/compose/src/jvmMain/kotlin/app/campfire/common/compose/layout/ResizePointerIcon.jvm.kt
+++ b/common/compose/src/jvmMain/kotlin/app/campfire/common/compose/layout/ResizePointerIcon.jvm.kt
@@ -1,0 +1,9 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.layout
+
+import androidx.compose.ui.input.pointer.PointerIcon
+import java.awt.Cursor
+
+internal actual val horizontalResizePointerIcon: PointerIcon = PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR))

--- a/common/compose/src/jvmTest/kotlin/app/campfire/common/compose/layout/AdaptiveCampfireLayoutRenderTest.kt
+++ b/common/compose/src/jvmTest/kotlin/app/campfire/common/compose/layout/AdaptiveCampfireLayoutRenderTest.kt
@@ -1,0 +1,192 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.layout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
+import androidx.window.core.layout.WindowSizeClass
+import app.campfire.common.compose.LocalWindowSizeClass
+import app.campfire.common.compose.navigation.LocalUserSession
+import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.common.test.user
+import app.campfire.core.session.UserSession
+import com.slack.circuit.overlay.rememberOverlayHost
+import java.io.File
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+
+/**
+ * Renders [AdaptiveCampfireLayout] off-screen at a desktop Large width with the supporting pane
+ * open, writing PNGs to `build/renders` for eyeballing. The assertions measure the pane from the
+ * pixels: the pane content is painted a flat colour, so the first column of that colour along a
+ * scanline is the pane's leading edge.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class AdaptiveCampfireLayoutRenderTest {
+
+  private val renders = File("build/renders").apply { mkdirs() }
+
+  @Test
+  fun `pane opens at the size-class default when nothing is stored`() {
+    val width = renderAndMeasure("supporting-pane-default", storedWidth = null)
+    assertEquals(SupportingContentWidthLarge, width)
+  }
+
+  @Test
+  fun `stored width is clamped into the allowed range`() {
+    assertEquals(SupportingContentMinWidth, renderAndMeasure("supporting-pane-clamped-min", storedWidth = 100.dp))
+    assertEquals(SupportingContentMaxWidth, renderAndMeasure("supporting-pane-clamped-max", storedWidth = 2000.dp))
+  }
+
+  @Test
+  fun `dragging the handle towards the start widens the pane and commits on release`() {
+    var committed: Dp? = null
+    scene(storedWidth = null, onWidthChange = { committed = it }).use { scene ->
+      scene.settle()
+      val edgeX = (WIDTH - SupportingContentWidthLarge.value) * DENSITY
+      val y = HEIGHT * DENSITY / 2f
+
+      scene.sendPointerEvent(PointerEventType.Move, Offset(edgeX, y))
+      scene.sendPointerEvent(PointerEventType.Press, Offset(edgeX, y), button = PointerButton.Primary)
+      var x = edgeX
+      repeat(5) {
+        x -= 30f * DENSITY
+        scene.sendPointerEvent(PointerEventType.Move, Offset(x, y))
+        scene.render()
+      }
+      val mid = scene.render(nanoTime = 2_000_000_000L)
+      save("supporting-pane-dragging", mid)
+      scene.sendPointerEvent(PointerEventType.Release, Offset(x, y), button = PointerButton.Primary)
+      val after = scene.render(nanoTime = 3_000_000_000L)
+      save("supporting-pane-dragged", after)
+
+      // Drag slop eats a fraction of a pixel, so allow sub-dp drift
+      assertWithinOneDp(SupportingContentWidthLarge + 150.dp, assertNotNull(committed))
+      assertWithinOneDp(SupportingContentWidthLarge + 150.dp, after.measurePaneWidth())
+    }
+  }
+
+  private fun renderAndMeasure(name: String, storedWidth: Dp?): Dp =
+    scene(storedWidth, onWidthChange = {}).use { scene ->
+      scene.settle()
+      val image = scene.render(nanoTime = 2_000_000_000L)
+      save(name, image)
+      image.measurePaneWidth()
+    }
+
+  private fun scene(storedWidth: Dp?, onWidthChange: (Dp) -> Unit) = ImageComposeScene(
+    width = (WIDTH * DENSITY).toInt(),
+    height = (HEIGHT * DENSITY).toInt(),
+    density = Density(DENSITY),
+  ) {
+    Layout(storedWidth, onWidthChange)
+  }
+
+  @Composable
+  private fun Layout(storedWidth: Dp?, onWidthChange: (Dp) -> Unit) {
+    CampfireTheme(useDarkColors = false) {
+      CompositionLocalProvider(
+        LocalWindowSizeClass provides WindowSizeClass(minWidthDp = WIDTH, minHeightDp = HEIGHT),
+        LocalUserSession provides UserSession.LoggedIn(user("user")),
+      ) {
+        AdaptiveCampfireLayout(
+          overlayHost = rememberOverlayHost(),
+          drawerState = rememberDrawerState(DrawerValue.Closed),
+          drawerEnabled = true,
+          drawerContent = {},
+          bottomBarNavigation = {},
+          railNavigation = { Box(Modifier.width(80.dp).fillMaxHeight().background(Color.Gray)) },
+          wideRailNavigation = { Box(Modifier.width(96.dp).fillMaxHeight().background(Color.DarkGray)) },
+          content = {
+            Box(Modifier.fillMaxSize().background(ContentColor)) {
+              Text("Content", color = Color.White)
+            }
+          },
+          playbackBarContent = { Box(Modifier.fillMaxWidth().height(72.dp).background(Color.Black)) },
+          supportingContent = {
+            Box(Modifier.fillMaxSize().background(PaneColor)) {
+              Text("Detail", color = Color.White)
+            }
+          },
+          showSupportingContent = true,
+          supportingContentWidth = storedWidth,
+          onSupportingContentWidthChange = onWidthChange,
+        )
+      }
+    }
+  }
+
+  private fun assertWithinOneDp(expected: Dp, actual: Dp) {
+    assertTrue(abs(expected.value - actual.value) < 1f, "expected $expected within 1dp, was $actual")
+  }
+
+  /** Runs the open animation to completion. */
+  private fun ImageComposeScene.settle() {
+    render()
+    render(nanoTime = 1_000_000_000L)
+  }
+
+  private fun save(name: String, image: Image) {
+    val bytes = image.encodeToData(EncodedImageFormat.PNG)!!.bytes
+    File(renders, "$name.png").writeBytes(bytes)
+    println("rendered ${File(renders, "$name.png").absolutePath}")
+    assertTrue(bytes.size > 1_000)
+  }
+
+  /**
+   * Width of the pane in dp, measured on a scanline a quarter of the way down (clear of the
+   * rounded top corner and the centred drag handle).
+   */
+  private fun Image.measurePaneWidth(): Dp {
+    val bitmap = Bitmap().also {
+      it.allocPixels(imageInfo)
+      assertTrue(readPixels(it))
+    }
+    val y = height / 4
+    val paneStart = (0 until width).first { x -> bitmap.getColor(x, y).isPane() }
+    return ((width - paneStart) / DENSITY).dp
+  }
+
+  private fun Int.isPane(): Boolean {
+    val r = (this shr 16) and 0xff
+    val g = (this shr 8) and 0xff
+    val b = this and 0xff
+    return abs(r - 0xC0) < 8 && abs(g - 0x30) < 8 && abs(b - 0x60) < 8
+  }
+
+  private companion object {
+    const val WIDTH = 1400
+    const val HEIGHT = 900
+    const val DENSITY = 2f
+    val ContentColor = Color(0xFF3060C0)
+    val PaneColor = Color(0xFFC03060)
+  }
+}

--- a/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/CampfireSettings.kt
+++ b/features/settings/api/src/commonMain/kotlin/app/campfire/settings/api/CampfireSettings.kt
@@ -78,6 +78,13 @@ interface CampfireSettings {
   var wideNavigationRailExpanded: Boolean
   fun observeWideNavigationRailExpanded(): StateFlow<Boolean>
 
+  /**
+   * Width in dp the user dragged the desktop supporting (detail) pane to, or `0` when it has
+   * never been resized and the layout's size-class default applies.
+   */
+  var supportingPaneWidth: Float
+  fun observeSupportingPaneWidth(): StateFlow<Float>
+
   var lastSeenVersion: String?
   fun observeLastSeenVersion(): StateFlow<String?>
 

--- a/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/CampfireSettingsImpl.kt
+++ b/features/settings/impl/src/commonMain/kotlin/app/campfire/settings/CampfireSettingsImpl.kt
@@ -124,6 +124,10 @@ class CampfireSettingsImpl(
   override var wideNavigationRailExpanded: Boolean by wideNavigationRailExpandedProperty
   override fun observeWideNavigationRailExpanded(): StateFlow<Boolean> = wideNavigationRailExpandedProperty.observe()
 
+  private val supportingPaneWidthProperty = floatSetting(KEY_SUPPORTING_PANE_WIDTH, 0f)
+  override var supportingPaneWidth: Float by supportingPaneWidthProperty
+  override fun observeSupportingPaneWidth(): StateFlow<Float> = supportingPaneWidthProperty.observe()
+
   private val lastSeenVersionProperty = stringOrNullSetting(KEY_LAST_SEEN_WHATS_NEW)
   override var lastSeenVersion: String? by lastSeenVersionProperty
   override fun observeLastSeenVersion(): StateFlow<String?> = lastSeenVersionProperty.observe()
@@ -165,6 +169,7 @@ internal const val KEY_SHOW_CONFIRM_DOWNLOAD = "pref_show_confirm_download"
 internal const val KEY_SHOW_WIDGET_PINNING = "pref_show_widget_pinning"
 internal const val KEY_SHOW_TIME_IN_BOOK = "pref_show_time_in_book"
 internal const val KEY_WIDE_NAVIGATION_RAIL_EXPANDED = "pref_wide_navigation_rail_expanded"
+internal const val KEY_SUPPORTING_PANE_WIDTH = "pref_supporting_pane_width"
 internal const val KEY_LAST_SEEN_WHATS_NEW = "pref_last_seen_whats_new"
 internal const val KEY_SOCKET_ENABLED = "pref_socket_enabled"
 internal const val KEY_APP_UPDATE_SIGN_IN_DISMISSED = "pref_app_update_sign_in_dismissed"

--- a/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/TestCampfireSettings.kt
+++ b/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/TestCampfireSettings.kt
@@ -130,6 +130,11 @@ class TestCampfireSettings(
     observeBoolean(::wideNavigationRailExpanded)
       .stateIn(testScope, SharingStarted.Lazily, wideNavigationRailExpanded)
 
+  override var supportingPaneWidth: Float by float()
+  override fun observeSupportingPaneWidth(): StateFlow<Float> =
+    observeFloat(::supportingPaneWidth)
+      .stateIn(testScope, SharingStarted.Lazily, supportingPaneWidth)
+
   override var lastSeenVersion: String? by stringOrNull()
   override fun observeLastSeenVersion(): StateFlow<String?> =
     observeStringOrNull(::lastSeenVersion)

--- a/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/TestSettings.kt
+++ b/features/settings/test/src/commonMain/kotlin/app/campfire/settings/test/TestSettings.kt
@@ -7,6 +7,7 @@ import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.coroutines.getBooleanFlow
+import com.russhwolf.settings.coroutines.getFloatFlow
 import com.russhwolf.settings.coroutines.getIntFlow
 import com.russhwolf.settings.coroutines.getLongFlow
 import com.russhwolf.settings.coroutines.getStringFlow
@@ -72,6 +73,15 @@ abstract class TestSettings {
 
   protected fun observeLong(property: KProperty<*>): Flow<Long> {
     return settings.getLongFlow(property.name, 0L)
+  }
+
+  protected fun float() = property(
+    getter = { getFloatOrNull(it) ?: 0f },
+    setter = { key, value -> putFloat(key, value) },
+  )
+
+  protected fun observeFloat(property: KProperty<*>): Flow<Float> {
+    return settings.getFloatFlow(property.name, 0f)
   }
 
   protected inline fun <reified E : Enum<E>> enum() = property(


### PR DESCRIPTION
## Summary

- On desktop, the supporting (detail) pane's leading edge carries a Material `VerticalDragHandle`. Dragging it resizes the pane, with the horizontal resize cursor on hover.
- Width is clamped between 320dp and the smaller of 640dp or half the content area. The existing size-class default (360–400dp) sits inside that range and still applies until the user resizes.
- The chosen width is persisted in `CampfireSettings` (`supportingPaneWidth`, 0 = never resized) and clamped on read. Mobile and tablet keep the fixed width with no handle.
- Open/close now animates a 0..1 fraction of the pane width rather than the width itself, so live drag updates aren't smoothed by the animation.

## Test plan

- [x] `:common:compose`, `:app:desktop`, `:features:settings:impl` compile for desktop, Android and iOS simulator
- [x] New `AdaptiveCampfireLayoutRenderTest` (jvmTest) renders the layout off-screen at a 1400dp desktop width and asserts the default width, both clamp bounds, and that a synthetic pointer drag widens the pane and commits the new width
- [ ] Manual: on desktop, drag the handle on the detail pane's edge, restart the app, confirm the width is remembered

What the render test PNGs (`common/compose/build/renders`) show:

| default | dragging | dragged |
|---|---|---|
| pane at 400dp, subtle handle centred on the edge | handle thickens and darkens, pane follows the pointer | pane at 550dp, handle back to resting state |

