### PR TITLE
Pin top app bars on desktop instead of collapsing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop playback of streamed audiobooks failing because track requests were not authenticated
 - Desktop app crashing on launch, and again on every launch after the first
 - Item detail showing a stray download button while the item is playing or already downloading, and a mismatched play button shape while a download is in progress
+- Desktop page headers scrolling out of view and stranding halfway, taking the back button and page actions with them
 
 ### Other Notes & Contributions
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/AdaptiveTopAppBarScrollBehavior.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/AdaptiveTopAppBarScrollBehavior.kt
@@ -1,0 +1,31 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.widgets
+
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import app.campfire.core.forPlatform
+
+/**
+ * [TopAppBarDefaults.enterAlwaysScrollBehavior] on touch platforms, pinned on desktop.
+ *
+ * A mouse wheel produces no fling, so a collapsing bar settles wherever the last notch left it —
+ * usually half off-screen, taking the navigation and action icons with it.
+ */
+@Composable
+fun adaptiveEnterAlwaysScrollBehavior(): TopAppBarScrollBehavior = forPlatform(
+  mobile = { TopAppBarDefaults.enterAlwaysScrollBehavior() },
+  desktop = { TopAppBarDefaults.pinnedScrollBehavior() },
+)
+
+/**
+ * [TopAppBarDefaults.exitUntilCollapsedScrollBehavior] on touch platforms, pinned on desktop.
+ * @see adaptiveEnterAlwaysScrollBehavior
+ */
+@Composable
+fun adaptiveExitUntilCollapsedScrollBehavior(): TopAppBarScrollBehavior = forPlatform(
+  mobile = { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() },
+  desktop = { TopAppBarDefaults.pinnedScrollBehavior() },
+)

--- a/core/src/commonMain/kotlin/app/campfire/core/Platform.kt
+++ b/core/src/commonMain/kotlin/app/campfire/core/Platform.kt
@@ -10,3 +10,24 @@ enum class Platform {
 }
 
 expect val currentPlatform: Platform
+
+inline fun <T> forPlatform(
+  android: () -> T,
+  ios: () -> T,
+  desktop: () -> T,
+): T = when (currentPlatform) {
+  Platform.ANDROID -> android()
+  Platform.IOS -> ios()
+  Platform.DESKTOP -> desktop()
+}
+
+inline fun <T> forPlatform(
+  mobile: () -> T,
+  desktop: () -> T,
+): T = when (currentPlatform) {
+  Platform.ANDROID,
+  Platform.IOS,
+  -> mobile()
+
+  Platform.DESKTOP -> desktop()
+}

--- a/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailUi.kt
+++ b/features/author/ui/src/commonMain/kotlin/app/campfire/author/ui/detail/AuthorDetailUi.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,6 +37,7 @@ import app.campfire.common.compose.widgets.ErrorListState
 import app.campfire.common.compose.widgets.LibraryItemCard
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.NavigationBackButton
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.common.screens.AuthorDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -61,7 +61,7 @@ fun AuthorDetail(
   state: AuthorDetailUiState,
   modifier: Modifier = Modifier,
 ) = SharedElementTransitionScope {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
   Scaffold(
     topBar = {
       CampfireTopAppBar(

--- a/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUi.kt
+++ b/features/collections/ui/src/commonMain/kotlin/app/campfire/collections/ui/list/CollectionsUi.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -33,6 +32,7 @@ import app.campfire.common.compose.widgets.ItemCollectionCard
 import app.campfire.common.compose.widgets.ItemCollectionGridCard
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.NavigationBackButton
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.common.screens.CollectionsScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -54,7 +54,7 @@ fun Collections(
   state: CollectionsUiState,
   modifier: Modifier = Modifier,
 ) {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
   val gridState = rememberLazyGridState()
 
   Scaffold(

--- a/features/discover/ui/src/commonMain/kotlin/app/campfire/discover/ui/UpcomingUi.kt
+++ b/features/discover/ui/src/commonMain/kotlin/app/campfire/discover/ui/UpcomingUi.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.derivedStateOf
@@ -58,6 +57,7 @@ import app.campfire.common.compose.util.withDensity
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.NavigationBackButton
+import app.campfire.common.compose.widgets.adaptiveExitUntilCollapsedScrollBehavior
 import app.campfire.core.di.UserScope
 import app.campfire.discover.api.DiscoverScanState
 import app.campfire.discover.api.screen.UpcomingScreen
@@ -83,7 +83,7 @@ fun UpcomingUi(
   state: UpcomingUiState,
   modifier: Modifier = Modifier,
 ) {
-  val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+  val scrollBehavior = adaptiveExitUntilCollapsedScrollBehavior()
   val listState = rememberLazyListState()
   Scaffold(
     topBar = {

--- a/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
+++ b/features/libraries/ui/src/commonMain/kotlin/app/campfire/libraries/ui/detail/LibraryItemUi.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -71,6 +70,7 @@ import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LibraryItemSharedTransitionKey
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.NavigationBackButton
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.core.model.LibraryId
@@ -142,7 +142,7 @@ fun LibraryItemContent(
   addToCollectionDialog: AddToCollectionDialog,
   modifier: Modifier,
 ) = SharedElementTransitionScope {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
 
   var showAddToCollectionDialog by remember { mutableStateOf(false) }
   var showOverflowMenu by remember { mutableStateOf(false) }

--- a/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUi.kt
+++ b/features/playlists/ui/src/commonMain/kotlin/app/campfire/playlists/ui/detail/PlaylistDetailUi.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -55,6 +54,7 @@ import app.campfire.common.compose.widgets.ErrorListState
 import app.campfire.common.compose.widgets.ItemCollectionSharedTransitionKey
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.NavigationBackButton
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.common.compose.widgets.dialog.ConfirmDownloadDialog
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -91,7 +91,7 @@ fun PlaylistDetail(
   modifier: Modifier = Modifier,
 ) = SharedElementTransitionScope {
   val scope = rememberCoroutineScope()
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
 
   var showDeleteConfirmation by remember { mutableStateOf(false) }
   if (showDeleteConfirmation) {

--- a/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/add/AddPodcastUi.kt
+++ b/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/add/AddPodcastUi.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.CampfireWindowInsets
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.core.di.UserScope
 import app.campfire.podcasts.api.screen.AddPodcastScreen
 import app.campfire.podcasts.ui.add.composables.AddPodcastCenteredMessage
@@ -57,7 +58,7 @@ fun AddPodcastUi(
   state: AddPodcastUiState,
   modifier: Modifier = Modifier,
 ) {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
   val focusManager = LocalFocusManager.current
   val listState = rememberLazyListState()
   val isListDragging by listState.interactionSource.collectIsDraggedAsState()

--- a/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/builder/AddPodcastBuilderUi.kt
+++ b/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/builder/AddPodcastBuilderUi.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -25,6 +24,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.campfire.common.compose.widgets.CampfireTopAppBar
 import app.campfire.common.compose.widgets.NavigationBackButton
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.core.di.UserScope
 import app.campfire.podcasts.api.screen.AddPodcastBuilderScreen
 import app.campfire.podcasts.ui.AddPodcastSharedTransitionKey
@@ -53,7 +53,7 @@ fun AddPodcastBuilderUi(
   state: AddPodcastBuilderUiState,
   modifier: Modifier = Modifier,
 ) = SharedElementTransitionScope {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
   val listState = rememberLazyListState()
 
   Scaffold(

--- a/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/find/FindEpisodesUi.kt
+++ b/features/podcasts/ui/src/commonMain/kotlin/app/campfire/podcasts/ui/find/FindEpisodesUi.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.core.di.UserScope
 import app.campfire.podcasts.api.screen.FindEpisodesScreen
 import app.campfire.podcasts.ui.find.composables.CenteredMessage
@@ -58,7 +59,7 @@ fun FindEpisodesUi(
   state: FindEpisodesUiState,
   modifier: Modifier = Modifier,
 ) {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
   val focusManager = LocalFocusManager.current
   val listState = rememberLazyListState()
   val isListDragging by listState.interactionSource.collectIsDraggedAsState()

--- a/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUi.kt
+++ b/features/series/ui/src/commonMain/kotlin/app/campfire/series/ui/detail/SeriesDetailUi.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,6 +38,7 @@ import app.campfire.common.compose.widgets.LibraryItemCard
 import app.campfire.common.compose.widgets.LoadingListState
 import app.campfire.common.compose.widgets.MaxBookDisplay
 import app.campfire.common.compose.widgets.NavigationBackButton
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.common.screens.SeriesDetailScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -61,7 +61,7 @@ fun SeriesDetail(
   state: SeriesDetailUiState,
   modifier: Modifier = Modifier,
 ) = SharedElementTransitionScope {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
   Scaffold(
     topBar = {
       CampfireTopAppBar(

--- a/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
+++ b/features/stats/ui/src/commonMain/kotlin/app/campfire/stats/ui/StatsUi.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -52,6 +51,7 @@ import app.campfire.common.compose.widgets.EmptyState
 import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LoadingState
 import app.campfire.common.compose.widgets.NavigationBackButton
+import app.campfire.common.compose.widgets.adaptiveExitUntilCollapsedScrollBehavior
 import app.campfire.common.screens.StatisticsScreen
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
@@ -110,7 +110,7 @@ fun StatsUi(
 
   var isUserStats by rememberSaveable { mutableStateOf(true) }
 
-  val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+  val scrollBehavior = adaptiveExitUntilCollapsedScrollBehavior()
   Scaffold(
     topBar = {
       if (!isTwoPaneLayout) {

--- a/infra/whats-new/ui/src/commonMain/kotlin/app/campfire/whatsnew/ui/changelog/ChangelogUi.kt
+++ b/infra/whats-new/ui/src/commonMain/kotlin/app/campfire/whatsnew/ui/changelog/ChangelogUi.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -40,6 +39,7 @@ import app.campfire.common.compose.widgets.CampfireLargeTopAppBar
 import app.campfire.common.compose.widgets.ErrorListState
 import app.campfire.common.compose.widgets.IconButtonTooltip
 import app.campfire.common.compose.widgets.LoadingState
+import app.campfire.common.compose.widgets.adaptiveEnterAlwaysScrollBehavior
 import app.campfire.core.coroutines.LoadState
 import app.campfire.core.di.UserScope
 import app.campfire.whatsnew.api.screen.ChangelogScreen
@@ -60,7 +60,7 @@ fun Changelog(
   state: ChangelogUiState,
   modifier: Modifier = Modifier,
 ) {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+  val scrollBehavior = adaptiveEnterAlwaysScrollBehavior()
   Scaffold(
     topBar = {
       CampfireLargeTopAppBar(

--- a/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/rail/CampfireWideNavigationRail.kt
+++ b/ui/navigation/ui/src/commonMain/kotlin/app/campfire/ui/navigation/rail/CampfireWideNavigationRail.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -22,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import app.campfire.common.compose.LocalWindowChromeInsets
 import app.campfire.common.compose.di.rememberComponent
 import app.campfire.ui.navigation.HomeNavigationItemIcon
 import app.campfire.ui.navigation.NavigationComponent
@@ -110,6 +112,7 @@ fun CampfireWideNavigationRailContent(
         headerScope.accountContent()
       }
     },
+    contentPadding = LocalWindowChromeInsets.current.asPaddingValues(),
   ) {
     // The rail neither scrolls nor wraps, so a long destination list scrolls inside one child
     Column(


### PR DESCRIPTION
A mouse wheel produces no fling, so a collapsing top app bar settles wherever the last scroll notch left it — usually half off-screen. With `enterAlwaysScrollBehavior` on a small bar, that takes the back button and every action icon with it. `LibraryItemUi` is the worst case: its bar has `title = {}`, so it's nothing *but* navigation and actions.

### What changed

- `forPlatform` in `:core` — an `android`/`ios`/`desktop` and a `mobile`/`desktop` branch over `currentPlatform`.
- `adaptiveEnterAlwaysScrollBehavior()` / `adaptiveExitUntilCollapsedScrollBehavior()` in `:common:compose`, which pin on desktop and keep the existing behavior on touch platforms.
- Eleven collapsing bars routed through them: library item, series detail, author detail, playlist detail, collections list, the three podcast add/find flows, changelog, upcoming, and stats.

Screens built desktop-first — settings panes, attribution, theme picker/builder, collection detail — were already using `pinnedScrollBehavior`, so this just brings the rest in line rather than introducing a new convention.

### What was deliberately left alone

The `SearchBarDefaults.enterAlwaysSearchBarScrollBehavior()` screens (home, library, series/authors/playlists lists, latest episodes, download queue). They behave well on desktop already, and their scroll offset drives the navigation bar/rail hide animation via `AttachScrollBehaviorToLocalNavigationBar` — pinning them would freeze that coupling too.

### Known trade-offs

- The check is on platform, not window size, so a desktop window narrowed to compact still gets pinned bars. That's intentional: the missing fling is a property of the input device, not the width. It does diverge from `WindowSizeClass.kt:62`, which defines desktop-ness as platform *and* expanded width.
- `ChangelogUi` uses `CampfireLargeTopAppBar`, so on desktop it's now a permanently tall header. Accepted for now; `adaptiveExitUntilCollapsedScrollBehavior()` is the escape hatch if it reads as too heavy.

### Also included

The wide navigation rail now pads its content by `LocalWindowChromeInsets` so the header clears the macOS traffic lights. It's a refinement of the still-unreleased rail from #1074, so it rides that feature's existing changelog entry rather than adding its own.

### Testing

`:app:desktop:compileKotlin` and `./scripts/ktlint --check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
