### PR TITLE
Document why compact widths use bottom navigation

### DIFF
--- a/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/WindowSizeClass.kt
+++ b/common/compose/src/commonMain/kotlin/app/campfire/common/compose/layout/WindowSizeClass.kt
@@ -64,12 +64,14 @@ val WindowSizeClass.usesBottomPlaybackBar: Boolean
 /**
  * Return the main navigation type for this size class. Desktop windows between the Expanded and
  * Extra-Large breakpoints get the collapsible wide rail; mobile keeps the compact rail there.
+ * Compact widths (phones in portrait, split-screen panes, narrow desktop windows) get the bottom
+ * navigation bar with the secondary destinations behind a modal drawer, which is the Material 3
+ * adaptive recommendation for that class regardless of platform.
  */
 val WindowSizeClass.navigationType: NavigationType
   get() = when {
     isWidthAtLeastExtraLarge -> NavigationType.Drawer
     isWidthAtLeastExpanded && currentPlatform == Platform.DESKTOP -> NavigationType.WideRail
     isWidthAtLeastMedium -> NavigationType.Rail
-    // TODO: This is essentially a phone portrait mode, What would be the optimal setup for this
     else -> NavigationType.BottomNavigation
   }


### PR DESCRIPTION
## Summary

Resolves the long-standing TODO on the compact-width branch of `WindowSizeClass.navigationType` ("This is essentially a phone portrait mode, what would be the optimal setup for this") by recording the answer in a doc comment. No behavior change, so no changelog entry.

The compact-width case (phones in portrait, split-screen panes, narrow desktop windows) already gets a bottom navigation bar with the primary destinations and a modal drawer for the secondary ones, which is the Material 3 adaptive recommendation for the Compact width class on every platform. A rail would cost more width than a bottom bar at that size, and the compact-width + compact-height combination only really occurs in very small desktop windows, so neither warrants its own branch.

One adjacent gap noticed while investigating, deliberately left out of this PR: `isLandscapePhone` keys off the Expanded breakpoint, so phones whose landscape width lands between Medium and Expanded (~600–840dp) get the tablet treatment (compact rail, large server icon, supporting pane) despite a compact height.

Closes #1064

## Test plan

- [x] `scripts/ktlint --check` on the changed file
- Comment-only change; nothing to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)