### PR TITLE
Stop cover requests churning when their slot resizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop app crashing on launch, and again on every launch after the first
 - Item detail showing a stray download button while the item is playing or already downloading, and a mismatched play button shape while a download is in progress
 - Desktop page headers scrolling out of view and stranding halfway, taking the back button and page actions with them
+- Cover art on the playing screen flickering and reloading while dragging the player up or down
+- Book covers flashing a loading spinner when opening an item from home, a library, or a series
 
 ### Other Notes & Contributions
 

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/CoverImage.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/CoverImage.kt
@@ -100,13 +100,17 @@ fun CoverImage(
         .clip(shape),
     )
 
+    // Coil seeds a request with any smaller rendition already in memory, which [Image] above is
+    // already drawing — covering that with a spinner is what made arriving on an item detail through
+    // a shared-element transition look so abrupt. Only fall back to the loading treatment when there
+    // is genuinely nothing on screen yet.
     val painterState by painter.state.collectAsState()
-    when (painterState) {
-      is AsyncImagePainter.State.Loading -> LoadingCover(
+    val loadingState = painterState as? AsyncImagePainter.State.Loading
+    if (loadingState != null && loadingState.painter == null) {
+      LoadingCover(
         shape = shape,
         size = size,
       )
-      else -> Unit
     }
   }
 }

--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/ImageRequests.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/widgets/ImageRequests.kt
@@ -7,9 +7,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.isFinite
 import androidx.compose.ui.unit.isSpecified
+import app.campfire.core.image.CoverUrls
+import coil3.SingletonImageLoader
 import coil3.compose.DrawScopeSizeResolver
 import coil3.compose.LocalPlatformContext
+import coil3.memory.MemoryCache
 import coil3.request.ImageRequest
 import coil3.size.Size
 
@@ -24,17 +28,57 @@ import coil3.size.Size
  * Prefer passing [size] for images that take part in a shared element transition: the draw-bounds
  * resolver latches onto the *first* draw, which during a transition is the origin element's size,
  * so a full-screen cover would otherwise be fetched and decoded at thumbnail size.
+ *
+ * A known [size] is rounded up to the [CoverUrls.WIDTH_BUCKETS] rendition the server would hand back
+ * for it. `CoverSizingInterceptor` puts that width in the URL and the URL *is* the memory cache key,
+ * so bucketing keeps both the request and its cache entry still while a slot resizes by a few pixels
+ * (a drag, a window resize, a `weight`/`aspectRatio` reflow) instead of decoding it over and over.
  */
 @Composable
 fun rememberDrawSizedRequest(model: Any?, size: Dp = Dp.Unspecified): ImageRequest {
   val context = LocalPlatformContext.current
-  val sizePx = if (size.isSpecified) with(LocalDensity.current) { size.roundToPx() } else null
+  val memoryCache = SingletonImageLoader.get(context).memoryCache
+  val sizePx = if (size.isSpecified && size.isFinite) {
+    with(LocalDensity.current) { size.roundToPx() }
+      .takeIf { it > 0 }
+      ?.let(CoverUrls::bucketWidth)
+  } else {
+    null
+  }
   return remember(context, model, sizePx) {
     ImageRequest.Builder(context)
       .data(model)
       .apply {
-        if (sizePx != null && sizePx > 0) size(Size(sizePx, sizePx)) else size(DrawScopeSizeResolver())
+        if (sizePx != null && sizePx > 0) {
+          size(Size(sizePx, sizePx))
+          memoryCache?.smallerCachedRendition(model, sizePx)?.let(::placeholderMemoryCacheKey)
+        } else {
+          size(DrawScopeSizeResolver())
+        }
       }
       .build()
   }
+}
+
+/**
+ * The key of the largest already-resident rendition of [model] narrower than [widthPx], if any.
+ *
+ * Handed to a request as its `placeholderMemoryCacheKey`, this is what keeps a shared-element
+ * transition from flying a spinner into place: opening an item detail asks for a wider rendition than
+ * the card that launched it, which is a different URL and so a cold cache entry. Seeding the request
+ * with the rendition the card already loaded means the cover is on screen for the whole transition
+ * and only sharpens once the larger one arrives.
+ *
+ * Only Audiobookshelf cover/author URLs have sibling renditions to find — everything else is served
+ * at one size under one key.
+ */
+internal fun MemoryCache.smallerCachedRendition(model: Any?, widthPx: Int): MemoryCache.Key? {
+  val url = model as? String ?: return null
+  if (!CoverUrls.isServerImageUrl(url)) return null
+  return CoverUrls.WIDTH_BUCKETS
+    .asReversed()
+    .asSequence()
+    .filter { it < widthPx }
+    .map { MemoryCache.Key(CoverUrls.sized(url, it)) }
+    .firstOrNull { this[it] != null }
 }

--- a/common/compose/src/commonTest/kotlin/app/campfire/common/compose/widgets/ImageRequestsTest.kt
+++ b/common/compose/src/commonTest/kotlin/app/campfire/common/compose/widgets/ImageRequestsTest.kt
@@ -1,0 +1,86 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.widgets
+
+import app.campfire.core.image.CoverUrls
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import coil3.Canvas
+import coil3.Image
+import coil3.memory.MemoryCache
+import kotlin.test.Test
+
+class ImageRequestsTest {
+
+  private val cover = "https://abs.example.com/api/items/li_1/cover?ts=5"
+
+  @Test
+  fun finds_the_rendition_a_smaller_slot_already_cached() {
+    val cache = cacheOf(800)
+    assertThat(cache.smallerCachedRendition(cover, 1200))
+      .isEqualTo(MemoryCache.Key("$cover&width=800"))
+  }
+
+  /**
+   * The whole mechanism is a silent no-op if this key drifts from the URL `CoverSizingInterceptor`
+   * actually stores under, so pin the literal both sides have to agree on.
+   */
+  @Test
+  fun keys_by_the_url_the_sizing_interceptor_writes() {
+    assertThat(CoverUrls.sized(cover, 768)).isEqualTo("$cover&width=800")
+  }
+
+  @Test
+  fun prefers_the_largest_cached_rendition_below_the_request() {
+    val cache = cacheOf(200, 600)
+    assertThat(cache.smallerCachedRendition(cover, 1200))
+      .isEqualTo(MemoryCache.Key("$cover&width=600"))
+  }
+
+  @Test
+  fun ignores_renditions_at_or_above_the_requested_width() {
+    val cache = cacheOf(800, 1200)
+    assertThat(cache.smallerCachedRendition(cover, 800)).isNull()
+  }
+
+  @Test
+  fun returns_null_when_no_rendition_is_cached() {
+    assertThat(cacheOf().smallerCachedRendition(cover, 1200)).isNull()
+  }
+
+  @Test
+  fun leaves_urls_the_server_does_not_resize_alone() {
+    val external = "https://cdn.example.com/art.png"
+    val cache = MemoryCache.Builder().maxSizeBytes(MaxSize).build().apply {
+      this[MemoryCache.Key(external)] = MemoryCache.Value(NoopImage)
+    }
+    assertThat(cache.smallerCachedRendition(external, 1200)).isNull()
+  }
+
+  @Test
+  fun ignores_data_that_is_not_a_url() {
+    assertThat(cacheOf(800).smallerCachedRendition(42, 1200)).isNull()
+  }
+
+  private fun cacheOf(vararg widths: Int): MemoryCache {
+    return MemoryCache.Builder().maxSizeBytes(MaxSize).build().apply {
+      for (width in widths) {
+        this[MemoryCache.Key(CoverUrls.sized(cover, width))] = MemoryCache.Value(NoopImage)
+      }
+    }
+  }
+
+  private object NoopImage : Image {
+    override val size: Long = 0
+    override val width: Int = 1
+    override val height: Int = 1
+    override val shareable: Boolean = true
+    override fun draw(canvas: Canvas) = Unit
+  }
+
+  private companion object {
+    const val MaxSize = 1024L * 1024L
+  }
+}

--- a/common/compose/src/jvmTest/kotlin/app/campfire/common/compose/widgets/CoverImagePlaceholderRenderTest.kt
+++ b/common/compose/src/jvmTest/kotlin/app/campfire/common/compose/widgets/CoverImagePlaceholderRenderTest.kt
@@ -1,0 +1,158 @@
+// Copyright 2026, Drew Heavner and the Campfire project contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+package app.campfire.common.compose.widgets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
+import app.campfire.common.compose.theme.CampfireTheme
+import app.campfire.core.image.CoverUrls
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.intercept.Interceptor
+import coil3.memory.MemoryCache
+import coil3.request.ImageResult
+import java.io.File
+import kotlin.math.abs
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+
+/**
+ * Renders [CoverImage] mid-request — the frame an item detail shows while the shared-element
+ * transition is still running — with the network stalled so the larger rendition never arrives.
+ *
+ * With the rendition a grid card already loaded sitting in the memory cache, the cover has to be on
+ * screen for that whole frame; with a cold cache it falls back to the loading treatment. PNGs land in
+ * `build/renders` for eyeballing.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class CoverImagePlaceholderRenderTest {
+
+  private val renders = File("build/renders").apply { mkdirs() }
+
+  @AfterTest
+  fun tearDown() {
+    SingletonImageLoader.reset()
+  }
+
+  @Test
+  fun `the rendition a card already loaded carries the cover while a larger one is fetched`() {
+    install(cachedRenditionWidth = 400)
+    val center = render("cover-warm").centerColor()
+    assertTrue(center.isCachedCover(), "expected the cached rendition, was ${center.toHexString()}")
+  }
+
+  @Test
+  fun `a cold cache still falls back to the loading cover`() {
+    install(cachedRenditionWidth = null)
+    val center = render("cover-cold").centerColor()
+    assertTrue(!center.isCachedCover(), "expected the loading cover, was ${center.toHexString()}")
+  }
+
+  /**
+   * An [ImageLoader] whose requests never resolve, so the painter stays in its loading state and the
+   * render captures the placeholder rather than the finished image.
+   */
+  private fun install(cachedRenditionWidth: Int?) {
+    val memoryCache = MemoryCache.Builder().maxSizeBytes(MaxCacheBytes).build()
+    if (cachedRenditionWidth != null) {
+      memoryCache[MemoryCache.Key(CoverUrls.sized(Cover, cachedRenditionWidth))] =
+        MemoryCache.Value(ColorImage(CachedCoverArgb, width = 400, height = 400))
+    }
+    SingletonImageLoader.reset()
+    SingletonImageLoader.setUnsafe(
+      ImageLoader.Builder(PlatformContext.INSTANCE)
+        .memoryCache { memoryCache }
+        .components { add(StalledInterceptor) }
+        .build(),
+    )
+  }
+
+  private fun render(name: String): Image = scene().use { scene ->
+    // Two frames: the first starts the request (and picks up the placeholder), the second draws it.
+    scene.render()
+    scene.render(nanoTime = FrameNanos).also { save(name, it) }
+  }
+
+  private fun scene() = ImageComposeScene(
+    width = (Width * SceneDensity).toInt(),
+    height = (Height * SceneDensity).toInt(),
+    density = Density(SceneDensity),
+    coroutineContext = Dispatchers.Unconfined,
+  ) {
+    Content()
+  }
+
+  @Composable
+  private fun Content() {
+    CampfireTheme(useDarkColors = false) {
+      Box(
+        modifier = Modifier.fillMaxSize().background(Color.White),
+        contentAlignment = Alignment.Center,
+      ) {
+        CoverImage(
+          imageUrl = Cover,
+          contentDescription = null,
+          size = 300.dp,
+        )
+      }
+    }
+  }
+
+  private fun save(name: String, image: Image) {
+    val bytes = image.encodeToData(EncodedImageFormat.PNG)!!.bytes
+    val file = File(renders, "$name.png")
+    file.writeBytes(bytes)
+    println("rendered ${file.absolutePath}")
+    assertTrue(bytes.size > 1_000)
+  }
+
+  private fun Image.centerColor(): Int {
+    val bitmap = Bitmap().also {
+      it.allocPixels(imageInfo)
+      assertTrue(readPixels(it))
+    }
+    return bitmap.getColor(width / 2, height / 2)
+  }
+
+  private fun Int.isCachedCover(): Boolean {
+    val r = (this shr 16) and 0xff
+    val g = (this shr 8) and 0xff
+    val b = this and 0xff
+    return abs(r - 0xE0) < 8 && abs(g - 0x7A) < 8 && abs(b - 0x3F) < 8
+  }
+
+  private fun Int.toHexString(): String = "#${(this and 0xFFFFFF).toString(16).padStart(6, '0')}"
+
+  private object StalledInterceptor : Interceptor {
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult = awaitCancellation()
+  }
+
+  private companion object {
+    const val Cover = "https://abs.example.com/api/items/li_1/cover?ts=5"
+    const val Width = 400
+    const val Height = 400
+    const val SceneDensity = 2f
+    const val FrameNanos = 1_000_000_000L
+    const val MaxCacheBytes = 8L * 1024L * 1024L
+    const val CachedCoverArgb = 0xFFE07A3F.toInt()
+  }
+}

--- a/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ExpandedItemImage.kt
+++ b/features/sessions/ui/src/commonMain/kotlin/app/campfire/sessions/ui/playback/expanded/composables/ExpandedItemImage.kt
@@ -17,12 +17,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isFinite
 import app.campfire.audioplayer.model.Metadata
 import app.campfire.audioplayer.model.RunningTimer
 import app.campfire.common.compose.icons.CampfireIcons
@@ -53,7 +55,13 @@ internal fun SharedTransitionScope.ExpandedItemImage(
     // The cover fills a weight/aspectRatio slot, so its layout size is Dp.Unspecified. Request the
     // rendition at the measured slot width instead, otherwise the shared-element transition latches
     // the draw-bounds resolver onto the tiny mini-bar bounds and the full-screen cover renders blurry.
-    val coverRequestSize = if (size != Dp.Unspecified) size else maxWidth
+    //
+    // Dragging the expanded sheet insets it a little more on every frame, which re-measures this slot
+    // continuously; feeding that straight into the request would rebuild it — and the cache key derived
+    // from it — dozens of times per gesture. Latch the widest slot seen so the view sticks to a single
+    // rendition for its lifetime.
+    val widthLatch = remember { SlotWidthLatch() }
+    val coverRequestSize = if (size != Dp.Unspecified) size else widthLatch.widen(maxWidth)
     CoverImage(
       imageUrl = mediaUrl,
       contentDescription = session?.libraryItem?.media?.metadata?.title,
@@ -102,5 +110,23 @@ internal fun SharedTransitionScope.ExpandedItemImage(
         }
       }
     }
+  }
+}
+
+/**
+ * Remembers the widest slot a cover has been measured into.
+ *
+ * Deliberately not snapshot state: [BoxWithConstraints] already re-runs its content whenever the
+ * measured width changes, so a wider slot is picked up by that same pass without an invalidation —
+ * and without the backwards-write recomposition loop a [androidx.compose.runtime.MutableState] would
+ * cause here. Widths only ever grow, so shrinking the slot (a drag, a window resize) reuses the
+ * rendition already in memory instead of fetching a smaller one.
+ */
+private class SlotWidthLatch {
+  private var width: Dp = 0.dp
+
+  fun widen(candidate: Dp): Dp {
+    if (candidate.isFinite && candidate > width) width = candidate
+    return width
   }
 }


### PR DESCRIPTION
Two regressions from requesting right-sized cover renditions (#957), both caused by the request size moving after the view is already on screen.

### Covers reloading while dragging the playback bar

The expanded bar's drag gesture applies a growing inset to the `Surface`, so the cover — which sits in a `weight(1f).aspectRatio(1f)` slot — is re-measured on every frame of the gesture. `rememberDrawSizedRequest` handed back a fresh `ImageRequest` each time, restarting `rememberAsyncImagePainter` and re-running the crossfade.

`ExpandedItemImage` now latches the widest slot width it has been measured into, so the view sticks to one rendition for its lifetime. The latch is deliberately not snapshot state: `BoxWithConstraints` already re-runs its content when the measurement changes, so a wider slot is picked up in that same pass without a backwards write.

### A spinner flying into place on item detail

The two ends of the shared-element transition ask for different renditions — the card takes `CoverImageSize` (256.dp), the detail `minWidth * 0.75f`. `CoverSizingInterceptor` puts the bucket width in the URL and the URL *is* the memory cache key (`UriKeyer`, no size extras absent transformations), so those are unrelated entries. A transition draws the *target's* content, so the card's loaded bitmap was dropped the moment navigation started and the detail arrived cold.

Requests now seed themselves with the largest rendition of the same cover already in memory, via `placeholderMemoryCacheKey`. Coil resolves that before size resolution and the interceptor chain, so it is the placeholder from the first frame. `CoverImage` had to change with it — it drew `LoadingCover` on *any* loading state, which would have painted straight over the placeholder; it now only does so when there is genuinely nothing to draw.

The cover is on screen for the whole transition and sharpens once the larger rendition arrives.

### Bucketed request sizes

A known request size is rounded up to the `CoverUrls.WIDTH_BUCKETS` rendition the server would return anyway. This keeps a request — and its cache entry — still across sub-bucket reflows (a drag, a window resize, a `weight`/`aspectRatio` change) instead of decoding the same image repeatedly.

### Verification

`CoverImagePlaceholderRenderTest` renders the mid-transition frame with the network stalled, warm and cold, asserting on the rendered pixels and writing both to `build/renders`:

| cold cache (unchanged) | warm — the card's rendition already in memory |
|---|---|
| `primaryContainer` fill + spinner | the cover, correctly shaped and clipped |

`ImageRequestsTest` covers the key selection, including one test pinning the literal `&width=800` string — the mechanism is a silent no-op if that key ever drifts from what `CoverSizingInterceptor` writes, and `CoverSizingInterceptorTest` pins the same format from the other side.

Full `:common:compose:jvmTest` (23) and `:app:common:jvmTest` (13) green.

### Worth a look in review

The placeholder lookup takes the largest smaller rendition with no floor on how much smaller. Card → detail is one bucket apart so it is barely visible, but mini-player → expanded player is 200px standing in for 1200px, which will be soft for a moment. I went with a blurry correct cover over a spinner, and the crossfade covers the swap — happy to add a distance limit if you'd rather it fall back.
